### PR TITLE
Prioritize INTCXROM over SLTROMSEL values and special case slot 3

### DIFF
--- a/host/cinek/circular_buffer.hpp
+++ b/host/cinek/circular_buffer.hpp
@@ -43,6 +43,7 @@ public:
 
   CircularBuffer() : _tail(0), _head(0){}
 
+  void clear() { _tail = 0; _head = 0; }
   bool push(const Element& item);
   bool push(Element&& item);
   Element* acquireTail();

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -56,6 +56,9 @@ struct ClemensRunSampler {
     sampledCyclesSpent = 0;
     sampledFramesPerSecond = 0.0f;
     sampledEmulatorSpeedMhz = 0.0f;
+    frameTimeBuffer.clear();
+    clocksBuffer.clear();
+    cyclesBuffer.clear();
   }
 
   void update(std::chrono::microseconds fixedFrameInterval,


### PR DESCRIPTION
Fix 80-column mode - which broken when adding Mockingboard support (more generally card IO.)

Verified that Ultima IV runs with Mockingboard playback with the new settings while 80-column mode also works now.

Proper prioritization of INTCXROM over SLTROMSEL.  This is based on what INTCXROM and SLOTCXROM do on legacy Apple systems - either all internal ROM or all card slot ROM (slot 3 not withstanding.)   All the SLTROMSEL register should do is select card vs internal ROM for each slot *provided* that the system is set up to read from slot ROM.  

The INTCXROM switch's intent is to enable diagnostic ROMs on legacy systems over slot ROM.  So:

INTCXROM > SLTROMSEL + SLOTCXROM.

Open issues: card expansion ROM is still a bit broken.  I also think Slot 3 ROM should always point to the internal ROM (though the C3ROM switches still reflect the toggle between slot and internal ROM.)  
