### PR TITLE
Linux Joystick Support

### DIFF
--- a/app.c
+++ b/app.c
@@ -42,15 +42,14 @@ int main(int argc, char *argv[]) {
     fclose(fp);
 
     memset(&machine, 0, sizeof(machine));
+    memset(&mmio, 0, sizeof(mmio));
     clemens_init(&machine, 1000, 1000, rom, 256 * 1024, malloc(CLEM_IIGS_BANK_SIZE),
                  malloc(CLEM_IIGS_BANK_SIZE), malloc(CLEM_IIGS_BANK_SIZE * 16), 16);
     clem_mmio_init(&mmio, &machine.dev_debug, machine.mem.bank_page_map,
                    machine.tspec.clocks_step_mega2, malloc(2048 * 7));
 
     machine.cpu.pins.resbIn = false;
-    clemens_emulate_cpu(&machine);
-    clemens_emulate_mmio(&machine, &mmio);
-    machine.cpu.pins.resbIn = true;
+    machine.resb_counter = 3;
 
     while (machine.cpu.cycles_spent < 1024) {
         clemens_emulate_cpu(&machine);

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -884,6 +884,9 @@ void ClemensFrontend::pollJoystickDevices() {
             if (joysticks[index].buttons & CLEM_HOST_JOYSTICK_BUTTON_B) {
                 input.gameport_button_mask |= 0x2;
             }
+            // printf("SKS: [%u] - A:(%d,%d)  B:(%d,%d)  BTN:%08X\n", index, joysticks[index].x[0],
+            //        joysticks[index].y[0], joysticks[index].x[1], joysticks[index].y[1],
+            //        joysticks[index].buttons);
             joystickCount++;
         } else if (validJoystickIds_[index] != -1) {
             input.type = kClemensInputType_PaddleDisconnected;

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -24,14 +24,14 @@
 
 #define CLEM_HOST_JOYSTICK_AXIS_DELTA 1023
 
-#define CLEM_HOST_JOYSTICK_PROVIDER_NONE    0
-#define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT 1
 #if defined(CLEMENS_PLATFORM_WINDOWS)
-#define CLEM_HOST_JOYSTICK_PROVIDER_DINPUT 1
-#define CLEM_HOST_JOYSTICK_PROVIDER_XINPUT 2
+#define CLEM_HOST_JOYSTICK_PROVIDER_DINPUT "dinput"
+#define CLEM_HOST_JOYSTICK_PROVIDER_XINPUT "xinput"
+#define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT CLEM_HOST_JOYSTICK_PROVIDER_DINPUT
 #elif defined(CLEMENS_PLATFORM_LINUX)
-#define CLEM_HOST_JOYSTICK_PROVIDED_EVDEV 1
+#define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT ""
 #endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -73,9 +73,9 @@ void clem_host_uuid_gen(ClemensHostUUID *uuid);
 /**
  * @brief Initializes the joystick system
  *
- * @param provider OS specific (Windows: 0 = XInput, 1 = DirectInput)
+ * @param provider OS specific (Windows: "xinput", "dinput"; Linux: "{evdev root dir}")
  */
-void clem_joystick_open_devices(unsigned provider);
+void clem_joystick_open_devices(const char* provider);
 
 /**
  * @brief Return joystick data for up to 4 devices

--- a/host/platform/host_linux.c
+++ b/host/platform/host_linux.c
@@ -6,9 +6,18 @@
 #include <assert.h>
 
 #define _GNU_SOURCE
+#include <dirent.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
 #include <unistd.h>
-
 #include <uuid/uuid.h>
 
 //  seems to be a reliable way to call getcpu() regardless of glibc/distribution
@@ -29,7 +38,187 @@ void clem_host_uuid_gen(ClemensHostUUID *uuid) {
     uuid_generate(uuid->data);
 }
 
-void clem_joystick_open_devices(unsigned provider) {}
+//  evdev implementation
+//  using https://fossies.org/linux/stella/src/tools/evdev-joystick/evdev-joystick.c
+//  as an education of evdev and joystick input.
+//
+#define CLEM_HOST_EVDEV_DIR    "/dev/input/"
+#define CLEM_HOST_EVDEV_PREFIX "event"
+
+//  this is overkill but defined to simplify lookup of input axis information
+//  during polls (versus remapping input codes to our own codes)
+#define CLEM_HOST_EVDEV_AXIS_LIMIT 32
+
+struct ClemensEvdevAxis {
+    int min_value;
+    int max_value;
+    int deadzone;
+};
+
+//  support only X and Y axis - for gamepads or devices with two sticks, RX, RY
+//  will map to those
+struct ClemensHostJoystickInfo {
+    int device_id;
+    char name[NAME_MAX];
+    int fd;
+    unsigned avail_axis;
+    struct ClemensEvdevAxis axis_info[CLEM_HOST_EVDEV_AXIS_LIMIT];
+    bool connected;
+};
+
+static struct ClemensHostJoystickInfo s_joysticks[CLEM_HOST_JOYSTICK_LIMIT];
+
+static unsigned s_axis_types[] = {ABS_X, ABS_Y, ABS_RX, ABS_RY, UINT32_MAX};
+
+static int _clem_joystick_evdev_assign_device(int device_index) {
+    //  device must have at least one axis (i.e. paddle style)
+    //  assumption that the device_id starts with CLEM_HOST_EVDEV_PREFIX since
+    //  this should only be called with that assumption in mind (see
+    //  _clem_joystick_evdev_enum_devices)
+    //
+    char path[NAME_MAX + 32];
+    unsigned avail_index, axis_index, axis_count, avail_axis;
+    struct input_absinfo axis_info;
+    int fd, i;
+    bool has_deadzones = false;
+
+    for (avail_index = 0; avail_index < CLEM_HOST_JOYSTICK_LIMIT; ++avail_index) {
+        if (!s_joysticks[avail_index].connected)
+            break;
+    }
+    if (avail_index >= CLEM_HOST_JOYSTICK_LIMIT) {
+        printf("host_linux: no available joystick slots\n");
+        return -1;
+    }
+
+    snprintf(path, sizeof(path), CLEM_HOST_EVDEV_DIR "event%u", device_index);
+    fd = open(path, O_RDWR | O_NONBLOCK);
+    if (fd == -1) {
+        printf("host_linux: could not open device at %s\n", path);
+        return -1;
+    }
+
+    ioctl(fd, EVIOCGNAME(sizeof(s_joysticks[avail_index].name)), s_joysticks[avail_index].name);
+
+    axis_index = 0;
+    axis_count = 0;
+    avail_axis = 0;
+    while (s_axis_types[axis_index] != UINT32_MAX) {
+        unsigned axis_type = s_axis_types[axis_index];
+        if (ioctl(fd, EVIOCGABS(axis_type), &axis_info) != -1) {
+            avail_axis |= (1 << axis_type);
+            s_joysticks[avail_index].axis_info[axis_type].min_value = axis_info.minimum;
+            s_joysticks[avail_index].axis_info[axis_type].max_value = axis_info.maximum;
+            s_joysticks[avail_index].axis_info[axis_type].deadzone = axis_info.flat;
+            has_deadzones = has_deadzones || axis_info.flat > 0;
+            ++axis_count;
+        }
+        ++axis_index;
+    }
+
+    /*
+    if (ioctl(fd, EVIOCGKEY(sizeof(result)), &result) == -1) {
+        printf("Has no key\n");
+    } else {
+        printf("Has key (%d)\n", result);
+    }
+    if (ioctl(fd, EVIOCGBIT(BTN_JOYSTICK, sizeof(result)), &result) == -1) {
+        printf("Has no button 0\n");
+    } else {
+        printf("Has button 0 (%d)\n", result);
+    }
+    */
+    if (axis_count > 0 && has_deadzones) {
+        printf("host_linux: evdev joystick %d: %s detected.\n", avail_index,
+               s_joysticks[avail_index].name);
+        for (i = 0; i < CLEM_HOST_EVDEV_AXIS_LIMIT; ++i) {
+            if (avail_axis & (1 << i)) {
+                printf("            axis %u: min: %d, max: %d, deadzone: %d\n", i,
+                       s_joysticks[avail_index].axis_info[i].min_value,
+                       s_joysticks[avail_index].axis_info[i].max_value,
+                       s_joysticks[avail_index].axis_info[i].deadzone);
+            }
+        }
+        printf("\n");
+    } else {
+        if (axis_count > 0) {
+            printf("host_linux: evdev device %d: %s\n", avail_index, s_joysticks[avail_index].name);
+            printf("            Has absolute axis values but no deadzone.\n"
+                   "            Assumption is this is not a real joystick, ignoring.\n");
+            printf("\n");
+        }
+        //  not a joystick (most likely since joysticks are devices that return absolute
+        //  axis values versus a mouse)
+        close(fd);
+        return -1;
+    }
+
+    s_joysticks[avail_index].avail_axis = avail_axis;
+    s_joysticks[avail_index].connected = true;
+    s_joysticks[avail_index].fd = fd;
+    s_joysticks[avail_index].device_id = device_index;
+
+    return avail_index;
+}
+
+static void _clem_joystick_evdev_clear_devices() {
+    unsigned i;
+    for (i = 0; i < CLEM_HOST_JOYSTICK_LIMIT; ++i) {
+        s_joysticks[i].device_id = -1;
+        if (s_joysticks[i].fd >= 0) {
+            close(s_joysticks[i].fd);
+        }
+        s_joysticks[i].connected = false;
+        s_joysticks[i].fd = -1;
+    }
+}
+
+//  This function may be called twice via recursion if the user requested a
+//  specific device and the device enumeration couldn't find that device.
+//  If so, then this function is called again to enumerate all valid devices
+//
+void _clem_joystick_evdev_enum_devices() {
+    DIR *dir;
+    struct dirent *entry;
+    size_t prefix_len = strlen(CLEM_HOST_EVDEV_PREFIX);
+    size_t device_id_len;
+    size_t suffix_offset;
+    unsigned found_device_count = 0;
+
+    //  somewhat cribbed from evdev-joystick mostly for reference/instruction
+    //  since enumeration 'by-id' is usually available to root, we'll need to
+    //  enumerate all devices in /dev/input/ that are named 'event*'
+    dir = opendir(CLEM_HOST_EVDEV_DIR);
+    if (!dir) {
+        printf("host_linux: could not enumerate " CLEM_HOST_EVDEV_DIR "\n");
+        _clem_joystick_evdev_clear_devices();
+        return;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        int device_index;
+        if (found_device_count == CLEM_HOST_JOYSTICK_LIMIT)
+            break;
+        device_id_len = strnlen(entry->d_name, 255);
+        if (device_id_len <= prefix_len)
+            continue;
+        //  actual device id is the prefix of the filtered filename
+        if (strncmp(entry->d_name, CLEM_HOST_EVDEV_PREFIX, prefix_len) != 0)
+            continue;
+        suffix_offset = prefix_len;
+        device_index = (int)strtol(entry->d_name + suffix_offset, NULL, 10);
+        if (_clem_joystick_evdev_assign_device(device_index) >= 0) {
+            ++found_device_count;
+        }
+    }
+    closedir(dir);
+}
+
+void clem_joystick_open_devices(const char *provider) {
+    (void)provider;
+    printf("host_linux: enumerating joystick devices with evdev\n");
+    _clem_joystick_evdev_enum_devices();
+}
 
 unsigned clem_joystick_poll(ClemensHostJoystick *joysticks) { return 0; }
 

--- a/host/platform/host_windows.c
+++ b/host/platform/host_windows.c
@@ -47,10 +47,15 @@ struct ClemensHostJoystickInfo {
     IDirectInputDevice8 *device;
     LONG axisDeadZoneX, axisDeadZoneY;
 };
+enum ClemensHostJoystickProvider {
+    kClemensHostJoystick_None,
+    kClemensHostJoystick_XInput,
+    kClemensHostJoystick_DInput
+};
 static struct ClemensHostJoystickInfo s_DInputDevices[CLEM_HOST_JOYSTICK_LIMIT];
 static unsigned s_DInputDeviceCount = 0;
 static IDirectInput8 *s_DInput = NULL;
-static unsigned s_Provider = CLEM_HOST_JOYSTICK_PROVIDER_NONE;
+static enum ClemensHostJoystickProvider s_Provider = kClemensHostJoystick_None;
 static DIJOYCONFIG s_DInputJoyConfig;
 static bool s_hasPreferredJoyCfg = false;
 static HHOOK s_win32Hook = NULL;
@@ -294,23 +299,24 @@ static unsigned _clem_joystick_xinput(ClemensHostJoystick *joysticks) {
     return count;
 }
 
-void clem_joystick_open_devices(unsigned provider) {
-    switch (provider) {
-    case CLEM_HOST_JOYSTICK_PROVIDER_XINPUT:
-        XInputEnable(TRUE);
-        break;
-    case CLEM_HOST_JOYSTICK_PROVIDER_DINPUT:
-        _clem_joystick_dinput_start();
-        break;
+void clem_joystick_open_devices(const char* provider) {
+    if (s_Provider != kClemensHostJoystick_None) {
+        return;
     }
-    s_Provider = provider;
+    if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_XINPUT) == 0) {
+        XInputEnable(TRUE);
+        s_Provider = kClemensHostJoystick_XInput;
+    } else if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_DINPUT) == 0) {
+        _clem_joystick_dinput_start();
+        s_Provider = kClemensHostJoystick_DInput;
+    }
 }
 
 unsigned clem_joystick_poll(ClemensHostJoystick *joysticks) {
     switch (s_Provider) {
-    case CLEM_HOST_JOYSTICK_PROVIDER_XINPUT:
+    case kClemensHostJoystick_XInput:
         return _clem_joystick_xinput(joysticks);
-    case CLEM_HOST_JOYSTICK_PROVIDER_DINPUT:
+    case kClemensHostJoystick_DInput:
         return _clem_joystick_dinput(joysticks);
     }
     return 0;
@@ -320,10 +326,10 @@ void clem_joystick_close_devices() {
     int i;
 
     switch (s_Provider) {
-    case CLEM_HOST_JOYSTICK_PROVIDER_XINPUT:
+    case kClemensHostJoystick_XInput:
         XInputEnable(FALSE);
         break;
-    case CLEM_HOST_JOYSTICK_PROVIDER_DINPUT:
+    case kClemensHostJoystick_DInput:
         _clem_joystick_dinput_devices_release();
         if (s_DInput) {
             IDirectInput8_Release(s_DInput);
@@ -335,5 +341,5 @@ void clem_joystick_close_devices() {
         }
         break;
     }
-    s_Provider = CLEM_HOST_JOYSTICK_PROVIDER_NONE;
+    s_Provider = kClemensHostJoystick_None;
 }

--- a/host/platform/host_windows.c
+++ b/host/platform/host_windows.c
@@ -299,14 +299,14 @@ static unsigned _clem_joystick_xinput(ClemensHostJoystick *joysticks) {
     return count;
 }
 
-void clem_joystick_open_devices(const char* provider) {
+void clem_joystick_open_devices(const char *provider) {
     if (s_Provider != kClemensHostJoystick_None) {
         return;
     }
-    if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_XINPUT) == 0) {
+    if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_XINPUT, 32) == 0) {
         XInputEnable(TRUE);
         s_Provider = kClemensHostJoystick_XInput;
-    } else if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_DINPUT) == 0) {
+    } else if (strncmp(provider, CLEM_HOST_JOYSTICK_PROVIDER_DINPUT, 32) == 0) {
         _clem_joystick_dinput_start();
         s_Provider = kClemensHostJoystick_DInput;
     }


### PR DESCRIPTION
Joystick poll using `evdev`.   

Joysticks are enumerated on startup.  Joystick detection requires that a joystick have:

* at least one absolute axis event type
* the axis has a deadzone (this may need to be reevaluated) 

Users must be a member of the `input` user group on Debian and likely other distributions (this is a requirement for all applications that require access to input devices other than keyboard or mouse.)   Otherwise joysticks will not be found.
