### PR TITLE
Apple 3.5 disk emulation fix (GS/OS boots!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The emulator backend is written in C.  The `host` front-end is written in C++ wi
 
 * Disk II copy protected image boot
 * Apple II speaker
-* Prodos 16 system boot (until the GUI)
+* Prodos 16 and GS/OS boot
 * Hi-res and Double Hi-res graphics
 * 80-column
 * IRQ/BRK/RESET interrupts
@@ -31,6 +31,7 @@ The emulator backend is written in C.  The `host` front-end is written in C++ wi
 * Super Hi-Res 320/640 modes
 * Mockingboard C without SSI-223
 * Ensoniq audio playback
+* Mouse support
 
 See CHANGELOG.md for details on the next release's upcoming features.
 
@@ -111,7 +112,7 @@ The best ways to run Apple IIgs software are:
 * A KEGS port available on MacOS or Linux (Windows ports have been spotty IMO GSPort, GSPlus, etc.)
 * MAME in the browser https://archive.org/details/softwarelibrary_apple2gs
 
-Honestly I think if something can write a modern port of KEGS to Windows with a decent GUI frontend, that'll be the emulator you want to use.
+Honestly I think if someone can write a modern port of KEGS to Windows with a decent GUI frontend, that'll be the emulator you want to use.
 
 So why do we need another emulator.   We don't.  This is a personal project that I thought wouldn't be too hard to write (oh, really?).  Also I started this project to address a midlife programming crisis of sorts.
 

--- a/clem_code.h
+++ b/clem_code.h
@@ -814,6 +814,19 @@ static inline void _cpu_bit(struct Clemens65C816 *cpu, uint16_t value,
   }
 }
 
+static inline void _cpu_bit_imm(struct Clemens65C816 *cpu, uint16_t value,
+                                bool is8) {
+  // immediate mode only affects the Z flag
+  if (is8) {
+    uint8_t v = (uint8_t)(value);
+    uint8_t a = (uint8_t)(cpu->regs.A);
+    _cpu_p_flags_z_data(cpu, v & a);
+  } else {
+    _cpu_p_flags_z_data_16(cpu, value & cpu->regs.A);
+  }
+}
+
+
 static inline void _cpu_inc(struct Clemens65C816 *cpu, uint16_t *value,
                             bool is8) {
   if (is8) {

--- a/clem_drive35.c
+++ b/clem_drive35.c
@@ -196,7 +196,9 @@ void clem_disk_read_and_position_head_35(
                     sense_out = (drive->qtr_track_index != 0);
                     break;
                 case CLEM_IWM_DISK35_QUERY_EJECTED:
-                    sense_out = (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTED) == 0;
+                    //  it appears the Neil Parker docs on this are confusing, or
+                    //  incorrect.   ejected == 1, not ejected == 0
+                    sense_out = (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTED) != 0;
                     break;
                 case CLEM_IWM_DISK35_QUERY_60HZ_ROTATION:
                     assert(true);

--- a/clem_types.h
+++ b/clem_types.h
@@ -516,6 +516,7 @@ struct ClemensCPUPins {
   bool vdaOut;      // Valid Data Address
   bool vpaOut;      // Valid Program Address
   bool rwbOut;      // Read/Write byte
+  bool ioOut;       // IO access (for introspection purposes - not on the 65816)
                     /*
                     bool vpbOut;                        // Vector Pull
                     bool mlbOut;                        // Memory Lock

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -9,7 +9,7 @@ with ROM1 if possible compatibility.)
 
 This is a running todo list.
 
-* Clean up ADB support (Mouse)
+
 * Verify Mega II Interrupts work
 * Lores mode
 * Linux support
@@ -33,6 +33,7 @@ This is a running todo list.
 
 ## DONE
 
+* Clean up ADB support (Mouse)
 * Fix Slot 3 I/O (defaulting to card vs internal ROM) - broke when Mockingboard
   support added
 * New GUI Host (better debugging, more intuitive, quality of life)

--- a/emulator.c
+++ b/emulator.c
@@ -1793,7 +1793,7 @@ void cpu_execute(struct Clemens65C816 *cpu, ClemensMachine *clem) {
   //  Start BIT
   case CLEM_OPC_BIT_IMM:
     _clem_read_pba_mode_imm_816(clem, &tmp_value, &tmp_pc, m_status);
-    _cpu_bit(cpu, tmp_value, m_status);
+    _cpu_bit_imm(cpu, tmp_value, m_status);
     _opcode_instruction_define(&opc_inst, IR, tmp_value, m_status);
     break;
   case CLEM_OPC_BIT_ABS:

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -76,7 +76,7 @@ public:
   //  Send a message to the publish delegate from the frontend
   void debugMessage(std::string msg);
   //  Enable a program trace
-  void debugProgramTrace(bool enable, std::string path);
+  void debugProgramTrace(std::string op, std::string path);
   //  Save and load the machine
   void saveMachine(std::string path);
   void loadMachine(std::string path);

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -169,6 +169,7 @@ private:
     float fps;
     bool mmioWasInitialized = false;
     bool isTracing = false;
+    bool isIWMTracing = false;
   };
 
   //  This state sticks around until processed by the UI frame - a hacky solution

--- a/host/clem_program_trace.hpp
+++ b/host/clem_program_trace.hpp
@@ -15,6 +15,10 @@ public:
   ClemensProgramTrace();
 
   void enableToolboxLogging(bool enable);
+  void enableIWMLogging(bool enable);
+
+  bool isToolboxLoggingEnabled() const { return enableToolboxLogging_; }
+  bool isIWMLoggingEnabled() const { return enableIWMLogging_; }
 
   ClemensTraceExecutedInstruction& addExecutedInstruction(
     const ClemensInstruction& instruction,
@@ -49,7 +53,20 @@ private:
     uint8_t pbr;
   };
   std::vector<Toolbox> toolboxCalls_;
+
+  struct MemoryOperation {
+    uint64_t seq;
+    char opname[4];
+    uint16_t pc;
+    uint16_t adr;
+    uint8_t pbr;
+    uint8_t dbr;
+    uint8_t value;      //  this could be parts of a 16-bit value
+  };
+  std::vector<MemoryOperation> memoryOps_;
+
   bool enableToolboxLogging_;
+  bool enableIWMLogging_;
 };
 
 #endif


### PR DESCRIPTION
Fixed querying of eject/disk switched status which contradicts some documentation I found online (eject status).  This caused the firmware/ROM to fail to read data blocks from extended ReadBlock calls (standard ReadBlock calls worked I think through a quirk in the ROM implementation.)

Also fixed the BIT instruction to match documented behavior for BIT #immedate - surprised I haven't run into issues in the past.