### PR TITLE
Moved graphics mode render to texture code into C render library

### DIFF
--- a/host/clem_display.cpp
+++ b/host/clem_display.cpp
@@ -22,14 +22,12 @@
 #include "shaders/glcore33.inl"
 #endif
 
-
 //  Renders ClemensVideo data onto a render target/texture representing the
 //  machine's screen
 //
 //  ClemensVideo comes in two packages: text and graphics.  This method allows
 //  us to render the Apple IIgs mixed video modes.
 //
-
 
 static const int kDisplayTextColumnLimit = 80;
 static const int kDisplayTextRowLimit = 24;
@@ -40,7 +38,6 @@ static stbtt_bakedchar kGlyphSet80col[512];
 static unsigned kPrimarySetToGlyph[256];
 static unsigned kAlternateSetToGlyph[256];
 
-
 static int kFontTextureWidth = 512;
 static int kFontTextureHeight = 256;
 
@@ -49,8 +46,6 @@ static int kGraphicsTextureHeight = 512;
 
 static int kRenderTargetWidth = 1024;
 static int kRenderTargetHeight = 512;
-
-
 
 namespace {
 
@@ -77,14 +72,14 @@ static const float kHiresColors[8][4] = {
 
 //  Apple IIgs colors
 static const uint8_t kHiresColors[8][4] = {
-  { 0x00, 0x00, 0x00, 0xFF },       // black group 1
-  { 0x11, 0xDD, 0x00, 0xFF },       // green (light green)
-  { 0xDD, 0x22, 0xDD, 0xFF },       // purple
-  { 0xFF, 0xFF, 0xFF, 0xFF },       // white group 1
-  { 0x00, 0x00, 0x00, 0xFF },       // black group 2
-  { 0xFF, 0x66, 0x00, 0xFF },       // orange
-  { 0x22, 0x22, 0xFF, 0xFF },       // medium blue
-  { 0xFF, 0xFF, 0xFF, 0xFF }        // white group 2
+    {0x00, 0x00, 0x00, 0xFF}, // black group 1
+    {0x11, 0xDD, 0x00, 0xFF}, // green (light green)
+    {0xDD, 0x22, 0xDD, 0xFF}, // purple
+    {0xFF, 0xFF, 0xFF, 0xFF}, // white group 1
+    {0x00, 0x00, 0x00, 0xFF}, // black group 2
+    {0xFF, 0x66, 0x00, 0xFF}, // orange
+    {0x22, 0x22, 0xFF, 0xFF}, // medium blue
+    {0xFF, 0xFF, 0xFF, 0xFF}  // white group 2
 };
 
 //  Double Hi-Res Graphics (better explanation than the reference books which
@@ -104,1111 +99,794 @@ static const uint8_t kHiresColors[8][4] = {
 //
 
 static const uint8_t kDblHiresColors[16][4] = {
-  {   0,    0,    0,    255 },      // black
-  { 221,    0,   51,    255 },      // deep red
-  { 136,   85,    0,    255 },      // brown
-  { 255,  102,    0,    255 },      // orange
-  {   0,  119,   34,    255 },      // dark green
-  {  85,   85,   85,    255 },      // dark gray
-  {  17,  221,    0,    255 },      // lt. green
-  { 255,  255,    0,    255 },      // yellow
-  {   0,    0,  153,    255 },      // dark blue
-  { 221,   34,  221,    255 },      // purple
-  { 170,  170,  170,    255 },      // lt. gray
-  { 255,  153,  136,    255 },      // pink
-  {  34,   34,  255,    255 },      // med blue
-  { 102,  170,  255,    255 },      // light blue
-  {  68,  255,  153,    255 },      // aquamarine
-  { 255,  255,  255,    255 }       // white
+    {0, 0, 0, 255},       // black
+    {221, 0, 51, 255},    // deep red
+    {136, 85, 0, 255},    // brown
+    {255, 102, 0, 255},   // orange
+    {0, 119, 34, 255},    // dark green
+    {85, 85, 85, 255},    // dark gray
+    {17, 221, 0, 255},    // lt. green
+    {255, 255, 0, 255},   // yellow
+    {0, 0, 153, 255},     // dark blue
+    {221, 34, 221, 255},  // purple
+    {170, 170, 170, 255}, // lt. gray
+    {255, 153, 136, 255}, // pink
+    {34, 34, 255, 255},   // med blue
+    {102, 170, 255, 255}, // light blue
+    {68, 255, 153, 255},  // aquamarine
+    {255, 255, 255, 255}  // white
 };
 
 static const uint8_t kGr16Colors[16][4] = {
-  {   0,    0,    0,    255 },      // black
-  { 221,    0,   51,    255 },      // deep red
-  {   0,    0,  153,    255 },      // dark blue
-  { 221,   34,  221,    255 },      // purple
-  {   0,  119,   34,    255 },      // dark green
-  {  85,   85,   85,    255 },      // dark gray
-  {  34,   34,  255,    255 },      // med blue
-  { 102,  170,  255,    255 },      // light blue
-  { 136,   85,    0,    255 },      // brown
-  { 255,  102,    0,    255 },      // orange
-  { 170,  170,  170,    255 },      // lt. gray
-  { 255,  153,  136,    255 },      // pink
-  {  17,  221,    0,    255 },      // lt. green
-  { 255,  255,    0,    255 },      // yellow
-  {  68,  255,  153,    255 },      // aquamarine
-  { 255,  255,  255,    255 }       // white
+    {0, 0, 0, 255},       // black
+    {221, 0, 51, 255},    // deep red
+    {0, 0, 153, 255},     // dark blue
+    {221, 34, 221, 255},  // purple
+    {0, 119, 34, 255},    // dark green
+    {85, 85, 85, 255},    // dark gray
+    {34, 34, 255, 255},   // med blue
+    {102, 170, 255, 255}, // light blue
+    {136, 85, 0, 255},    // brown
+    {255, 102, 0, 255},   // orange
+    {170, 170, 170, 255}, // lt. gray
+    {255, 153, 136, 255}, // pink
+    {17, 221, 0, 255},    // lt. green
+    {255, 255, 0, 255},   // yellow
+    {68, 255, 153, 255},  // aquamarine
+    {255, 255, 255, 255}  // white
 };
 
-enum {
-  kZero,
-  kEven,
-  kOdd,
-  kOne,
-  kColorStateCount
-};
-
-//  HGR colors black, green/orange (odd), violet/blue (even), white
-//    violet even ; green odd   (hcolor 2, 1)
-//    orange even ; blue odd    (hcolor 5, 6)
-uint8_t abgrFromHGRBitTable[kColorStateCount][2] = {
-  { 0, 4 },   /* black */
-  { 2, 6 },   /* even */
-  { 1, 5 },   /* odd */
-  { 3, 7 }    /* white */
-};
-
-//  bit 0 = incoming pixel at x+1, bit 1 = current pixel, bit 2 = pixel at x-1
-unsigned stateToColorAction[8] = {
-  /* b000 */  0,    //  > 2 adjacent off = black
-  /* b001 */  0,    //  2 adjacent off outgoing  = black
-  /* b010 */  1,    //  color at bit 1
-  /* b011 */  3,    //  2 adjacent on incoming = white
-  /* b100 */  0,    //  2 adhacent off incoming = black
-  /* b101 */  2,    //  color at bit 2
-  /* b110 */  3,    //  2 adjacent on outgoing = white
-  /* b111 */  3,    //  > 2 adjacent on = white
-};
-
-void a2hgrToABGR8Scale2x2(uint8_t* pixout, uint8_t* pixout2, const uint8_t* hgr) {
-  //  input is 40 bytes of hgr data to 280 bytes (1 byte per pixel)
-  //  colors are one, zero, even, odd
-  //  strategy:
-  //
-  //  two pixels: X and X + 1, and an extra 'register' BIT = zero
-  //  1 and 1 = white; BIT = one
-  //  1 and 0 = white if BIT = one else color(BIT) where BIT = even/odd(X)
-  //  0 and 1 = black if BIT = zero else color(BIT) where BIT = even/odd(X + 1)
-  //  0 and 0 = black; BIT = zero
-  //
-  //  0  1  2  3  4  5  6  7  8  9 10 11 12
-  //  --------------------------------------
-  //  0  0                                 |black; BIT = zero
-  //     0  1                              |black if BIT = zero; BIT = even
-  //        1  0                           |color(BIT) if BIT = zero; BIT = even
-  //           0  1                        |color(BIT) if BIT = one; BIT = even
-  //              1  1                     |white; BIT = one
-  //                 1  0                  |white; if BIT = one; BIT = odd
-  //                    0  1               |color(BIT); if BIT = odd; BIT = odd
-  //                       1  0            |color(BIT); if BIT = odd; BIT = odd
-  //                          0  0         |black; BIT = zero
-  //
-  //  "BIT" really is the value at X-1, so...
-  //
-  //  X-2, X-1, X
-  //  any  1    1   = white
-  //   1   1    0   = white
-  //   0   1    0   = color(even/odd(X-1), group)
-  //   0   0    1   = black
-  //   1   0    1   = color(even/odd(X), group)
-  //  any  0    0   = black
-  //
-  //  group = bit 7 of color/pixel byte
-
-  unsigned state = 0;
-  int xpos = -2;
-  unsigned group;
-  uint8_t pixel;
-  for (int byteIdx = 0; byteIdx < 40; ++byteIdx) {
-    uint8_t byte = hgr[byteIdx];
-    group = byte >> 7;
-    unsigned pxmask = 0x1;
-    while (pxmask != 0x80) {
-      unsigned bit = byte & pxmask;
-      state <<= 1;
-      pxmask <<= 1;
-      if (bit) state |= 1;
-
-      unsigned action = stateToColorAction[state & 0x7];
-      unsigned color;
-      if (xpos >= 0) {
-        if (action == 0) color = 0;
-        else if (action == 1) {
-          if (xpos & 2) color = 2;
-          else color = 1;
-        } else if (action == 2) {
-          if (xpos & 2) color = 1;
-          else color = 2;
-        } else {
-          color = 3;
-        }
-        //  normalize hcolor 0 to 7 to 0-255 to be shader friendly
-        pixel = (abgrFromHGRBitTable[color][group & 1] << 5) + 16;
-        pixout[xpos] = pixel;
-        pixout[xpos+1] = pixel;
-        pixout2[xpos] = pixel;
-        pixout2[xpos+1] = pixel;
-      }
-      xpos += 2;
-    }
-  }
-  state <<= 1;
-  unsigned action = stateToColorAction[state & 0x7];
-  unsigned color;
-  if (action == 0) color = 0;
-  else if (action == 1) {
-    color = 2;
-  } else if (action == 2) {
-    color = 1;
-  } else {
-    color = 3;
-  }
-  pixel = (abgrFromHGRBitTable[color][group & 1] << 5) + 16;
-  pixout[xpos] = pixel;
-  pixout[xpos+1] = pixel;
-  pixout2[xpos] = pixel;
-  pixout2[xpos+1] = pixel;
-}
-
-uint32_t grColorToABGR(unsigned color)
-{
-  const uint8_t* grColor = &kGr16Colors[color][0];
-  unsigned abgr = ((unsigned)grColor[3] << 24) |
-                  ((unsigned)grColor[2] << 16) |
-                  ((unsigned)grColor[1] << 8) |
-                  grColor[0];
-  return abgr;
+uint32_t grColorToABGR(unsigned color) {
+    const uint8_t *grColor = &kGr16Colors[color][0];
+    unsigned abgr = ((unsigned)grColor[3] << 24) | ((unsigned)grColor[2] << 16) |
+                    ((unsigned)grColor[1] << 8) | grColor[0];
+    return abgr;
 } // namespace
 
+static sg_image loadFont(stbtt_bakedchar *glyphSet, const cinek::ByteBuffer &fileBuffer) {
+    unsigned char *textureData = (unsigned char *)malloc(kFontTextureWidth * kFontTextureHeight);
 
+    stbtt_BakeFontBitmap(fileBuffer.getHead(), 0, 16.0f, textureData, kFontTextureWidth,
+                         kFontTextureHeight, 0xe000, 512, glyphSet);
 
-static sg_image loadFont(stbtt_bakedchar* glyphSet,
-                         const cinek::ByteBuffer& fileBuffer)
-{
-  unsigned char *textureData = (unsigned char *)malloc(
-    kFontTextureWidth * kFontTextureHeight);
+    sg_image_desc imageDesc = {};
+    imageDesc.width = kFontTextureWidth;
+    imageDesc.height = kFontTextureHeight;
+    imageDesc.pixel_format = SG_PIXELFORMAT_R8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.usage = SG_USAGE_IMMUTABLE;
+    imageDesc.data.subimage[0][0].ptr = textureData;
+    imageDesc.data.subimage[0][0].size = imageDesc.width * imageDesc.height;
+    sg_image fontImage = sg_make_image(imageDesc);
 
-  stbtt_BakeFontBitmap(fileBuffer.getHead(), 0, 16.0f,
-                       textureData, kFontTextureWidth, kFontTextureHeight,
-                       0xe000, 512,
-                       glyphSet);
+    free(textureData);
 
-  sg_image_desc imageDesc = {};
-  imageDesc.width = kFontTextureWidth;
-  imageDesc.height = kFontTextureHeight;
-  imageDesc.pixel_format = SG_PIXELFORMAT_R8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.usage = SG_USAGE_IMMUTABLE;
-  imageDesc.data.subimage[0][0].ptr = textureData;
-  imageDesc.data.subimage[0][0].size = imageDesc.width * imageDesc.height;
-  sg_image fontImage = sg_make_image(imageDesc);
-
-  free(textureData);
-
-  return fontImage;
+    return fontImage;
 }
 
-void defineUniformBlocks(sg_shader_desc& shaderDesc) {
-  shaderDesc.vs.uniform_blocks[0].size = sizeof(ClemensDisplayVertexParams);
+void defineUniformBlocks(sg_shader_desc &shaderDesc) {
+    shaderDesc.vs.uniform_blocks[0].size = sizeof(ClemensDisplayVertexParams);
 
 #if defined(CK3D_BACKEND_GL)
-  shaderDesc.vs.uniform_blocks[0].uniforms[0].name = "render_dims";
-  shaderDesc.vs.uniform_blocks[0].uniforms[0].type = SG_UNIFORMTYPE_FLOAT2;
-  shaderDesc.vs.uniform_blocks[0].uniforms[1].name = "display_ratio";
-  shaderDesc.vs.uniform_blocks[0].uniforms[1].type = SG_UNIFORMTYPE_FLOAT2;
-  shaderDesc.vs.uniform_blocks[0].uniforms[2].name = "virtual_dims";
-  shaderDesc.vs.uniform_blocks[0].uniforms[2].type = SG_UNIFORMTYPE_FLOAT2;
-  shaderDesc.vs.uniform_blocks[0].uniforms[3].name = "offsets";
-  shaderDesc.vs.uniform_blocks[0].uniforms[3].type = SG_UNIFORMTYPE_FLOAT2;
+    shaderDesc.vs.uniform_blocks[0].uniforms[0].name = "render_dims";
+    shaderDesc.vs.uniform_blocks[0].uniforms[0].type = SG_UNIFORMTYPE_FLOAT2;
+    shaderDesc.vs.uniform_blocks[0].uniforms[1].name = "display_ratio";
+    shaderDesc.vs.uniform_blocks[0].uniforms[1].type = SG_UNIFORMTYPE_FLOAT2;
+    shaderDesc.vs.uniform_blocks[0].uniforms[2].name = "virtual_dims";
+    shaderDesc.vs.uniform_blocks[0].uniforms[2].type = SG_UNIFORMTYPE_FLOAT2;
+    shaderDesc.vs.uniform_blocks[0].uniforms[3].name = "offsets";
+    shaderDesc.vs.uniform_blocks[0].uniforms[3].type = SG_UNIFORMTYPE_FLOAT2;
 #endif
 }
 
+} // namespace
 
-} // namespace anon
+ClemensDisplayProvider::ClemensDisplayProvider(const cinek::ByteBuffer &systemFontLoBuffer,
+                                               const cinek::ByteBuffer &systemFontHiBuffer) {
+    systemFontImage_ = loadFont(kGlyphSet40col, systemFontLoBuffer);
+    systemFontImageHi_ = loadFont(kGlyphSet80col, systemFontHiBuffer);
 
-ClemensDisplayProvider::ClemensDisplayProvider(
-  const cinek::ByteBuffer& systemFontLoBuffer,
-  const cinek::ByteBuffer& systemFontHiBuffer
-) {
-  systemFontImage_ = loadFont(kGlyphSet40col, systemFontLoBuffer);
-  systemFontImageHi_ = loadFont(kGlyphSet80col, systemFontHiBuffer);
+    const uint8_t blankImageData[16] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                                        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    sg_image_desc imageDesc = {};
+    imageDesc.width = 4;
+    imageDesc.height = 4;
+    imageDesc.pixel_format = SG_PIXELFORMAT_R8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.usage = SG_USAGE_IMMUTABLE;
+    imageDesc.data.subimage[0][0].ptr = blankImageData;
+    imageDesc.data.subimage[0][0].size = imageDesc.width * imageDesc.height;
+    blankImage_ = sg_make_image(imageDesc);
 
-  const uint8_t blankImageData[16] = {
-    0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff
-  };
-  sg_image_desc imageDesc = {};
-  imageDesc.width = 4;
-  imageDesc.height = 4;
-  imageDesc.pixel_format = SG_PIXELFORMAT_R8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.usage = SG_USAGE_IMMUTABLE;
-  imageDesc.data.subimage[0][0].ptr = blankImageData;
-  imageDesc.data.subimage[0][0].size = imageDesc.width * imageDesc.height;
-  blankImage_ = sg_make_image(imageDesc);
+    //  map screen byte code to glyph index
+    //    a 32-bit word split into two 16-bit half-words.  half-word values will
+    //    differ if the character code is flashing
+    for (int i = 0; i < 0x20; ++i) {
+        kPrimarySetToGlyph[i] = (0x140 + i) | ((0x140 + i) << 16);
+        kPrimarySetToGlyph[i + 0x20] = (0x120 + i) | ((0x120 + i) << 16);
+        kPrimarySetToGlyph[i + 0x40] = (0x40 + i) | ((0x140 + i) << 16);
+        kPrimarySetToGlyph[i + 0x60] = (0x20 + i) | ((0x120 + i) << 16);
+        kPrimarySetToGlyph[i + 0x80] = (0x40 + i) | ((0x40 + i) << 16);
+        kPrimarySetToGlyph[i + 0xA0] = (0x20 + i) | ((0x20 + i) << 16);
+        kPrimarySetToGlyph[i + 0xC0] = (0x40 + i) | ((0x40 + i) << 16);
+        kPrimarySetToGlyph[i + 0xE0] = (0x60 + i) | ((0x60 + i) << 16);
 
-  //  map screen byte code to glyph index
-  //    a 32-bit word split into two 16-bit half-words.  half-word values will
-  //    differ if the character code is flashing
-  for (int i = 0; i < 0x20; ++i) {
-    kPrimarySetToGlyph[i] =         (0x140 + i) | ((0x140 + i) << 16);
-    kPrimarySetToGlyph[i + 0x20] =  (0x120 + i) | ((0x120 + i) << 16);
-    kPrimarySetToGlyph[i + 0x40] =  (0x40 + i)  | ((0x140 + i) << 16);
-    kPrimarySetToGlyph[i + 0x60] =  (0x20 + i)  | ((0x120 + i) << 16);
-    kPrimarySetToGlyph[i + 0x80] =  (0x40 + i)  | ((0x40 + i) << 16);
-    kPrimarySetToGlyph[i + 0xA0] =  (0x20 + i)  | ((0x20 + i) << 16);
-    kPrimarySetToGlyph[i + 0xC0] =  (0x40 + i)  | ((0x40 + i) << 16);
-    kPrimarySetToGlyph[i + 0xE0] =  (0x60 + i)  | ((0x60 + i) << 16);
+        kAlternateSetToGlyph[i] = (0x140 + i) | ((0x140 + i) << 16);
+        kAlternateSetToGlyph[i + 0x20] = (0x120 + i) | ((0x120 + i) << 16);
+        kAlternateSetToGlyph[i + 0x40] = (0x80 + i) | ((0x80 + i) << 16);
+        kAlternateSetToGlyph[i + 0x60] = (0x60 + i) | ((0x160 + i) << 16);
+        kAlternateSetToGlyph[i + 0x80] = (0x40 + i) | ((0x40 + i) << 16);
+        kAlternateSetToGlyph[i + 0xA0] = (0x20 + i) | ((0x20 + i) << 16);
+        kAlternateSetToGlyph[i + 0xC0] = (0x40 + i) | ((0x40 + i) << 16);
+        kAlternateSetToGlyph[i + 0xE0] = (0x60 + i) | ((0x60 + i) << 16);
+    }
 
-    kAlternateSetToGlyph[i] =         (0x140 + i) | ((0x140 + i) << 16);
-    kAlternateSetToGlyph[i + 0x20] =  (0x120 + i) | ((0x120 + i) << 16);
-    kAlternateSetToGlyph[i + 0x40] =  (0x80 + i)  | ((0x80 + i) << 16);
-    kAlternateSetToGlyph[i + 0x60] =  (0x60 + i)  | ((0x160 + i) << 16);
-    kAlternateSetToGlyph[i + 0x80] =  (0x40 + i)  | ((0x40 + i) << 16);
-    kAlternateSetToGlyph[i + 0xA0] =  (0x20 + i)  | ((0x20 + i) << 16);
-    kAlternateSetToGlyph[i + 0xC0] =  (0x40 + i)  | ((0x40 + i) << 16);
-    kAlternateSetToGlyph[i + 0xE0] =  (0x60 + i)  | ((0x60 + i) << 16);
-  }
-
-  //  create shader
-  sg_shader_desc shaderDesc = {};
-  defineUniformBlocks(shaderDesc);
+    //  create shader
+    sg_shader_desc shaderDesc = {};
+    defineUniformBlocks(shaderDesc);
 #if defined(CK3D_BACKEND_D3D11)
-  shaderDesc.attrs[0].sem_name = "POSITION";
-  shaderDesc.attrs[1].sem_name = "TEXCOORD";
-  shaderDesc.attrs[1].sem_index = 1;
-  shaderDesc.attrs[2].sem_name = "COLOR";
-  shaderDesc.attrs[2].sem_index = 1;
+    shaderDesc.attrs[0].sem_name = "POSITION";
+    shaderDesc.attrs[1].sem_name = "TEXCOORD";
+    shaderDesc.attrs[1].sem_index = 1;
+    shaderDesc.attrs[2].sem_name = "COLOR";
+    shaderDesc.attrs[2].sem_index = 1;
 #endif
-  shaderDesc.vs.source = VS_VERTEX_SOURCE;
-  shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
+    shaderDesc.vs.source = VS_VERTEX_SOURCE;
+    shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
 #if defined(CK3D_BACKEND_GL)
-  shaderDesc.fs.images[0].name = "tex";
+    shaderDesc.fs.images[0].name = "tex";
 #endif
-  shaderDesc.fs.source = FS_TEXT_SOURCE;
-  textShader_ = sg_make_shader(shaderDesc);
+    shaderDesc.fs.source = FS_TEXT_SOURCE;
+    textShader_ = sg_make_shader(shaderDesc);
 
-  //  create text pipeline and vertex buffer, no alpha blending, triangles
-  sg_pipeline_desc renderPipelineDesc = {};
-  renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
-  renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
-  renderPipelineDesc.shader = textShader_;
-  renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
-  renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
-  renderPipelineDesc.colors[0].blend.enabled = true;
-  renderPipelineDesc.colors[0].write_mask = SG_COLORMASK_RGB;
-  renderPipelineDesc.colors[0].blend.src_factor_rgb = SG_BLENDFACTOR_SRC_ALPHA;
-  renderPipelineDesc.colors[0].blend.dst_factor_rgb = SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-  renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
-  textPipeline_ = sg_make_pipeline(renderPipelineDesc);
+    //  create text pipeline and vertex buffer, no alpha blending, triangles
+    sg_pipeline_desc renderPipelineDesc = {};
+    renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
+    renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
+    renderPipelineDesc.shader = textShader_;
+    renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
+    renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
+    renderPipelineDesc.colors[0].blend.enabled = true;
+    renderPipelineDesc.colors[0].write_mask = SG_COLORMASK_RGB;
+    renderPipelineDesc.colors[0].blend.src_factor_rgb = SG_BLENDFACTOR_SRC_ALPHA;
+    renderPipelineDesc.colors[0].blend.dst_factor_rgb = SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
+    renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
+    textPipeline_ = sg_make_pipeline(renderPipelineDesc);
 
-  //  create hires pipeline and vertex buffer, no alpha blending, triangles
-  shaderDesc = {};
-  defineUniformBlocks(shaderDesc);
+    //  create hires pipeline and vertex buffer, no alpha blending, triangles
+    shaderDesc = {};
+    defineUniformBlocks(shaderDesc);
 #if defined(CK3D_BACKEND_D3D11)
-  shaderDesc.attrs[0].sem_name = "POSITION";
-  shaderDesc.attrs[1].sem_name = "TEXCOORD";
-  shaderDesc.attrs[1].sem_index = 1;
-  shaderDesc.attrs[2].sem_name = "COLOR";
-  shaderDesc.attrs[2].sem_index = 1;
+    shaderDesc.attrs[0].sem_name = "POSITION";
+    shaderDesc.attrs[1].sem_name = "TEXCOORD";
+    shaderDesc.attrs[1].sem_index = 1;
+    shaderDesc.attrs[2].sem_name = "COLOR";
+    shaderDesc.attrs[2].sem_index = 1;
 #endif
-  shaderDesc.vs.source = VS_VERTEX_SOURCE;
-  shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
-  shaderDesc.fs.images[1].image_type = SG_IMAGETYPE_2D;
+    shaderDesc.vs.source = VS_VERTEX_SOURCE;
+    shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
+    shaderDesc.fs.images[1].image_type = SG_IMAGETYPE_2D;
 #if defined(CK3D_BACKEND_GL)
-  shaderDesc.fs.images[0].name = "hgr_tex";
-  shaderDesc.fs.images[1].name = "hcolor_tex";
+    shaderDesc.fs.images[0].name = "hgr_tex";
+    shaderDesc.fs.images[1].name = "hcolor_tex";
 #endif
-  shaderDesc.fs.source = FS_HIRES_SOURCE;
-  hiresShader_ = sg_make_shader(shaderDesc);
+    shaderDesc.fs.source = FS_HIRES_SOURCE;
+    hiresShader_ = sg_make_shader(shaderDesc);
 
-  renderPipelineDesc = {};
-  renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
-  renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
-  renderPipelineDesc.shader = hiresShader_;
-  renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
-  renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
-  renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
-  hiresPipeline_ = sg_make_pipeline(renderPipelineDesc);
+    renderPipelineDesc = {};
+    renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
+    renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
+    renderPipelineDesc.shader = hiresShader_;
+    renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
+    renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
+    renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
+    hiresPipeline_ = sg_make_pipeline(renderPipelineDesc);
 
-  //  create hires pipeline and vertex buffer, no alpha blending, triangles
-  shaderDesc = {};
-  defineUniformBlocks(shaderDesc);
+    //  create hires pipeline and vertex buffer, no alpha blending, triangles
+    shaderDesc = {};
+    defineUniformBlocks(shaderDesc);
 #if defined(CK3D_BACKEND_D3D11)
-  shaderDesc.attrs[0].sem_name = "POSITION";
-  shaderDesc.attrs[1].sem_name = "TEXCOORD";
-  shaderDesc.attrs[1].sem_index = 1;
-  shaderDesc.attrs[2].sem_name = "COLOR";
-  shaderDesc.attrs[2].sem_index = 1;
+    shaderDesc.attrs[0].sem_name = "POSITION";
+    shaderDesc.attrs[1].sem_name = "TEXCOORD";
+    shaderDesc.attrs[1].sem_index = 1;
+    shaderDesc.attrs[2].sem_name = "COLOR";
+    shaderDesc.attrs[2].sem_index = 1;
 #endif
-  shaderDesc.vs.source = VS_VERTEX_SOURCE;
-  shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
-  shaderDesc.fs.images[1].image_type = SG_IMAGETYPE_2D;
+    shaderDesc.vs.source = VS_VERTEX_SOURCE;
+    shaderDesc.fs.images[0].image_type = SG_IMAGETYPE_2D;
+    shaderDesc.fs.images[1].image_type = SG_IMAGETYPE_2D;
 #if defined(CK3D_BACKEND_GL)
-  shaderDesc.fs.images[0].name = "hgr_tex";
-  shaderDesc.fs.images[1].name = "hcolor_tex";
+    shaderDesc.fs.images[0].name = "hgr_tex";
+    shaderDesc.fs.images[1].name = "hcolor_tex";
 #endif
-  shaderDesc.fs.source = FS_SUPER_SOURCE;
-  superHiresShader_ = sg_make_shader(shaderDesc);
+    shaderDesc.fs.source = FS_SUPER_SOURCE;
+    superHiresShader_ = sg_make_shader(shaderDesc);
 
-  renderPipelineDesc = {};
-  renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
-  renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
-  renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
-  renderPipelineDesc.shader = superHiresShader_;
-  renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
-  renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
-  renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
-  superHiresPipeline_ = sg_make_pipeline(renderPipelineDesc);
+    renderPipelineDesc = {};
+    renderPipelineDesc.layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
+    renderPipelineDesc.layout.attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
+    renderPipelineDesc.layout.buffers[0].stride = sizeof(DrawVertex);
+    renderPipelineDesc.shader = superHiresShader_;
+    renderPipelineDesc.cull_mode = SG_CULLMODE_BACK;
+    renderPipelineDesc.face_winding = SG_FACEWINDING_CCW;
+    renderPipelineDesc.depth.pixel_format = SG_PIXELFORMAT_NONE;
+    superHiresPipeline_ = sg_make_pipeline(renderPipelineDesc);
 }
 
 ClemensDisplayProvider::~ClemensDisplayProvider() {
-  sg_destroy_pipeline(superHiresPipeline_);
-  sg_destroy_shader(superHiresShader_);
-  sg_destroy_pipeline(hiresPipeline_);
-  sg_destroy_shader(hiresShader_);
-  sg_destroy_pipeline(textPipeline_);
-  sg_destroy_shader(textShader_);
-  sg_destroy_image(systemFontImageHi_);
-  sg_destroy_image(systemFontImage_);
-  sg_destroy_image(blankImage_);
+    sg_destroy_pipeline(superHiresPipeline_);
+    sg_destroy_shader(superHiresShader_);
+    sg_destroy_pipeline(hiresPipeline_);
+    sg_destroy_shader(hiresShader_);
+    sg_destroy_pipeline(textPipeline_);
+    sg_destroy_shader(textShader_);
+    sg_destroy_image(systemFontImageHi_);
+    sg_destroy_image(systemFontImage_);
+    sg_destroy_image(blankImage_);
 }
 
-void* ClemensDisplayProvider::allocate(size_t sz) {
-  return ::malloc(sz);
-}
+void *ClemensDisplayProvider::allocate(size_t sz) { return ::malloc(sz); }
 
-void ClemensDisplayProvider::free(void *ptr) {
-  ::free(ptr);
-}
+void ClemensDisplayProvider::free(void *ptr) { ::free(ptr); }
 
-ClemensDisplay::ClemensDisplay(ClemensDisplayProvider& provider) :
-  provider_(provider)
-{
-  //  This data is specific to display and should be instanced per display
-  //  require double the vertices to display the background under the
-  //  foreground
-  textVertices_.size = 4 * (kDisplayTextRowLimit * kDisplayTextColumnLimit * 6) * (
-    sizeof(DrawVertex));
-  textVertices_.ptr = provider_.allocate(textVertices_.size);
+ClemensDisplay::ClemensDisplay(ClemensDisplayProvider &provider) : provider_(provider) {
+    //  This data is specific to display and should be instanced per display
+    //  require double the vertices to display the background under the
+    //  foreground
+    textVertices_.size =
+        4 * (kDisplayTextRowLimit * kDisplayTextColumnLimit * 6) * (sizeof(DrawVertex));
+    textVertices_.ptr = provider_.allocate(textVertices_.size);
 
-  sg_buffer_desc vertexBufDesc = { };
-  //  using 2 x 2 x 40x24 quads (lores has two pixels per box)
-  vertexBufDesc.usage = SG_USAGE_STREAM;
-  vertexBufDesc.size = textVertices_.size;
-  textVertexBuffer_ = sg_make_buffer(&vertexBufDesc);
+    sg_buffer_desc vertexBufDesc = {};
+    //  using 2 x 2 x 40x24 quads (lores has two pixels per box)
+    vertexBufDesc.usage = SG_USAGE_STREAM;
+    vertexBufDesc.size = textVertices_.size;
+    textVertexBuffer_ = sg_make_buffer(&vertexBufDesc);
 
-  vertexBufDesc = { };
-  //  simple quad -TODO:  do we need this?
-  vertexBufDesc.usage = SG_USAGE_STREAM;
-  vertexBufDesc.size = 6 * sizeof(DrawVertex);
-  vertexBuffer_ = sg_make_buffer(&vertexBufDesc);
+    vertexBufDesc = {};
+    //  simple quad -TODO:  do we need this?
+    vertexBufDesc.usage = SG_USAGE_STREAM;
+    vertexBufDesc.size = 6 * sizeof(DrawVertex);
+    vertexBuffer_ = sg_make_buffer(&vertexBufDesc);
 
-  //  sokol doesn't support Texture1D out of the box, so fake it with a 2D
-  //  abgr color texture of 8 vertical lines, 8 pixels high.
-  uint8_t hiresColorData[32 * 8];
-  for (int y = 0; y < 8; ++y) {
-    uint8_t* texdata = &hiresColorData[32 * y];
-    for (int x = 0; x < 8; ++x) {
-      texdata[x * 4] = kHiresColors[x][0];
-      texdata[x * 4 + 1] = kHiresColors[x][1];
-      texdata[x * 4 + 2] = kHiresColors[x][2];
-      texdata[x * 4 + 3] = kHiresColors[x][3];
-    }
-  }
-
-  sg_image_desc imageDesc = {};
-  imageDesc.width = 8;
-  imageDesc.height = 8;
-  imageDesc.type = SG_IMAGETYPE_2D;
-  imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.usage = SG_USAGE_IMMUTABLE;
-  imageDesc.data.subimage[0][0].ptr = hiresColorData;
-  imageDesc.data.subimage[0][0].size = sizeof(hiresColorData);
-  hgrColorArray_ = sg_make_image(imageDesc);
-
-  uint8_t dblHiresColorData[64 * 8];
-  for (int y = 0; y < 8; ++y) {
-    uint8_t* texdata = &dblHiresColorData[64 * y];
-    for (int x = 0; x < 16; ++x) {
-      texdata[x * 4] = kDblHiresColors[x][0];
-      texdata[x * 4 + 1] = kDblHiresColors[x][1];
-      texdata[x * 4 + 2] = kDblHiresColors[x][2];
-      texdata[x * 4 + 3] = kDblHiresColors[x][3];
-    }
-  }
-
-  imageDesc = {};
-  imageDesc.width = 16;
-  imageDesc.height = 8;
-  imageDesc.type = SG_IMAGETYPE_2D;
-  imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.usage = SG_USAGE_IMMUTABLE;
-  imageDesc.data.subimage[0][0].ptr = dblHiresColorData;
-  imageDesc.data.subimage[0][0].size = sizeof(dblHiresColorData);
-  dblhgrColorArray_ = sg_make_image(imageDesc);
-
-  emulatorRGBABuffer_ = new uint8_t[1024 * 8];
-
-  imageDesc = {};
-  imageDesc.width = 256;
-  imageDesc.height = 8;
-  imageDesc.type = SG_IMAGETYPE_2D;
-  imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.usage = SG_USAGE_STREAM;
-  rgbaColorArray_ = sg_make_image(imageDesc);
-
-  imageDesc = {};
-  imageDesc.width = kGraphicsTextureWidth;
-  imageDesc.height = kGraphicsTextureHeight;
-  imageDesc.pixel_format = SG_PIXELFORMAT_R8;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.usage = SG_USAGE_STREAM;
-  graphicsTarget_ = sg_make_image(imageDesc);
-  emulatorVideoBuffer_ = new uint8_t[kGraphicsTextureWidth * kGraphicsTextureHeight];
-
-  //  create offscreen pass and image targets
-  //const int rtSampleCount = sg_query_features().msaa_render_targets ?
-  imageDesc = {};
-  imageDesc.render_target = true;
-  imageDesc.width = kRenderTargetWidth;
-  imageDesc.height = kRenderTargetHeight;
-  imageDesc.min_filter = SG_FILTER_LINEAR;
-  imageDesc.mag_filter = SG_FILTER_LINEAR;
-  imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-  imageDesc.sample_count = 1;
-  screenTarget_ = sg_make_image(imageDesc);
-
-  sg_pass_desc passDesc = {};
-  passDesc.color_attachments[0].image = screenTarget_;
-  screenPass_ = sg_make_pass(passDesc);
-}
-
-ClemensDisplay::~ClemensDisplay()
-{
-  sg_destroy_pass(screenPass_);
-  sg_destroy_image(screenTarget_);
-  sg_destroy_image(graphicsTarget_);
-  sg_destroy_image(hgrColorArray_);
-  sg_destroy_image(dblhgrColorArray_);
-  sg_destroy_image(rgbaColorArray_);
-  sg_destroy_buffer(vertexBuffer_);
-  sg_destroy_buffer(textVertexBuffer_);
-  provider_.free((void *)textVertices_.ptr);
-  delete[] emulatorVideoBuffer_;
-  delete[] emulatorRGBABuffer_;
-}
-
-void ClemensDisplay::start(
-  const ClemensMonitor& monitor,
-  int screen_w,
-  int screen_h
-) {
-  sg_pass_action passAction = {};
-  passAction.colors[0].action = SG_ACTION_CLEAR;
-  const uint8_t* borderColor = &kGr16Colors[monitor.border_color & 0xf][0];
-  passAction.colors[0].value = {
-    borderColor[0]/255.0f,
-    borderColor[1]/255.0f,
-    borderColor[2]/255.0f,
-    1.0f
-  };
-
-  sg_begin_pass(screenPass_, &passAction);
-
-  emulatorMonitorDimensions_[0] = screen_w;
-  emulatorMonitorDimensions_[1] = screen_h;
-
-  emulatorVideoDimensions_[0] = monitor.width;
-  emulatorVideoDimensions_[1] = monitor.height;
-
-  emulatorTextColor_ = monitor.text_color;
-  emulatorSignal_ = monitor.signal;
-  emulatorColor_ = monitor.color;
-}
-
-void ClemensDisplay::finish(float *uvs)
-{
-  sg_end_pass();
-  uvs[0] = emulatorMonitorDimensions_[0] / kRenderTargetWidth;
-  uvs[1] = emulatorMonitorDimensions_[1] / kRenderTargetHeight;
-}
-
-void ClemensDisplay::renderTextGraphics(
-  const ClemensVideo& text, const ClemensVideo& graphics, const uint8_t* mainMemory,
-  const uint8_t* auxMemory, bool text80col, bool useAltCharSet) {
-
-  DrawVertex* verticesBegin =
-    reinterpret_cast<DrawVertex *>(const_cast<void*>(textVertices_.ptr));
-  DrawVertex* vertices = verticesBegin;
-  DisplayVertexParams textVertexParams;
-  DisplayVertexParams loresVertexParams;
-
-  DrawVertex* loresVertices = vertices;
-  if (graphics.format == kClemensVideoFormat_Double_Lores) {
-    loresVertexParams = createVertexParams(80, 48);
-    vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 80, auxMemory, 0);
-    if (!vertices) return;
-    vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 80, mainMemory, 1);
-    if (!vertices) return;
-  } else if (graphics.format == kClemensVideoFormat_Lores) {
-    loresVertexParams = createVertexParams(40, 48);
-    vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 40, mainMemory, 0);
-  }
-
-  DrawVertex* textVertices = vertices;
-  if (text.format == kClemensVideoFormat_Text) {
-    if (text80col) {
-      textVertexParams = createVertexParams(80, 24);
-      vertices = renderTextPlane(vertices, text, textVertexParams, 80, auxMemory, 0,
-                                 useAltCharSet);
-      if (!vertices) return;
-      vertices = renderTextPlane(vertices, text, textVertexParams, 80, mainMemory, 1,
-                                 useAltCharSet);
-      if (!vertices) return;
-    } else {
-      textVertexParams = createVertexParams(40, 24);
-      vertices = renderTextPlane(vertices, text, textVertexParams, 40, mainMemory, 0,
-                                 useAltCharSet);
-      if (!vertices) return;
-    }
-  }
-
-  if ((vertices - verticesBegin) == 0) return;
-
-  sg_apply_pipeline(provider_.textPipeline_);
-  sg_update_buffer(textVertexBuffer_, textVertices_);
-
-  //  render lores first
-  sg_bindings backBindings = {};
-  backBindings.fs_images[0] = provider_.blankImage_;
-  backBindings.vertex_buffers[0] = textVertexBuffer_;
-  int loresVertexCount = int(textVertices - loresVertices);
-  if (loresVertexCount > 0) {
-    int drawCount = graphics.format == kClemensVideoFormat_Double_Lores ? 2 : 1;
-    assert((loresVertexCount % drawCount) == 0);   // sanity check
-    int vertexPerDrawCall = loresVertexCount / drawCount;
-
-    sg_range uniformsBuffer = {};
-    uniformsBuffer.ptr = &loresVertexParams;
-    uniformsBuffer.size = sizeof(loresVertexParams);
-    sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, uniformsBuffer);
-    sg_apply_bindings(backBindings);
-    sg_draw(0, vertexPerDrawCall, 1);
-    if (graphics.format == kClemensVideoFormat_Double_Lores) {
-      sg_draw(vertexPerDrawCall, vertexPerDrawCall, 1);
-    }
-  }
-
-  //  render the text background and character requiring two draw calls.  the
-  //  background and text characters are not interleaved
-  sg_bindings textBindings = {};
-  textBindings.fs_images[0] = text80col ? provider_.systemFontImageHi_ : provider_.systemFontImage_;
-  textBindings.vertex_buffers[0] = textVertexBuffer_;
-  int textVertexOffset = loresVertexCount;
-  int textVertexCount = int(vertices - textVertices);
-  if (textVertexCount > 0) {
-    int drawCount = text80col ? 4 : 2;
-    assert((textVertexCount % drawCount) == 0);   // sanity check
-    int textVertexPerDrawCall = textVertexCount / drawCount;
-
-    sg_range uniformsBuffer = {};
-    uniformsBuffer.ptr = &textVertexParams;
-    uniformsBuffer.size = sizeof(textVertexParams);
-    sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, uniformsBuffer);
-    sg_apply_bindings(backBindings);
-    sg_draw(textVertexOffset, textVertexPerDrawCall, 1);
-    sg_apply_bindings(textBindings);
-    sg_draw(textVertexOffset + textVertexPerDrawCall, textVertexPerDrawCall, 1);
-    if (text80col) {
-      sg_apply_bindings(backBindings);
-      sg_draw(textVertexOffset + textVertexPerDrawCall * 2, textVertexPerDrawCall, 1);
-      sg_apply_bindings(textBindings);
-      sg_draw(textVertexOffset + textVertexPerDrawCall * 3, textVertexPerDrawCall, 1);
-    }
-  }
-}
-
-auto ClemensDisplay::renderTextPlane(
-  DrawVertex* vertices,
-  const ClemensVideo& video,
-  const DisplayVertexParams& vertexParams,
-  int columns,
-  const uint8_t* memory,
-  int phase,
-  bool useAlternateCharacterSet
-) -> DrawVertex* {
-  if (video.format != kClemensVideoFormat_Text) {
-    return nullptr;
-  }
-
-  const int kPhaseCount = columns / 40;
-
-  stbtt_bakedchar* glyphSet;
-  if (columns == 80) {
-    glyphSet = kGlyphSet80col;
-  } else {
-    glyphSet = kGlyphSet40col;
-  }
-
-  // pass 1 - background
-  unsigned textABGR = grColorToABGR((emulatorTextColor_ >> 4) & 0xf);
-
-  DrawVertex* vertex = vertices;
-  for (int i = 0; i < video.scanline_count; ++i) {
-    for (int j = 0; j < video.scanline_byte_cnt; ++j) {
-      float x0 = ((j * kPhaseCount) + phase);
-      float y0 = i + video.scanline_start;
-      float x1 = x0 + 1.0f;
-      float y1 = y0 + 1.0f;
-      vertex[0] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[1] = { { x0, y1 }, { 0.0f, 1.0f }, textABGR };
-      vertex[2] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[3] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[4] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[5] = { { x1, y0 }, { 1.0f, 0.0f }, textABGR };
-      vertex += 6;
-    }
-  }
-
-  //  poss 2 - foreground
-  //  determine cycle for flashing characters - we use a vertical blank counter
-  //  which in combination with the screen mode (NTSC vs PAL) can be used to
-  //  calculate a real-time value
-  unsigned monitorRefreshRate = emulatorSignal_ == CLEM_MONITOR_SIGNAL_PAL ? 50 : 60;
-  unsigned videoTimePhase = video.vbl_counter % monitorRefreshRate;
-  textABGR = grColorToABGR(emulatorTextColor_ & 0xf);
-  for (int i = 0; i < video.scanline_count; ++i) {
-    int row = i + video.scanline_start;
-    const uint8_t* scanline = memory + video.scanlines[row].offset;
-    for (int j = 0; j < video.scanline_byte_cnt; ++j) {
-      //  TODO: handle flashing chars
-      unsigned glyphIndex;
-      const uint8_t charIndex = scanline[j];
-      if (useAlternateCharacterSet) {
-        glyphIndex = kAlternateSetToGlyph[charIndex];
-      } else {
-        glyphIndex =  kPrimarySetToGlyph[charIndex];
-      }
-      //  TODO: is the cycle really 1 second?
-      if (videoTimePhase >= monitorRefreshRate / 2) {
-        glyphIndex = (glyphIndex << 16) | (glyphIndex >> 16);
-      }
-      glyphIndex &= 0xffff;
-      //auto* glyph = &glyphSet[glyphIndex];
-      stbtt_aligned_quad quad;
-      float xpos = ((j * kPhaseCount) + phase) * vertexParams.display_ratio[0];
-      float ypos = row * vertexParams.display_ratio[1] + (vertexParams.display_ratio[1] - 1);
-      stbtt_GetBakedQuad(glyphSet, kFontTextureWidth, kFontTextureHeight, glyphIndex, &xpos, &ypos, &quad, 1);
-      float l = quad.x0 / vertexParams.display_ratio[0];
-      float r = quad.x1 / vertexParams.display_ratio[0];
-      float t = quad.y0 / vertexParams.display_ratio[1];
-      float b = quad.y1 / vertexParams.display_ratio[1];
-      vertex[0] = { { l, t }, { quad.s0, quad.t0 }, textABGR };
-      vertex[1] = { { l, b }, { quad.s0, quad.t1 }, textABGR };
-      vertex[2] = { { r, b }, { quad.s1, quad.t1 }, textABGR };
-      vertex[3] = { { l, t }, { quad.s0, quad.t0 }, textABGR };
-      vertex[4] = { { r, b }, { quad.s1, quad.t1 }, textABGR };
-      vertex[5] = { { r, t }, { quad.s1, quad.t0 }, textABGR };
-      vertex += 6;
-    }
-  }
-
-  return vertex;
-}
-
-auto ClemensDisplay::renderLoresPlane(DrawVertex* vertices, const ClemensVideo& video,
-                                      const DisplayVertexParams& , int columns,
-                                      const uint8_t* memory, int phase) -> DrawVertex* {
-  if (video.format != kClemensVideoFormat_Lores) {
-    return nullptr;
-  }
-
-  const int kPhaseCount = columns / 40;
-
-  // background pass
-  DrawVertex* vertex = vertices;
-  for (int i = 0; i < video.scanline_count; ++i) {
-    int row = i + video.scanline_start;
-    const uint8_t* scanline = memory + video.scanlines[row].offset;
-    for (int j = 0; j < video.scanline_byte_cnt; ++j) {
-      float x0 = ((j * kPhaseCount) + phase);
-      float y0 = i * 2;
-      float x1 = x0 + 1.0f;
-      float y1 = y0 + 1.0f;
-
-      uint8_t block = scanline[j];
-      unsigned textABGR = grColorToABGR(block & 0xf);
-      vertex[0] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[1] = { { x0, y1 }, { 0.0f, 1.0f }, textABGR };
-      vertex[2] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[3] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[4] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[5] = { { x1, y0 }, { 1.0f, 0.0f }, textABGR };
-      vertex += 6;
-      textABGR = grColorToABGR(block >> 4);
-      y0 = y1;
-      y1 += 1.0f;
-      vertex[0] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[1] = { { x0, y1 }, { 0.0f, 1.0f }, textABGR };
-      vertex[2] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[3] = { { x0, y0 }, { 0.0f, 0.0f }, textABGR };
-      vertex[4] = { { x1, y1 }, { 1.0f, 1.0f }, textABGR };
-      vertex[5] = { { x1, y0 }, { 1.0f, 0.0f }, textABGR };
-      vertex += 6;
-    }
-  }
-
-  return vertex;
-}
-
-void ClemensDisplay::renderHiresGraphics(
-  const ClemensVideo& video,
-  const uint8_t* memory
-) {
-  if (video.format != kClemensVideoFormat_Hires) {
-    return;
-  }
-
-  //  TODO: simplify vertex shader for graphics screens
-  //        a lot of these uniforms don't seem  necessary, but we have to set
-  //        them up so the shader works.
-  auto vertexParams = createVertexParams(
-    emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
-  //  draw the graphics data with the incredible A2 hires color rules in mind
-  //  and scale in software the pixels to 2x2 so they conform to our output
-  //  texture size (which is 4x the size of a 280x192 screen)
-  for (int i = 0; i < video.scanline_count; ++i) {
-    int row = i + video.scanline_start;
-    const uint8_t* scanline = memory + video.scanlines[row].offset;
-    uint8_t* pixout = emulatorVideoBuffer_ + i * 2 * kGraphicsTextureWidth;
-    a2hgrToABGR8Scale2x2(pixout, pixout + kGraphicsTextureWidth, scanline);
-  }
-
-  renderHiresGraphicsTexture(video, vertexParams, hgrColorArray_);
-}
-
-//  Interesting...
-//    References: Patent - US4786893A
-//    "Method and apparatus for generating RGB color signals from composite
-//      digital video signal"
-//
-//    https://patents.google.com/patent/US4786893A/en?oq=US4786893
-//
-//    Patent seems to refer to Apple II composite signals converted to RGB
-//    using the sliding bit window as referred to in the Hardware Reference.
-//    It's likely this method is used in the IIgs - and so it's good enough for
-//    a baseline (doesn't fix IIgs Double Hires issues related to artifacting
-//    that allows better quality for NTSC hardware... which is another issue)
-//
-//  Notes:
-//    The "Prior Art Method" described in the patent matches my first naive
-//    implementation (4 bits per effective pixel = the color.)  The problem
-//    with this is that data is streamed serially to the controller vs on a per
-//    nibble basis.  This becomes an issue when transitioning between colors
-//    and the 4-bit color isn't aligned on the nibble.
-//
-//  Concept:
-//    Implement a version of the "Present Invention" from the patent
-//    - Given the most recent bit from the bitstream
-//    - if the result indicates a color pattern change, then render the
-//      original color until the color pattern change occurs
-//
-//  Details:
-//    Bit stream: incoming from pixin
-//    Shift register:
-//        history (most recent 4 bits being relevant)
-//    Barrel shifter:
-//        the original color at the start of the 4-bit string
-//        (this can be simplified in software as just a stored-off value)
-//    Color Change Test:
-//        If Shift Register Bit 3 != incoming bit, then color change
-//    Plot:
-//        If Color Change, Select Latch Color
-//        Else Select Barrel Shifted Color (Current)
-//        Set Latch color to selected color
-//    Latched Color:
-//        Initially Zero
-//
-//  This is a literal translation of the patent's Fig. 4 - which works pretty
-//  well to emulate the IIgs implementation.   This could be optimized via
-//  lookup tables.
-//
-//  TODO: optimize using lookup tables
-//
-static inline bool jk_ff(bool j, bool k, bool q) {
-  if (!j && !k) return q;
-  if (!j && k) return 0;
-  if (j && !k) return 1;
-  return !q;
-}
-
-void a2dhgrToABGR81x2(
-  uint8_t* pixout0, uint8_t* pixout1,
-  const uint8_t* scanlines[2],
-  int scanlineByteCnt
-) {
-  int pixinByteCounter = 0;
-  int pixinBitCounter = 0;
-  uint8_t pixinByte = *scanlines[0];
-  uint8_t shifter = 0;
-  uint8_t barrel = 0;
-  uint8_t latch = 0;
-  bool jk0 = false;
-  bool jk1 = false;
-
-  scanlineByteCnt <<= 1;
-  while (pixinByteCounter < scanlineByteCnt) {
-    bool pixinBit = (pixinByte & 0x1);
-    bool colorChanged0 = (pixinBit && !(shifter & 0x8));
-    bool colorChanged1 = (!pixinBit && (shifter & 0x8));
-    unsigned barrelShift = (pixinBitCounter % 4);
-    barrel = shifter >> barrelShift;
-    barrel |= (shifter << (4 - barrelShift));
-    barrel &= 0xf;
-
-    uint8_t selected =  (jk0 || jk1) ? latch : barrel;
-    uint8_t pixout = (latch << 4) + 8;
-    *(pixout0++) = pixout;
-    *(pixout1++) = pixout;
-
-    //  next clock
-    jk0 = jk_ff(colorChanged0, shifter & 0x4, jk0);
-    jk1 = jk_ff(colorChanged1, !(shifter & 0x4), jk1);
-    shifter <<= 1;
-    shifter |= (pixinBit ? 0x1 : 0);
-    latch = selected;
-    pixinByte >>= 1;
-    ++pixinBitCounter;
-    if (!(pixinBitCounter % 7)) {
-      ++scanlines[pixinByteCounter % 2];
-      ++pixinByteCounter;
-      pixinByte = *scanlines[pixinByteCounter % 2];
-    }
-  }
-}
-
-void ClemensDisplay::renderDoubleHiresGraphics(
-  const ClemensVideo& video,
-  const uint8_t* main,
-  const uint8_t* aux
-) {
-  if (video.format != kClemensVideoFormat_Double_Hires) {
-    return;
-  }
-  auto vertexParams = createVertexParams(
-    emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
-
-
-  //  An oversimplication of double hires reads that the 'effective' resolution
-  //  is 4 pixels per color (so 140x192 - let's say a color is a 'block' of 4
-  //  pixels.   Since a block is a 4-bit pattern representing actual pixels on
-  //  the screen, adjacent blocks to the current block of interest will effect
-  //  this block.   To best handle the 'bit per pixel' method of rendering,
-  //  where the pixel color is determine by past state, our plotter will
-  //  'slide' along the bit array.  At some point the plotter will decide what
-  //  color to render at an earlier point in the array and proceed ahead.
-  //
-  for (int y = 0; y < video.scanline_count; ++y) {
-    int row = y + video.scanline_start;
-    const uint8_t* pixsources[2] = {
-      aux + video.scanlines[row].offset,
-      main + video.scanlines[row].offset
-    };
-    uint8_t* pixout = emulatorVideoBuffer_ + y * 2 * kGraphicsTextureWidth;
-    a2dhgrToABGR81x2(pixout, pixout + kGraphicsTextureWidth, pixsources, video.scanline_byte_cnt);
-    /*
-    const uint8_t* pixin = pixsources[0];
-    unsigned color = 0;
-    unsigned x = 0, xi = 0;
-    uint8_t data = pixin[0];
-    while (x < 560) {
-      color <<= 1;
-      if (data & 0x1) color |= 0x1;
-      data >>= 1;
-      ++x;
-      if ((x % 4) == 0) {
-        unsigned xo = x - 4;
-        for (unsigned xo = x - 4; xo < x; ++xo) {
-          unsigned pixel = ((color & 0xf) << 4) + 8;
-          pixout[xo] = pixel;
-          (pixout + kGraphicsTextureWidth)[xo] = pixel;
+    //  sokol doesn't support Texture1D out of the box, so fake it with a 2D
+    //  abgr color texture of 8 vertical lines, 8 pixels high.
+    uint8_t hiresColorData[32 * 8];
+    for (int y = 0; y < 8; ++y) {
+        uint8_t *texdata = &hiresColorData[32 * y];
+        for (int x = 0; x < 8; ++x) {
+            texdata[x * 4] = kHiresColors[x][0];
+            texdata[x * 4 + 1] = kHiresColors[x][1];
+            texdata[x * 4 + 2] = kHiresColors[x][2];
+            texdata[x * 4 + 3] = kHiresColors[x][3];
         }
-      }
-      if ((x % 7) == 0) {
-        ++xi;
-        pixin = pixsources[xi % 2];
-        data = pixin[xi >> 1];
-      }
     }
-    */
-  }
-  //
-  renderHiresGraphicsTexture(video, vertexParams, dblhgrColorArray_);
-}
 
-void ClemensDisplay::renderHiresGraphicsTexture(
-  const ClemensVideo& video,
-  const DisplayVertexParams& vertexParams,
-  sg_image colorArray
-) {
-  sg_image_data graphicsImageData = {};
-  graphicsImageData.subimage[0][0].ptr = emulatorVideoBuffer_;
-  graphicsImageData.subimage[0][0].size = kGraphicsTextureWidth * kGraphicsTextureHeight;
+    sg_image_desc imageDesc = {};
+    imageDesc.width = 8;
+    imageDesc.height = 8;
+    imageDesc.type = SG_IMAGETYPE_2D;
+    imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.usage = SG_USAGE_IMMUTABLE;
+    imageDesc.data.subimage[0][0].ptr = hiresColorData;
+    imageDesc.data.subimage[0][0].size = sizeof(hiresColorData);
+    hgrColorArray_ = sg_make_image(imageDesc);
 
-  sg_update_image(graphicsTarget_, graphicsImageData);
-
-  sg_range rangeParam;
-  rangeParam.ptr = &vertexParams;
-  rangeParam.size = sizeof(vertexParams);
-
-  sg_apply_pipeline(provider_.hiresPipeline_);
-  sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, rangeParam);
-
-  //  texture contains a scaled version of the original 280 x 160/192 screen
-  //  to avoid UV rounding issues
-  DrawVertex vertices[6];
-  float y_scalar = emulatorVideoDimensions_[1] / 192.0f;
-  float x0 = 0.0f;
-  float y0 = 0.0f;
-  float x1 = x0 + emulatorVideoDimensions_[0];
-  float y1 = y0 + (video.scanline_count * y_scalar);
-  float u0 = 0.0f;
-  float v0 = 0.0f;
-  float u1 = emulatorVideoDimensions_[0] / kGraphicsTextureWidth;
-  float v1 = (video.scanline_count * y_scalar) / kGraphicsTextureHeight;
-
-  sg_range verticesRange;
-  verticesRange.ptr = &vertices[0];
-  verticesRange.size = 6 * sizeof(DrawVertex);
-  vertices[0] = { { x0, y0 }, { u0, v0 }, 0xffffffff };
-  vertices[1] = { { x0, y1 }, { u0, v1 }, 0xffffffff };
-  vertices[2] = { { x1, y1 }, { u1, v1 }, 0xffffffff };
-  vertices[3] = { { x0, y0 }, { u0, v0 }, 0xffffffff };
-  vertices[4] = { { x1, y1 }, { u1, v1 }, 0xffffffff };
-  vertices[5] = { { x1, y0 }, { u1, v0 }, 0xffffffff };
-
-  sg_bindings renderBindings = {};
-  renderBindings.vertex_buffers[0] = vertexBuffer_;
-  renderBindings.fs_images[0] = graphicsTarget_;
-  renderBindings.fs_images[1] = colorArray;
-  renderBindings.vertex_buffer_offsets[0] = (
-    sg_append_buffer(renderBindings.vertex_buffers[0], verticesRange));
-  sg_apply_bindings(renderBindings);
-  sg_draw(0, 6, 1);
-}
-
-void ClemensDisplay::renderSuperHiresGraphics(
-  const ClemensVideo& video,
-  const uint8_t* memory
-) {
-  // 1x2 pixels
-  uint8_t* video_out = emulatorVideoBuffer_;
-  clemens_render_video(&video, memory, video_out,
-                       kGraphicsTextureWidth, kGraphicsTextureHeight,
-                       kGraphicsTextureWidth * 2, 1);
-
-
-  uint8_t* buffer0 = video_out;
-  for (int y = 0; y < video.scanline_count; ++y) {
-    uint8_t* buffer1 = buffer0 + kGraphicsTextureWidth;
-    memcpy(buffer1, buffer0, kGraphicsTextureWidth);
-    buffer0 += kGraphicsTextureWidth * 2;
-  }
-
-  for (int y = 0; y < 8; ++y) {
-    uint8_t* texdata = &emulatorRGBABuffer_[1024 * y];
-    for (int x = 0; x < 256; ++x) {
-        texdata[x * 4] = (uint8_t)(video.rgba[x] >> 24);
-        texdata[x * 4 + 1] = (uint8_t)((video.rgba[x] >> 16) & 0xff);
-        texdata[x * 4 + 2] = (uint8_t)((video.rgba[x] >> 8) & 0xff);
-        texdata[x * 4 + 3] = (uint8_t)(video.rgba[x] & 0xff);
+    uint8_t dblHiresColorData[64 * 8];
+    for (int y = 0; y < 8; ++y) {
+        uint8_t *texdata = &dblHiresColorData[64 * y];
+        for (int x = 0; x < 16; ++x) {
+            texdata[x * 4] = kDblHiresColors[x][0];
+            texdata[x * 4 + 1] = kDblHiresColors[x][1];
+            texdata[x * 4 + 2] = kDblHiresColors[x][2];
+            texdata[x * 4 + 3] = kDblHiresColors[x][3];
+        }
     }
-  }
 
-  sg_image_data graphicsImageData = {};
-  graphicsImageData.subimage[0][0].ptr = emulatorVideoBuffer_;
-  graphicsImageData.subimage[0][0].size = kGraphicsTextureWidth * kGraphicsTextureHeight;
-  sg_update_image(graphicsTarget_, graphicsImageData);
+    imageDesc = {};
+    imageDesc.width = 16;
+    imageDesc.height = 8;
+    imageDesc.type = SG_IMAGETYPE_2D;
+    imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.usage = SG_USAGE_IMMUTABLE;
+    imageDesc.data.subimage[0][0].ptr = dblHiresColorData;
+    imageDesc.data.subimage[0][0].size = sizeof(dblHiresColorData);
+    dblhgrColorArray_ = sg_make_image(imageDesc);
 
-  graphicsImageData.subimage[0][0].ptr = emulatorRGBABuffer_;
-  graphicsImageData.subimage[0][0].size = 256 * 4 * 8;
-  sg_update_image(rgbaColorArray_, graphicsImageData);
+    emulatorRGBABuffer_ = new uint8_t[1024 * 8];
 
-  auto vertexParams = createVertexParams(
-    emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
-  sg_range rangeParam;
-  rangeParam.ptr = &vertexParams;
-  rangeParam.size = sizeof(vertexParams);
+    imageDesc = {};
+    imageDesc.width = 256;
+    imageDesc.height = 8;
+    imageDesc.type = SG_IMAGETYPE_2D;
+    imageDesc.pixel_format = SG_PIXELFORMAT_RGBA8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.usage = SG_USAGE_STREAM;
+    rgbaColorArray_ = sg_make_image(imageDesc);
 
-  sg_apply_pipeline(provider_.superHiresPipeline_);
-  sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, rangeParam);
+    imageDesc = {};
+    imageDesc.width = kGraphicsTextureWidth;
+    imageDesc.height = kGraphicsTextureHeight;
+    imageDesc.pixel_format = SG_PIXELFORMAT_R8;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.usage = SG_USAGE_STREAM;
+    graphicsTarget_ = sg_make_image(imageDesc);
+    emulatorVideoBuffer_ = new uint8_t[kGraphicsTextureWidth * kGraphicsTextureHeight];
 
-  //  texture contains a scaled version of the original 280 x 160/192 screen
-  //  to avoid UV rounding issues
-  DrawVertex vertices[6];
-  float y_scalar = emulatorVideoDimensions_[1] / 200.0f;
-  float x0 = 0.0f;
-  float y0 = 0.0f;
-  float x1 = x0 + emulatorVideoDimensions_[0];
-  float y1 = y0 + (video.scanline_count * y_scalar);
-  float u0 = 0.0f;
-  float v0 = 0.0f;
-  float u1 = emulatorVideoDimensions_[0] / kGraphicsTextureWidth;
-  float v1 = (video.scanline_count * y_scalar) / kGraphicsTextureHeight;
+    //  create offscreen pass and image targets
+    // const int rtSampleCount = sg_query_features().msaa_render_targets ?
+    imageDesc = {};
+    imageDesc.render_target = true;
+    imageDesc.width = kRenderTargetWidth;
+    imageDesc.height = kRenderTargetHeight;
+    imageDesc.min_filter = SG_FILTER_LINEAR;
+    imageDesc.mag_filter = SG_FILTER_LINEAR;
+    imageDesc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    imageDesc.sample_count = 1;
+    screenTarget_ = sg_make_image(imageDesc);
 
-  sg_range verticesRange;
-  verticesRange.ptr = &vertices[0];
-  verticesRange.size = 6 * sizeof(DrawVertex);
-  vertices[0] = { { x0, y0 }, { u0, v0 }, 0xffffffff };
-  vertices[1] = { { x0, y1 }, { u0, v1 }, 0xffffffff };
-  vertices[2] = { { x1, y1 }, { u1, v1 }, 0xffffffff };
-  vertices[3] = { { x0, y0 }, { u0, v0 }, 0xffffffff };
-  vertices[4] = { { x1, y1 }, { u1, v1 }, 0xffffffff };
-  vertices[5] = { { x1, y0 }, { u1, v0 }, 0xffffffff };
-
-  sg_bindings renderBindings = {};
-  renderBindings.vertex_buffers[0] = vertexBuffer_;
-  renderBindings.fs_images[0] = graphicsTarget_;
-  renderBindings.fs_images[1] = rgbaColorArray_;
-  renderBindings.vertex_buffer_offsets[0] = (
-    sg_append_buffer(renderBindings.vertex_buffers[0], verticesRange));
-  sg_apply_bindings(renderBindings);
-  sg_draw(0, 6, 1);
+    sg_pass_desc passDesc = {};
+    passDesc.color_attachments[0].image = screenTarget_;
+    screenPass_ = sg_make_pass(passDesc);
 }
 
+ClemensDisplay::~ClemensDisplay() {
+    sg_destroy_pass(screenPass_);
+    sg_destroy_image(screenTarget_);
+    sg_destroy_image(graphicsTarget_);
+    sg_destroy_image(hgrColorArray_);
+    sg_destroy_image(dblhgrColorArray_);
+    sg_destroy_image(rgbaColorArray_);
+    sg_destroy_buffer(vertexBuffer_);
+    sg_destroy_buffer(textVertexBuffer_);
+    provider_.free((void *)textVertices_.ptr);
+    delete[] emulatorVideoBuffer_;
+    delete[] emulatorRGBABuffer_;
+}
 
-auto ClemensDisplay::createVertexParams(
-  float virtualDimX,
-  float virtualDimY
-) -> DisplayVertexParams
-{
-  DisplayVertexParams vertexParams;
-  vertexParams.virtual_dims[0] = virtualDimX;
-  vertexParams.virtual_dims[1] = virtualDimY;
-  vertexParams.display_ratio[0] = emulatorVideoDimensions_[0] / virtualDimX;
-  vertexParams.display_ratio[1] = emulatorVideoDimensions_[1] / virtualDimY;
-  vertexParams.render_dims[0] = kRenderTargetWidth;
-  vertexParams.render_dims[1] = kRenderTargetHeight;
-  vertexParams.offsets[0] = (emulatorMonitorDimensions_[0] - emulatorVideoDimensions_[0]) * 0.5f;
-  vertexParams.offsets[1] = (emulatorMonitorDimensions_[1] - emulatorVideoDimensions_[1]) * 0.5f;
-  return vertexParams;
+void ClemensDisplay::start(const ClemensMonitor &monitor, int screen_w, int screen_h) {
+    sg_pass_action passAction = {};
+    passAction.colors[0].action = SG_ACTION_CLEAR;
+    const uint8_t *borderColor = &kGr16Colors[monitor.border_color & 0xf][0];
+    passAction.colors[0].value = {borderColor[0] / 255.0f, borderColor[1] / 255.0f,
+                                  borderColor[2] / 255.0f, 1.0f};
+
+    sg_begin_pass(screenPass_, &passAction);
+
+    emulatorMonitorDimensions_[0] = screen_w;
+    emulatorMonitorDimensions_[1] = screen_h;
+
+    emulatorVideoDimensions_[0] = monitor.width;
+    emulatorVideoDimensions_[1] = monitor.height;
+
+    emulatorTextColor_ = monitor.text_color;
+    emulatorSignal_ = monitor.signal;
+    emulatorColor_ = monitor.color;
+}
+
+void ClemensDisplay::finish(float *uvs) {
+    sg_end_pass();
+    uvs[0] = emulatorMonitorDimensions_[0] / kRenderTargetWidth;
+    uvs[1] = emulatorMonitorDimensions_[1] / kRenderTargetHeight;
+}
+
+void ClemensDisplay::renderTextGraphics(const ClemensVideo &text, const ClemensVideo &graphics,
+                                        const uint8_t *mainMemory, const uint8_t *auxMemory,
+                                        bool text80col, bool useAltCharSet) {
+
+    DrawVertex *verticesBegin =
+        reinterpret_cast<DrawVertex *>(const_cast<void *>(textVertices_.ptr));
+    DrawVertex *vertices = verticesBegin;
+    DisplayVertexParams textVertexParams;
+    DisplayVertexParams loresVertexParams;
+
+    DrawVertex *loresVertices = vertices;
+    if (graphics.format == kClemensVideoFormat_Double_Lores) {
+        loresVertexParams = createVertexParams(80, 48);
+        vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 80, auxMemory, 0);
+        if (!vertices)
+            return;
+        vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 80, mainMemory, 1);
+        if (!vertices)
+            return;
+    } else if (graphics.format == kClemensVideoFormat_Lores) {
+        loresVertexParams = createVertexParams(40, 48);
+        vertices = renderLoresPlane(vertices, graphics, loresVertexParams, 40, mainMemory, 0);
+    }
+
+    DrawVertex *textVertices = vertices;
+    if (text.format == kClemensVideoFormat_Text) {
+        if (text80col) {
+            textVertexParams = createVertexParams(80, 24);
+            vertices =
+                renderTextPlane(vertices, text, textVertexParams, 80, auxMemory, 0, useAltCharSet);
+            if (!vertices)
+                return;
+            vertices =
+                renderTextPlane(vertices, text, textVertexParams, 80, mainMemory, 1, useAltCharSet);
+            if (!vertices)
+                return;
+        } else {
+            textVertexParams = createVertexParams(40, 24);
+            vertices =
+                renderTextPlane(vertices, text, textVertexParams, 40, mainMemory, 0, useAltCharSet);
+            if (!vertices)
+                return;
+        }
+    }
+
+    if ((vertices - verticesBegin) == 0)
+        return;
+
+    sg_apply_pipeline(provider_.textPipeline_);
+    sg_update_buffer(textVertexBuffer_, textVertices_);
+
+    //  render lores first
+    sg_bindings backBindings = {};
+    backBindings.fs_images[0] = provider_.blankImage_;
+    backBindings.vertex_buffers[0] = textVertexBuffer_;
+    int loresVertexCount = int(textVertices - loresVertices);
+    if (loresVertexCount > 0) {
+        int drawCount = graphics.format == kClemensVideoFormat_Double_Lores ? 2 : 1;
+        assert((loresVertexCount % drawCount) == 0); // sanity check
+        int vertexPerDrawCall = loresVertexCount / drawCount;
+
+        sg_range uniformsBuffer = {};
+        uniformsBuffer.ptr = &loresVertexParams;
+        uniformsBuffer.size = sizeof(loresVertexParams);
+        sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, uniformsBuffer);
+        sg_apply_bindings(backBindings);
+        sg_draw(0, vertexPerDrawCall, 1);
+        if (graphics.format == kClemensVideoFormat_Double_Lores) {
+            sg_draw(vertexPerDrawCall, vertexPerDrawCall, 1);
+        }
+    }
+
+    //  render the text background and character requiring two draw calls.  the
+    //  background and text characters are not interleaved
+    sg_bindings textBindings = {};
+    textBindings.fs_images[0] =
+        text80col ? provider_.systemFontImageHi_ : provider_.systemFontImage_;
+    textBindings.vertex_buffers[0] = textVertexBuffer_;
+    int textVertexOffset = loresVertexCount;
+    int textVertexCount = int(vertices - textVertices);
+    if (textVertexCount > 0) {
+        int drawCount = text80col ? 4 : 2;
+        assert((textVertexCount % drawCount) == 0); // sanity check
+        int textVertexPerDrawCall = textVertexCount / drawCount;
+
+        sg_range uniformsBuffer = {};
+        uniformsBuffer.ptr = &textVertexParams;
+        uniformsBuffer.size = sizeof(textVertexParams);
+        sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, uniformsBuffer);
+        sg_apply_bindings(backBindings);
+        sg_draw(textVertexOffset, textVertexPerDrawCall, 1);
+        sg_apply_bindings(textBindings);
+        sg_draw(textVertexOffset + textVertexPerDrawCall, textVertexPerDrawCall, 1);
+        if (text80col) {
+            sg_apply_bindings(backBindings);
+            sg_draw(textVertexOffset + textVertexPerDrawCall * 2, textVertexPerDrawCall, 1);
+            sg_apply_bindings(textBindings);
+            sg_draw(textVertexOffset + textVertexPerDrawCall * 3, textVertexPerDrawCall, 1);
+        }
+    }
+}
+
+auto ClemensDisplay::renderTextPlane(DrawVertex *vertices, const ClemensVideo &video,
+                                     const DisplayVertexParams &vertexParams, int columns,
+                                     const uint8_t *memory, int phase,
+                                     bool useAlternateCharacterSet) -> DrawVertex * {
+    if (video.format != kClemensVideoFormat_Text) {
+        return nullptr;
+    }
+
+    const int kPhaseCount = columns / 40;
+
+    stbtt_bakedchar *glyphSet;
+    if (columns == 80) {
+        glyphSet = kGlyphSet80col;
+    } else {
+        glyphSet = kGlyphSet40col;
+    }
+
+    // pass 1 - background
+    unsigned textABGR = grColorToABGR((emulatorTextColor_ >> 4) & 0xf);
+
+    DrawVertex *vertex = vertices;
+    for (int i = 0; i < video.scanline_count; ++i) {
+        for (int j = 0; j < video.scanline_byte_cnt; ++j) {
+            float x0 = ((j * kPhaseCount) + phase);
+            float y0 = i + video.scanline_start;
+            float x1 = x0 + 1.0f;
+            float y1 = y0 + 1.0f;
+            vertex[0] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[1] = {{x0, y1}, {0.0f, 1.0f}, textABGR};
+            vertex[2] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[3] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[4] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[5] = {{x1, y0}, {1.0f, 0.0f}, textABGR};
+            vertex += 6;
+        }
+    }
+
+    //  poss 2 - foreground
+    //  determine cycle for flashing characters - we use a vertical blank counter
+    //  which in combination with the screen mode (NTSC vs PAL) can be used to
+    //  calculate a real-time value
+    unsigned monitorRefreshRate = emulatorSignal_ == CLEM_MONITOR_SIGNAL_PAL ? 50 : 60;
+    unsigned videoTimePhase = video.vbl_counter % monitorRefreshRate;
+    textABGR = grColorToABGR(emulatorTextColor_ & 0xf);
+    for (int i = 0; i < video.scanline_count; ++i) {
+        int row = i + video.scanline_start;
+        const uint8_t *scanline = memory + video.scanlines[row].offset;
+        for (int j = 0; j < video.scanline_byte_cnt; ++j) {
+            //  TODO: handle flashing chars
+            unsigned glyphIndex;
+            const uint8_t charIndex = scanline[j];
+            if (useAlternateCharacterSet) {
+                glyphIndex = kAlternateSetToGlyph[charIndex];
+            } else {
+                glyphIndex = kPrimarySetToGlyph[charIndex];
+            }
+            //  TODO: is the cycle really 1 second?
+            if (videoTimePhase >= monitorRefreshRate / 2) {
+                glyphIndex = (glyphIndex << 16) | (glyphIndex >> 16);
+            }
+            glyphIndex &= 0xffff;
+            // auto* glyph = &glyphSet[glyphIndex];
+            stbtt_aligned_quad quad;
+            float xpos = ((j * kPhaseCount) + phase) * vertexParams.display_ratio[0];
+            float ypos = row * vertexParams.display_ratio[1] + (vertexParams.display_ratio[1] - 1);
+            stbtt_GetBakedQuad(glyphSet, kFontTextureWidth, kFontTextureHeight, glyphIndex, &xpos,
+                               &ypos, &quad, 1);
+            float l = quad.x0 / vertexParams.display_ratio[0];
+            float r = quad.x1 / vertexParams.display_ratio[0];
+            float t = quad.y0 / vertexParams.display_ratio[1];
+            float b = quad.y1 / vertexParams.display_ratio[1];
+            vertex[0] = {{l, t}, {quad.s0, quad.t0}, textABGR};
+            vertex[1] = {{l, b}, {quad.s0, quad.t1}, textABGR};
+            vertex[2] = {{r, b}, {quad.s1, quad.t1}, textABGR};
+            vertex[3] = {{l, t}, {quad.s0, quad.t0}, textABGR};
+            vertex[4] = {{r, b}, {quad.s1, quad.t1}, textABGR};
+            vertex[5] = {{r, t}, {quad.s1, quad.t0}, textABGR};
+            vertex += 6;
+        }
+    }
+
+    return vertex;
+}
+
+auto ClemensDisplay::renderLoresPlane(DrawVertex *vertices, const ClemensVideo &video,
+                                      const DisplayVertexParams &, int columns,
+                                      const uint8_t *memory, int phase) -> DrawVertex * {
+    if (video.format != kClemensVideoFormat_Lores) {
+        return nullptr;
+    }
+
+    const int kPhaseCount = columns / 40;
+
+    // background pass
+    DrawVertex *vertex = vertices;
+    for (int i = 0; i < video.scanline_count; ++i) {
+        int row = i + video.scanline_start;
+        const uint8_t *scanline = memory + video.scanlines[row].offset;
+        for (int j = 0; j < video.scanline_byte_cnt; ++j) {
+            float x0 = ((j * kPhaseCount) + phase);
+            float y0 = i * 2;
+            float x1 = x0 + 1.0f;
+            float y1 = y0 + 1.0f;
+
+            uint8_t block = scanline[j];
+            unsigned textABGR = grColorToABGR(block & 0xf);
+            vertex[0] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[1] = {{x0, y1}, {0.0f, 1.0f}, textABGR};
+            vertex[2] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[3] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[4] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[5] = {{x1, y0}, {1.0f, 0.0f}, textABGR};
+            vertex += 6;
+            textABGR = grColorToABGR(block >> 4);
+            y0 = y1;
+            y1 += 1.0f;
+            vertex[0] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[1] = {{x0, y1}, {0.0f, 1.0f}, textABGR};
+            vertex[2] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[3] = {{x0, y0}, {0.0f, 0.0f}, textABGR};
+            vertex[4] = {{x1, y1}, {1.0f, 1.0f}, textABGR};
+            vertex[5] = {{x1, y0}, {1.0f, 0.0f}, textABGR};
+            vertex += 6;
+        }
+    }
+
+    return vertex;
+}
+
+void ClemensDisplay::renderHiresGraphics(const ClemensVideo &video, const uint8_t *memory) {
+    if (video.format != kClemensVideoFormat_Hires) {
+        return;
+    }
+    clemens_render_graphics(&video, memory, nullptr, emulatorVideoBuffer_, kGraphicsTextureWidth,
+                            kGraphicsTextureHeight, kGraphicsTextureWidth);
+
+    //  TODO: simplify vertex shader for graphics screens
+    //        a lot of these uniforms don't seem  necessary, but we have to set
+    //        them up so the shader works.
+    auto vertexParams =
+        createVertexParams(emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
+    renderHiresGraphicsTexture(video, vertexParams, hgrColorArray_);
+}
+
+void ClemensDisplay::renderDoubleHiresGraphics(const ClemensVideo &video, const uint8_t *main,
+                                               const uint8_t *aux) {
+    if (video.format != kClemensVideoFormat_Double_Hires) {
+        return;
+    }
+
+    clemens_render_graphics(&video, main, aux, emulatorVideoBuffer_, kGraphicsTextureWidth,
+                            kGraphicsTextureHeight, kGraphicsTextureWidth);
+
+    auto vertexParams =
+        createVertexParams(emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
+    renderHiresGraphicsTexture(video, vertexParams, dblhgrColorArray_);
+}
+
+void ClemensDisplay::renderHiresGraphicsTexture(const ClemensVideo &video,
+                                                const DisplayVertexParams &vertexParams,
+                                                sg_image colorArray) {
+    sg_image_data graphicsImageData = {};
+    graphicsImageData.subimage[0][0].ptr = emulatorVideoBuffer_;
+    graphicsImageData.subimage[0][0].size = kGraphicsTextureWidth * kGraphicsTextureHeight;
+
+    sg_update_image(graphicsTarget_, graphicsImageData);
+
+    sg_range rangeParam;
+    rangeParam.ptr = &vertexParams;
+    rangeParam.size = sizeof(vertexParams);
+
+    sg_apply_pipeline(provider_.hiresPipeline_);
+    sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, rangeParam);
+
+    //  texture contains a scaled version of the original 280 x 160/192 screen
+    //  to avoid UV rounding issues
+    DrawVertex vertices[6];
+    float y_scalar = emulatorVideoDimensions_[1] / 192.0f;
+    float x0 = 0.0f;
+    float y0 = 0.0f;
+    float x1 = x0 + emulatorVideoDimensions_[0];
+    float y1 = y0 + (video.scanline_count * y_scalar);
+    float u0 = 0.0f;
+    float v0 = 0.0f;
+    float u1 = emulatorVideoDimensions_[0] / kGraphicsTextureWidth;
+    float v1 = (video.scanline_count * y_scalar) / kGraphicsTextureHeight;
+
+    sg_range verticesRange;
+    verticesRange.ptr = &vertices[0];
+    verticesRange.size = 6 * sizeof(DrawVertex);
+    vertices[0] = {{x0, y0}, {u0, v0}, 0xffffffff};
+    vertices[1] = {{x0, y1}, {u0, v1}, 0xffffffff};
+    vertices[2] = {{x1, y1}, {u1, v1}, 0xffffffff};
+    vertices[3] = {{x0, y0}, {u0, v0}, 0xffffffff};
+    vertices[4] = {{x1, y1}, {u1, v1}, 0xffffffff};
+    vertices[5] = {{x1, y0}, {u1, v0}, 0xffffffff};
+
+    sg_bindings renderBindings = {};
+    renderBindings.vertex_buffers[0] = vertexBuffer_;
+    renderBindings.fs_images[0] = graphicsTarget_;
+    renderBindings.fs_images[1] = colorArray;
+    renderBindings.vertex_buffer_offsets[0] =
+        (sg_append_buffer(renderBindings.vertex_buffers[0], verticesRange));
+    sg_apply_bindings(renderBindings);
+    sg_draw(0, 6, 1);
+}
+
+void ClemensDisplay::renderSuperHiresGraphics(const ClemensVideo &video, const uint8_t *memory) {
+    // 1x2 pixels
+    uint8_t *video_out = emulatorVideoBuffer_;
+    clemens_render_graphics(&video, memory, nullptr, video_out, kGraphicsTextureWidth,
+                            kGraphicsTextureHeight, kGraphicsTextureWidth);
+
+    uint8_t *buffer0 = video_out;
+    for (int y = 0; y < video.scanline_count; ++y) {
+        uint8_t *buffer1 = buffer0 + kGraphicsTextureWidth;
+        memcpy(buffer1, buffer0, kGraphicsTextureWidth);
+        buffer0 += kGraphicsTextureWidth * 2;
+    }
+
+    for (int y = 0; y < 8; ++y) {
+        uint8_t *texdata = &emulatorRGBABuffer_[1024 * y];
+        for (int x = 0; x < 256; ++x) {
+            texdata[x * 4] = (uint8_t)(video.rgba[x] >> 24);
+            texdata[x * 4 + 1] = (uint8_t)((video.rgba[x] >> 16) & 0xff);
+            texdata[x * 4 + 2] = (uint8_t)((video.rgba[x] >> 8) & 0xff);
+            texdata[x * 4 + 3] = (uint8_t)(video.rgba[x] & 0xff);
+        }
+    }
+
+    sg_image_data graphicsImageData = {};
+    graphicsImageData.subimage[0][0].ptr = emulatorVideoBuffer_;
+    graphicsImageData.subimage[0][0].size = kGraphicsTextureWidth * kGraphicsTextureHeight;
+    sg_update_image(graphicsTarget_, graphicsImageData);
+
+    graphicsImageData.subimage[0][0].ptr = emulatorRGBABuffer_;
+    graphicsImageData.subimage[0][0].size = 256 * 4 * 8;
+    sg_update_image(rgbaColorArray_, graphicsImageData);
+
+    auto vertexParams =
+        createVertexParams(emulatorVideoDimensions_[0], emulatorVideoDimensions_[1]);
+    sg_range rangeParam;
+    rangeParam.ptr = &vertexParams;
+    rangeParam.size = sizeof(vertexParams);
+
+    sg_apply_pipeline(provider_.superHiresPipeline_);
+    sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, rangeParam);
+
+    //  texture contains a scaled version of the original 280 x 160/192 screen
+    //  to avoid UV rounding issues
+    DrawVertex vertices[6];
+    float y_scalar = emulatorVideoDimensions_[1] / 200.0f;
+    float x0 = 0.0f;
+    float y0 = 0.0f;
+    float x1 = x0 + emulatorVideoDimensions_[0];
+    float y1 = y0 + (video.scanline_count * y_scalar);
+    float u0 = 0.0f;
+    float v0 = 0.0f;
+    float u1 = emulatorVideoDimensions_[0] / kGraphicsTextureWidth;
+    float v1 = (video.scanline_count * y_scalar) / kGraphicsTextureHeight;
+
+    sg_range verticesRange;
+    verticesRange.ptr = &vertices[0];
+    verticesRange.size = 6 * sizeof(DrawVertex);
+    vertices[0] = {{x0, y0}, {u0, v0}, 0xffffffff};
+    vertices[1] = {{x0, y1}, {u0, v1}, 0xffffffff};
+    vertices[2] = {{x1, y1}, {u1, v1}, 0xffffffff};
+    vertices[3] = {{x0, y0}, {u0, v0}, 0xffffffff};
+    vertices[4] = {{x1, y1}, {u1, v1}, 0xffffffff};
+    vertices[5] = {{x1, y0}, {u1, v0}, 0xffffffff};
+
+    sg_bindings renderBindings = {};
+    renderBindings.vertex_buffers[0] = vertexBuffer_;
+    renderBindings.fs_images[0] = graphicsTarget_;
+    renderBindings.fs_images[1] = rgbaColorArray_;
+    renderBindings.vertex_buffer_offsets[0] =
+        (sg_append_buffer(renderBindings.vertex_buffers[0], verticesRange));
+    sg_apply_bindings(renderBindings);
+    sg_draw(0, 6, 1);
+}
+
+auto ClemensDisplay::createVertexParams(float virtualDimX, float virtualDimY)
+    -> DisplayVertexParams {
+    DisplayVertexParams vertexParams;
+    vertexParams.virtual_dims[0] = virtualDimX;
+    vertexParams.virtual_dims[1] = virtualDimY;
+    vertexParams.display_ratio[0] = emulatorVideoDimensions_[0] / virtualDimX;
+    vertexParams.display_ratio[1] = emulatorVideoDimensions_[1] / virtualDimY;
+    vertexParams.render_dims[0] = kRenderTargetWidth;
+    vertexParams.render_dims[1] = kRenderTargetHeight;
+    vertexParams.offsets[0] = (emulatorMonitorDimensions_[0] - emulatorVideoDimensions_[0]) * 0.5f;
+    vertexParams.offsets[1] = (emulatorMonitorDimensions_[1] - emulatorVideoDimensions_[1]) * 0.5f;
+    return vertexParams;
 }
 
 #if defined(__GNUC__)

--- a/render.c
+++ b/render.c
@@ -14,132 +14,407 @@
 
 /* IN all of these functions, it's assumed out_x_limit is aligned with 4 pixels
  */
-static void _render_super_hires_320(const uint8_t* scan_row,
-                                    unsigned scan_control, unsigned scan_cnt,
-                                    uint8_t* out_row, unsigned out_x_limit,
-                                    unsigned x_step) {
-  unsigned scan_x = 0, out_x = 0;
-  uint8_t palette_off =
-    (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
-  uint8_t pixel;
-  for (; scan_x < scan_cnt && out_x < out_x_limit; ++scan_x) {
-    pixel = scan_row[scan_x] >> 4;
-    out_row[out_x] = palette_off + pixel;
-    out_x += x_step;
-    out_row[out_x] = palette_off + pixel;
-    out_x += x_step;
-    pixel = scan_row[scan_x] & 0xf;
-    out_row[out_x] = palette_off + pixel;
-    out_x += x_step;
-    out_row[out_x] = palette_off + pixel;
-    out_x += x_step;
-  }
-}
-
-static void _render_super_hires_320_fill(const uint8_t* scan_row,
-                                         unsigned scan_control, unsigned scan_cnt,
-                                         uint8_t* out_row, unsigned out_x_limit,
-                                         unsigned x_step) {
-
-  unsigned scan_x = 0, out_x = 0;
-  uint8_t palette_off =
-    (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
-  // NOTE: HW ref says these values are undetermined if the first scan byte is
-  //       zero.   Rather than emulating this undetermined behavior, set as 0
-  //       which will mean palette index 0
-  uint8_t pixel_a = 0, pixel_b = 0;
-  while (scan_x < scan_cnt && out_x < out_x_limit) {
-    if (scan_row[scan_x]) {
-      pixel_a = scan_row[scan_x] >> 4;
-      pixel_b = scan_row[scan_x] & 0xf;
+static void _render_super_hires_320(const uint8_t *scan_row, unsigned scan_control,
+                                    unsigned scan_cnt, uint8_t *out_row, unsigned out_x_limit) {
+    unsigned scan_x = 0, out_x = 0;
+    uint8_t palette_off = (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
+    uint8_t pixel;
+    for (; scan_x < scan_cnt && out_x < out_x_limit; ++scan_x) {
+        pixel = scan_row[scan_x] >> 4;
+        out_row[out_x] = palette_off + pixel;
+        out_x++;
+        out_row[out_x] = palette_off + pixel;
+        out_x++;
+        pixel = scan_row[scan_x] & 0xf;
+        out_row[out_x] = palette_off + pixel;
+        out_x++;
+        out_row[out_x] = palette_off + pixel;
+        out_x++;
     }
-    out_row[out_x] = palette_off + pixel_a;
-    out_x += x_step;
-    out_row[out_x] = palette_off + pixel_a;
-    out_x += x_step;
-    out_row[out_x] = palette_off + pixel_b;
-    out_x += x_step;
-    out_row[out_x] = palette_off + pixel_a;
-    out_x += x_step;
-  }
-
 }
 
-static void _render_super_hires_640(const uint8_t* scan_row,
-                                    unsigned scan_control, unsigned scan_cnt,
-                                    uint8_t* out_row, unsigned out_x_limit,
-                                    unsigned x_step) {
-  // See Ch 4, Table 4-21 IIgs HW Ref.
-  // Palette offset cycles from +8, +12, +0, +4 offset into a palette row
-  // starting at column 0, 1, 2, 3 and so forth.
-  // Dithering will be performed by the host as this step doesn't output RGBA
-  // values but palette indices (like in 320 mode)
-  unsigned scan_x = 0, out_x = 0;
-  uint8_t palette_off =
-    (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
-  uint8_t pixel;
-  for (; scan_x < scan_cnt && out_x < out_x_limit; ++scan_x) {
-    pixel = scan_row[scan_x] >> 6;
-    out_row[out_x] = (palette_off + 0x08) + pixel;
-    out_x += x_step;
-    pixel = (scan_row[scan_x] >> 4) & 0x3;
-    out_row[out_x] = (palette_off + 0x0c) + pixel;
-    out_x += x_step;
-    pixel = (scan_row[scan_x] >> 2) & 0x3;
-    out_row[out_x] = (palette_off + 0x00) + pixel;
-    out_x += x_step;
-    pixel = scan_row[scan_x] & 0x3;
-    out_row[out_x] = (palette_off + 0x04) + pixel;
-    out_x += x_step;
-  }
+static void _render_super_hires_320_fill(const uint8_t *scan_row, unsigned scan_control,
+                                         unsigned scan_cnt, uint8_t *out_row,
+                                         unsigned out_x_limit) {
+
+    unsigned scan_x = 0, out_x = 0;
+    uint8_t palette_off = (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
+    // NOTE: HW ref says these values are undetermined if the first scan byte is
+    //       zero.   Rather than emulating this undetermined behavior, set as 0
+    //       which will mean palette index 0
+    uint8_t pixel_a = 0, pixel_b = 0;
+    while (scan_x < scan_cnt && out_x < out_x_limit) {
+        if (scan_row[scan_x]) {
+            pixel_a = scan_row[scan_x] >> 4;
+            pixel_b = scan_row[scan_x] & 0xf;
+        }
+        out_row[out_x] = palette_off + pixel_a;
+        out_x++;
+        out_row[out_x] = palette_off + pixel_a;
+        out_x++;
+        out_row[out_x] = palette_off + pixel_b;
+        out_x++;
+        out_row[out_x] = palette_off + pixel_a;
+        out_x++;
+    }
 }
 
-static void _render_super_hires(const ClemensVideo* video, const uint8_t* memory,
-                                uint8_t* texture, unsigned width, unsigned height,
-                                unsigned stride, unsigned x_step) {
-  uint8_t* out_row = texture;
-  unsigned scanline_end = video->scanline_start + video->scanline_count;
-  unsigned scan_control;
-  unsigned scan_y;
-  for (scan_y = video->scanline_start; scan_y < scanline_end; ++scan_y) {
-    scan_control = video->scanlines[scan_y].control;
-    if (scan_control & CLEM_VGC_SCANLINE_CONTROL_640_MODE) {
-      _render_super_hires_640(memory + video->scanlines[scan_y].offset,
-                              video->scanlines[scan_y].control,
-                              video->scanline_byte_cnt,
-                              out_row, width, x_step);
-    } else if (scan_control & CLEM_VGC_SCANLINE_COLORFILL_MODE) {
-      _render_super_hires_320_fill(memory + video->scanlines[scan_y].offset,
-                                   video->scanlines[scan_y].control,
-                                   video->scanline_byte_cnt,
-                                   out_row, width, x_step);
+static void _render_super_hires_640(const uint8_t *scan_row, unsigned scan_control,
+                                    unsigned scan_cnt, uint8_t *out_row, unsigned out_x_limit) {
+    // See Ch 4, Table 4-21 IIgs HW Ref.
+    // Palette offset cycles from +8, +12, +0, +4 offset into a palette row
+    // starting at column 0, 1, 2, 3 and so forth.
+    // Dithering will be performed by the host as this step doesn't output RGBA
+    // values but palette indices (like in 320 mode)
+    unsigned scan_x = 0, out_x = 0;
+    uint8_t palette_off = (scan_control & CLEM_VGC_SCANLINE_PALETTE_INDEX_MASK) << 4;
+    uint8_t pixel;
+    for (; scan_x < scan_cnt && out_x < out_x_limit; ++scan_x) {
+        pixel = scan_row[scan_x] >> 6;
+        out_row[out_x] = (palette_off + 0x08) + pixel;
+        out_x++;
+        pixel = (scan_row[scan_x] >> 4) & 0x3;
+        out_row[out_x] = (palette_off + 0x0c) + pixel;
+        out_x++;
+        pixel = (scan_row[scan_x] >> 2) & 0x3;
+        out_row[out_x] = (palette_off + 0x00) + pixel;
+        out_x++;
+        pixel = scan_row[scan_x] & 0x3;
+        out_row[out_x] = (palette_off + 0x04) + pixel;
+        out_x++;
+    }
+}
+
+static void _render_super_hires(const ClemensVideo *video, const uint8_t *memory, uint8_t *texture,
+                                unsigned width, unsigned height, unsigned stride) {
+    uint8_t *out_row = texture;
+    unsigned scanline_end = video->scanline_start + video->scanline_count;
+    unsigned scan_control;
+    unsigned scan_y;
+    for (scan_y = video->scanline_start; scan_y < scanline_end; ++scan_y) {
+        scan_control = video->scanlines[scan_y].control;
+        if (scan_control & CLEM_VGC_SCANLINE_CONTROL_640_MODE) {
+            _render_super_hires_640(memory + video->scanlines[scan_y].offset,
+                                    video->scanlines[scan_y].control, video->scanline_byte_cnt,
+                                    out_row, width);
+        } else if (scan_control & CLEM_VGC_SCANLINE_COLORFILL_MODE) {
+            _render_super_hires_320_fill(memory + video->scanlines[scan_y].offset,
+                                         video->scanlines[scan_y].control, video->scanline_byte_cnt,
+                                         out_row, width);
+        } else {
+            _render_super_hires_320(memory + video->scanlines[scan_y].offset,
+                                    video->scanlines[scan_y].control, video->scanline_byte_cnt,
+                                    out_row, width);
+        }
+        out_row += stride;
+        out_row += stride;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum {
+    kClemensRenderZero,
+    kClemensRenderEven,
+    kClemensRenderOdd,
+    kClemensRenderOne,
+    kClemensRenderColorStateCount
+};
+
+//  HGR colors black, green/orange (odd), violet/blue (even), white
+//    violet even ; green odd   (hcolor 2, 1)
+//    orange even ; blue odd    (hcolor 5, 6)
+static uint8_t abgrFromHGRBitTable[kClemensRenderColorStateCount][2] = {
+    {0, 4}, /* black */
+    {2, 6}, /* even */
+    {1, 5}, /* odd */
+    {3, 7}  /* white */
+};
+
+//  bit 0 = incoming pixel at x+1, bit 1 = current pixel, bit 2 = pixel at x-1
+static unsigned stateToColorAction[8] = {
+    /* b000 */ 0, //  > 2 adjacent off = black
+    /* b001 */ 0, //  2 adjacent off outgoing  = black
+    /* b010 */ 1, //  color at bit 1
+    /* b011 */ 3, //  2 adjacent on incoming = white
+    /* b100 */ 0, //  2 adhacent off incoming = black
+    /* b101 */ 2, //  color at bit 2
+    /* b110 */ 3, //  2 adjacent on outgoing = white
+    /* b111 */ 3, //  > 2 adjacent on = white
+};
+
+static void a2hgrToABGR8Scale2x2(uint8_t *pixout, uint8_t *pixout2, const uint8_t *hgr) {
+    //  input is 40 bytes of hgr data to 280 bytes (1 byte per pixel)
+    //  colors are one, zero, even, odd
+    //  strategy:
+    //
+    //  two pixels: X and X + 1, and an extra 'register' BIT = zero
+    //  1 and 1 = white; BIT = one
+    //  1 and 0 = white if BIT = one else color(BIT) where BIT = even/odd(X)
+    //  0 and 1 = black if BIT = zero else color(BIT) where BIT = even/odd(X + 1)
+    //  0 and 0 = black; BIT = zero
+    //
+    //  0  1  2  3  4  5  6  7  8  9 10 11 12
+    //  --------------------------------------
+    //  0  0                                 |black; BIT = zero
+    //     0  1                              |black if BIT = zero; BIT = even
+    //        1  0                           |color(BIT) if BIT = zero; BIT = even
+    //           0  1                        |color(BIT) if BIT = one; BIT = even
+    //              1  1                     |white; BIT = one
+    //                 1  0                  |white; if BIT = one; BIT = odd
+    //                    0  1               |color(BIT); if BIT = odd; BIT = odd
+    //                       1  0            |color(BIT); if BIT = odd; BIT = odd
+    //                          0  0         |black; BIT = zero
+    //
+    //  "BIT" really is the value at X-1, so...
+    //
+    //  X-2, X-1, X
+    //  any  1    1   = white
+    //   1   1    0   = white
+    //   0   1    0   = color(even/odd(X-1), group)
+    //   0   0    1   = black
+    //   1   0    1   = color(even/odd(X), group)
+    //  any  0    0   = black
+    //
+    //  group = bit 7 of color/pixel byte
+
+    unsigned state = 0;
+    int xpos = -2;
+    unsigned group;
+    uint8_t pixel;
+    for (int byteIdx = 0; byteIdx < 40; ++byteIdx) {
+        uint8_t byte = hgr[byteIdx];
+        group = byte >> 7;
+        unsigned pxmask = 0x1;
+        while (pxmask != 0x80) {
+            unsigned bit = byte & pxmask;
+            state <<= 1;
+            pxmask <<= 1;
+            if (bit)
+                state |= 1;
+
+            unsigned action = stateToColorAction[state & 0x7];
+            unsigned color;
+            if (xpos >= 0) {
+                if (action == 0)
+                    color = 0;
+                else if (action == 1) {
+                    if (xpos & 2)
+                        color = 2;
+                    else
+                        color = 1;
+                } else if (action == 2) {
+                    if (xpos & 2)
+                        color = 1;
+                    else
+                        color = 2;
+                } else {
+                    color = 3;
+                }
+                //  normalize hcolor 0 to 7 to 0-255 to be shader friendly
+                pixel = (abgrFromHGRBitTable[color][group & 1] << 5) + 16;
+                pixout[xpos] = pixel;
+                pixout[xpos + 1] = pixel;
+                pixout2[xpos] = pixel;
+                pixout2[xpos + 1] = pixel;
+            }
+            xpos += 2;
+        }
+    }
+    state <<= 1;
+    unsigned action = stateToColorAction[state & 0x7];
+    unsigned color;
+    if (action == 0)
+        color = 0;
+    else if (action == 1) {
+        color = 2;
+    } else if (action == 2) {
+        color = 1;
     } else {
-      _render_super_hires_320(memory + video->scanlines[scan_y].offset,
-                              video->scanlines[scan_y].control,
-                              video->scanline_byte_cnt,
-                              out_row, width, x_step);
+        color = 3;
     }
-    out_row += stride;
-  }
+    pixel = (abgrFromHGRBitTable[color][group & 1] << 5) + 16;
+    pixout[xpos] = pixel;
+    pixout[xpos + 1] = pixel;
+    pixout2[xpos] = pixel;
+    pixout2[xpos + 1] = pixel;
 }
 
-void clemens_render_video(const ClemensVideo* video, const uint8_t* memory,
-                          uint8_t* texture, unsigned width, unsigned height,
-                          unsigned stride,
-                          unsigned x_step) {
+static void _render_hires(const ClemensVideo *video, const uint8_t *memory, uint8_t *texture,
+                          unsigned width, unsigned height, unsigned stride) {
+    //  draw the graphics data with the incredible A2 hires color rules in mind
+    //  and scale in software the pixels to 2x2 so they conform to our output
+    //  texture size (which is 4x the size of a 280x192 screen)
+    for (int i = 0; i < video->scanline_count; ++i) {
+        int row = i + video->scanline_start;
+        const uint8_t *scanline = memory + video->scanlines[row].offset;
+        uint8_t *pixout = texture + i * 2 * stride;
+        a2hgrToABGR8Scale2x2(pixout, pixout + stride, scanline);
+    }
+}
 
-  switch (video->format) {
+////////////////////////////////////////////////////////////////////////////////
+
+//  Interesting...
+//    References: Patent - US4786893A
+//    "Method and apparatus for generating RGB color signals from composite
+//      digital video signal"
+//
+//    https://patents.google.com/patent/US4786893A/en?oq=US4786893
+//
+//    Patent seems to refer to Apple II composite signals converted to RGB
+//    using the sliding bit window as referred to in the Hardware Reference.
+//    It's likely this method is used in the IIgs - and so it's good enough for
+//    a baseline (doesn't fix IIgs Double Hires issues related to artifacting
+//    that allows better quality for NTSC hardware... which is another issue)
+//
+//  Notes:
+//    The "Prior Art Method" described in the patent matches my first naive
+//    implementation (4 bits per effective pixel = the color.)  The problem
+//    with this is that data is streamed serially to the controller vs on a per
+//    nibble basis.  This becomes an issue when transitioning between colors
+//    and the 4-bit color isn't aligned on the nibble.
+//
+//  Concept:
+//    Implement a version of the "Present Invention" from the patent
+//    - Given the most recent bit from the bitstream
+//    - if the result indicates a color pattern change, then render the
+//      original color until the color pattern change occurs
+//
+//  Details:
+//    Bit stream: incoming from pixin
+//    Shift register:
+//        history (most recent 4 bits being relevant)
+//    Barrel shifter:
+//        the original color at the start of the 4-bit string
+//        (this can be simplified in software as just a stored-off value)
+//    Color Change Test:
+//        If Shift Register Bit 3 != incoming bit, then color change
+//    Plot:
+//        If Color Change, Select Latch Color
+//        Else Select Barrel Shifted Color (Current)
+//        Set Latch color to selected color
+//    Latched Color:
+//        Initially Zero
+//
+//  This is a literal translation of the patent's Fig. 4 - which works pretty
+//  well to emulate the IIgs implementation.   This could be optimized via
+//  lookup tables.
+//
+//  TODO: optimize using lookup tables
+//
+static inline bool jk_ff(bool j, bool k, bool q) {
+    if (!j && !k)
+        return q;
+    if (!j && k)
+        return 0;
+    if (j && !k)
+        return 1;
+    return !q;
+}
+
+static void a2dhgrToABGR81x2(uint8_t *pixout0, uint8_t *pixout1, const uint8_t *scanlines[2],
+                             int scanlineByteCnt) {
+    int pixinByteCounter = 0;
+    int pixinBitCounter = 0;
+    uint8_t pixinByte = *scanlines[0];
+    uint8_t shifter = 0;
+    uint8_t barrel = 0;
+    uint8_t latch = 0;
+    bool jk0 = false;
+    bool jk1 = false;
+
+    scanlineByteCnt <<= 1;
+    while (pixinByteCounter < scanlineByteCnt) {
+        bool pixinBit = (pixinByte & 0x1);
+        bool colorChanged0 = (pixinBit && !(shifter & 0x8));
+        bool colorChanged1 = (!pixinBit && (shifter & 0x8));
+        unsigned barrelShift = (pixinBitCounter % 4);
+        barrel = shifter >> barrelShift;
+        barrel |= (shifter << (4 - barrelShift));
+        barrel &= 0xf;
+
+        uint8_t selected = (jk0 || jk1) ? latch : barrel;
+        uint8_t pixout = (latch << 4) + 8;
+        *(pixout0++) = pixout;
+        *(pixout1++) = pixout;
+
+        //  next clock
+        jk0 = jk_ff(colorChanged0, shifter & 0x4, jk0);
+        jk1 = jk_ff(colorChanged1, !(shifter & 0x4), jk1);
+        shifter <<= 1;
+        shifter |= (pixinBit ? 0x1 : 0);
+        latch = selected;
+        pixinByte >>= 1;
+        ++pixinBitCounter;
+        if (!(pixinBitCounter % 7)) {
+            ++scanlines[pixinByteCounter % 2];
+            ++pixinByteCounter;
+            pixinByte = *scanlines[pixinByteCounter % 2];
+        }
+    }
+}
+
+static void _render_double_hires(const ClemensVideo *video, const uint8_t *main, const uint8_t *aux,
+                                 uint8_t *texture, unsigned width, unsigned height,
+                                 unsigned stride) {
+    //  An oversimplication of double hires reads that the 'effective' resolution
+    //  is 4 pixels per color (so 140x192 - let's say a color is a 'block' of 4
+    //  pixels.   Since a block is a 4-bit pattern representing actual pixels on
+    //  the screen, adjacent blocks to the current block of interest will effect
+    //  this block.   To best handle the 'bit per pixel' method of rendering,
+    //  where the pixel color is determine by past state, our plotter will
+    //  'slide' along the bit array.  At some point the plotter will decide what
+    //  color to render at an earlier point in the array and proceed ahead.
+    //
+    for (int y = 0; y < video->scanline_count; ++y) {
+        int row = y + video->scanline_start;
+        const uint8_t *pixsources[2] = {aux + video->scanlines[row].offset,
+                                        main + video->scanlines[row].offset};
+        uint8_t *pixout = texture + y * 2 * stride;
+        a2dhgrToABGR81x2(pixout, pixout + stride, pixsources, video->scanline_byte_cnt);
+        /*
+        const uint8_t* pixin = pixsources[0];
+        unsigned color = 0;
+        unsigned x = 0, xi = 0;
+        uint8_t data = pixin[0];
+        while (x < 560) {
+          color <<= 1;
+          if (data & 0x1) color |= 0x1;
+          data >>= 1;
+          ++x;
+          if ((x % 4) == 0) {
+            unsigned xo = x - 4;
+            for (unsigned xo = x - 4; xo < x; ++xo) {
+              unsigned pixel = ((color & 0xf) << 4) + 8;
+              pixout[xo] = pixel;
+              (pixout + kGraphicsTextureWidth)[xo] = pixel;
+            }
+          }
+          if ((x % 7) == 0) {
+            ++xi;
+            pixin = pixsources[xi % 2];
+            data = pixin[xi >> 1];
+          }
+        }
+        */
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void clemens_render_graphics(const ClemensVideo *video, const uint8_t *memory, const uint8_t *aux,
+                             uint8_t *texture, unsigned width, unsigned height, unsigned stride) {
+
+    switch (video->format) {
     case kClemensVideoFormat_Super_Hires:
-      _render_super_hires(video, memory, texture, width, height, stride, x_step);
-      break;
+        _render_super_hires(video, memory, texture, width, height, stride);
+        break;
     case kClemensVideoFormat_Double_Hires:
-      break;
+        _render_double_hires(video, memory, aux, texture, width, height, stride);
+        break;
     case kClemensVideoFormat_Hires:
-      break;
-    case kClemensVideoFormat_Double_Lores:
-      break;
-    case kClemensVideoFormat_Lores:
-      break;
-  }
-
+        _render_hires(video, memory, texture, width, height, stride);
+        break;
+    }
 }

--- a/render.h
+++ b/render.h
@@ -8,34 +8,22 @@ extern "C" {
 #endif
 
 /**
- * @brief Renders indexed color (16 colors x 16 palettes) into an 8-bit texture
+ * @brief Renders indexed color into an 8-bit texture
  *
- * Note this method provides stride and x_step as a method to implement a form
- * of scaling the result by the host.  This function provides the reference
- * bitmap with 'holes' that the host can fill in with pixels to scale up the
- * image.  This is to support targets that want to generate a larger, blockier
- * screen result to perform various effects.
- *
- * If the output texture scale matches the emulated screen's dimensions (1:1),
- * then x_step == 1 and stride == byte width of the texture row.
- *
- * To scale 2x2, set x_step == 2 and stride == row_byte_size * 2, and so on.
- * The result will not fill in the pixels at (1, 0), (0, 1) and (1, 1) of the
- * output pixel - that will be left to the host implementation as described
- * above.
+ * Note to support all graphics rendering modes, the output texture should be
+ * at least 640 x 400 texels.  Hires and Super hires 320 pixels are scaled 2x2
+ * to fill out the texture.  Double hires and 640 mode render pixels at 1x2.
  *
  * @param video
  * @param memory
+ * @param aux
  * @param texture
  * @param width
  * @param height
  * @param stride
- * @param x_step
  */
-void clemens_render_video(const ClemensVideo* video, const uint8_t* memory,
-                          uint8_t* texture,
-                          unsigned width, unsigned height, unsigned stride,
-                          unsigned x_step);
+void clemens_render_graphics(const ClemensVideo *video, const uint8_t *memory, const uint8_t *aux,
+                             uint8_t *texture, unsigned width, unsigned height, unsigned stride);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Moved some useful code from `clem_display.cpp` to the emulator render library.  Note that text rendering is still implemented solely in clem_display.cpp due to how it uses font atlases and renders one quad per character versus rendering to a bitmap. 