### PR TITLE
SmartPort drive support on the IWM with an Emulated Hard Drive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,4 +74,5 @@ target_include_directories(clemens_mpack_format
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 add_subdirectory(iocards)
+add_subdirectory(smartport)
 add_subdirectory(host)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(clemens_65816_mmio STATIC
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_mmio.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_rtc.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_scc.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clem_smartport.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_timer.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_vgc.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_woz.c"

--- a/app.c
+++ b/app.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
     clemens_init(&machine, 1000, 1000, rom, 256 * 1024, malloc(CLEM_IIGS_BANK_SIZE),
                  malloc(CLEM_IIGS_BANK_SIZE), malloc(CLEM_IIGS_BANK_SIZE * 16), 16);
     clem_mmio_init(&mmio, &machine.dev_debug, machine.mem.bank_page_map,
-                   machine.tspec.clocks_step_mega2, malloc(2048 * 7));
+                   machine.tspec.clocks_step_mega2, malloc(2048 * 7), 16);
 
     machine.cpu.pins.resbIn = false;
     machine.resb_counter = 3;

--- a/clem_2img.c
+++ b/clem_2img.c
@@ -41,12 +41,10 @@ struct Clemens2IMGDisk {
 */
 
 static const uint8_t gcr_6_2_byte[64] = {
-    0x96, 0x97, 0x9a, 0x9b, 0x9d, 0x9e, 0x9f, 0xa6, 0xa7, 0xab, 0xac,
-    0xad, 0xae, 0xaf, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb9, 0xba,
-    0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xcb, 0xcd, 0xce, 0xcf, 0xd3, 0xd6,
-    0xd7, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe5, 0xe6, 0xe7,
-    0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf2, 0xf3, 0xf4, 0xf5,
-    0xf6, 0xf7, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff};
+    0x96, 0x97, 0x9a, 0x9b, 0x9d, 0x9e, 0x9f, 0xa6, 0xa7, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb2, 0xb3,
+    0xb4, 0xb5, 0xb6, 0xb7, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xcb, 0xcd, 0xce, 0xcf, 0xd3,
+    0xd6, 0xd7, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe5, 0xe6, 0xe7, 0xe9, 0xea, 0xeb, 0xec,
+    0xed, 0xee, 0xef, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff};
 
 static const unsigned prodos_to_logical_sector_map_525[1][16] = {
     {0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15}};
@@ -56,436 +54,529 @@ static const unsigned dos_to_logical_sector_map_525[1][16] = {
     {0, 7, 14, 6, 13, 5, 12, 4, 11, 3, 10, 2, 9, 1, 8, 15}};
 
 /* 3.5" drives have 512 byte sectors (ProDOS assumed) */
-static const unsigned
-    prodos_to_logical_sector_map_35[CLEM_DISK_35_NUM_REGIONS][16] = {
-        {0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11, -1, -1, -1, -1},
-        {0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, -1, -1, -1, -1, -1},
-        {0, 5, 1, 6, 2, 7, 3, 8, 4, 9, -1, -1, -1, -1, -1, -1},
-        {0, 5, 1, 6, 2, 7, 3, 8, 4, -1, -1, -1, -1, -1, -1, -1},
-        {0, 4, 1, 5, 2, 6, 3, 7, -1, -1, -1, -1, -1, -1, -1, -1}};
+static const unsigned prodos_to_logical_sector_map_35[CLEM_DISK_35_NUM_REGIONS][16] = {
+    {0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11, -1, -1, -1, -1},
+    {0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, -1, -1, -1, -1, -1},
+    {0, 5, 1, 6, 2, 7, 3, 8, 4, 9, -1, -1, -1, -1, -1, -1},
+    {0, 5, 1, 6, 2, 7, 3, 8, 4, -1, -1, -1, -1, -1, -1, -1},
+    {0, 4, 1, 5, 2, 6, 3, 7, -1, -1, -1, -1, -1, -1, -1, -1}};
 
-static inline size_t _increment_data_ptr(const uint8_t *p, size_t amt,
-                                         const uint8_t *end) {
-  const uint8_t *n = p + amt;
-  return n <= end ? amt : n - end;
+static inline size_t _increment_data_ptr(const uint8_t *p, size_t amt, const uint8_t *end) {
+    const uint8_t *n = p + amt;
+    return n <= end ? amt : n - end;
 }
 
+//  all encoding is to little endian order in the final stream
 static inline uint16_t _decode_u16(const uint8_t *data) {
-  return le16toh(((uint16_t)data[1] << 8) | data[0]);
+    return ((uint16_t)data[1] << 8) | data[0];
 }
 
 static inline uint16_t _decode_u32(const uint8_t *data) {
-  return le32toh(((uint32_t)data[3] << 24) | ((uint32_t)data[2] << 16) |
-                 ((uint32_t)data[1] << 8) | data[0]);
+    return (((uint32_t)data[3] << 24) | ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) |
+            data[0]);
 }
 
-bool clem_2img_parse_header(struct Clemens2IMGDisk *disk, uint8_t *data,
-                            uint8_t *data_end) {
-  size_t allocation_amt = 0;
-  int state = 0;
-  uint32_t param32;
-  disk->image_buffer = data;
-  disk->image_buffer_length = data_end - data;
-
-  while (data < data_end) {
-    size_t data_size = 0;
-    switch (state) {
-    case 0: // is 2IMG?
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (!memcmp(data, "2IMG", data_size)) {
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 1: // creator tag
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        memcpy(disk->creator, data, data_size);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 2: // header size
-      data_size = _increment_data_ptr(data, 2, data_end);
-      if (data_size == 2 && _decode_u16(data) == 0x40) {
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 3: // version number
-      data_size = _increment_data_ptr(data, 2, data_end);
-      if (data_size == 2) {
-        disk->version = _decode_u16(data);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 4: // image format
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->format = _decode_u32(data);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 5: // flags
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->is_nibblized = false;
-        param32 = _decode_u32(data);
-        if (param32 & 0x80000000) {
-          disk->is_write_protected = true;
-        }
-        if (disk->format == CLEM_2IMG_FORMAT_DOS) {
-          if (param32 & 0x100) {
-            disk->dos_volume = param32 & 0xff;
-          } else {
-            disk->dos_volume = 254;
-            ;
-          }
-          disk->dos_volume = param32 & 0xff;
-        } else {
-          disk->dos_volume = 0;
-        }
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 6: // ProDOS blocks
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->block_count = _decode_u32(data);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 7: // points to the start of the data chunk
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->image_data_offset = _decode_u32(data);
-        disk->data = disk->image_buffer + disk->image_data_offset;
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 8: // data_end - data = size
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        param32 = _decode_u32(data);
-        if (param32 == 0) {
-          //  this is possible for prodos images
-          //  use blocks * 512
-          param32 = disk->block_count * 512;
-        }
-        if (param32 > 0x000c8000) {
-          //  todo check if we need to convert to le?
-          //  what disk images actually do this?
-          assert(false);
-        }
-        disk->data_end = disk->data + param32;
-        allocation_amt += param32;
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 9: // points to the start of the comment chunk
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->comment = disk->image_buffer + _decode_u32(data);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 10: // data_end - data = size
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        param32 = _decode_u32(data);
-        disk->comment_end = disk->comment + param32;
-        allocation_amt += param32;
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 11: // points to the start of the creator chunk
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        disk->creator_data = disk->image_buffer + _decode_u32(data);
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 12: // commend_end - comment = size
-      data_size = _increment_data_ptr(data, 4, data_end);
-      if (data_size == 4) {
-        param32 = _decode_u32(data);
-        disk->creator_data_end = disk->creator + param32;
-        allocation_amt += param32;
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 13: // empty space
-      data_size = _increment_data_ptr(data, 16, data_end);
-      if (data_size == 16) {
-        ++state;
-      } else {
-        return false;
-      }
-      break;
-    case 14: // if well formed header, we shouldn't get here
-      return true;
-    }
-    data += data_size;
-  }
-  return false;
+static inline void _encode_u16(uint8_t **data, uint16_t u16) {
+    (*data)[1] = (uint8_t)(u16 >> 8);
+    (*data)[0] = (uint8_t)(u16 & 0xff);
+    *data += 2;
 }
 
-bool clem_2img_generate_header(struct Clemens2IMGDisk *disk, uint32_t format,
-                               uint8_t *image, uint8_t *image_end) {
-  uint32_t disk_size = (uint32_t)(image_end - image);
-
-  strncpy(disk->creator, "CLEM", sizeof(disk->creator));
-
-  /* validate that the input contains only sector data */
-  if (format == CLEM_2IMG_FORMAT_PRODOS) {
-    disk->block_count = disk_size / 512;
-    if (disk_size % 512) {
-      return false;
-    }
-  } else if (format == CLEM_2IMG_FORMAT_DOS) {
-    disk->block_count = 0;
-    if (disk_size % 256) {
-      return false;
-    }
-  }
-
-  /* TODO: support creator data and comments */
-  disk->image_buffer = image;
-  disk->image_buffer_length = disk_size;
-  disk->image_data_offset = 0;
-
-  disk->data = disk->image_buffer + disk->image_data_offset;
-  disk->data_end = disk->data + disk_size;
-
-  disk->creator_data = (char *)image + disk_size;
-  disk->creator_data_end = disk->creator_data;
-  disk->comment = (char *)image + disk_size;
-  disk->comment_end = disk->comment;
-
-  disk->version = 0x0001;
-  disk->format = format;
-  if (format == CLEM_2IMG_FORMAT_DOS) {
-    disk->dos_volume = 0xfe;
-  } else {
-    disk->dos_volume = 0x00;
-  }
-  disk->is_write_protected = true;
-  disk->is_nibblized = false;
-  return true;
+static inline void _encode_u32(uint8_t **data, uint32_t u32) {
+    (*data)[3] = (uint8_t)(u32 >> 24);
+    (*data)[2] = (uint8_t)(u32 >> 16);
+    (*data)[1] = (uint8_t)(u32 >> 8);
+    (*data)[0] = (uint8_t)(u32 & 0xff);
+    *data += 4;
 }
 
-static void _clem_nib_init_encoder(struct ClemensNibEncoder *encoder,
-                                   uint8_t *begin, uint8_t *end) {
-
-  encoder->begin = begin;
-  encoder->end = end;
-  encoder->bit_index = 0;
-  encoder->bit_index_end = (end - begin) * 8;
-}
-
-static void _clem_nib_write_bytes(struct ClemensNibEncoder *encoder,
-                                  unsigned cnt, unsigned bit_cnt,
-                                  uint8_t value) {
-  uint8_t *nib_cur = encoder->begin + (encoder->bit_index / 8);
-  unsigned bit_count = bit_cnt * cnt;
-  unsigned nib_bit_index_end = encoder->bit_index + bit_count;
-  unsigned bit_cnt_minus_1 = bit_cnt - 1;
-  unsigned out_shift = 7 - (encoder->bit_index % 8);
-  unsigned in_shift = 0;
-
-  nib_bit_index_end %= encoder->bit_index_end;
-
-  while (encoder->bit_index != nib_bit_index_end) {
-    if (value & (1 << (bit_cnt_minus_1 - in_shift))) {
-      nib_cur[0] |= (1 << out_shift);
+static void _encode_mem(uint8_t **data, uint8_t *mem, uint32_t cnt, bool overlapped) {
+    if (overlapped) {
+        memmove(*data, mem, cnt);
     } else {
-      nib_cur[0] &= ~(1 << out_shift);
+        memcpy(*data, mem, cnt);
     }
-    encoder->bit_index = (encoder->bit_index + 1) % encoder->bit_index_end;
-    in_shift = (in_shift + 1) % bit_cnt;
-    out_shift = 7 - (encoder->bit_index % 8);
-    nib_cur = encoder->begin + (encoder->bit_index / 8);
-  }
+    *data += cnt;
 }
 
-static void _clem_nib_encode_self_sync_ff(struct ClemensNibEncoder *encoder,
-                                          unsigned cnt) {
-  _clem_nib_write_bytes(encoder, cnt, 10, 0xff);
+bool clem_2img_parse_header(struct Clemens2IMGDisk *disk, uint8_t *data, uint8_t *data_end) {
+    size_t allocation_amt = 0;
+    int state = 0;
+    uint32_t param32;
+    disk->image_buffer = data;
+    disk->image_buffer_length = data_end - data;
+
+    while (data < data_end) {
+        size_t data_size = 0;
+        switch (state) {
+        case 0: // is 2IMG?
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (!memcmp(data, "2IMG", data_size)) {
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 1: // creator tag
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                memcpy(disk->creator, data, data_size);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 2: // header size
+            data_size = _increment_data_ptr(data, 2, data_end);
+            if (data_size == 2 && _decode_u16(data) == CLEM_2IMG_HEADER_BYTE_SIZE) {
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 3: // version number
+            data_size = _increment_data_ptr(data, 2, data_end);
+            if (data_size == 2) {
+                disk->version = _decode_u16(data);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 4: // image format
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->format = _decode_u32(data);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 5: // flags
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->is_nibblized = false;
+                param32 = _decode_u32(data);
+                if (param32 & 0x80000000) {
+                    disk->is_write_protected = true;
+                }
+                if (disk->format == CLEM_2IMG_FORMAT_DOS) {
+                    if (param32 & 0x100) {
+                        disk->dos_volume = param32 & 0xff;
+                    } else {
+                        disk->dos_volume = 254;
+                        ;
+                    }
+                    disk->dos_volume = param32 & 0xff;
+                } else {
+                    disk->dos_volume = 0;
+                }
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 6: // ProDOS blocks
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->block_count = _decode_u32(data);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 7: // points to the start of the data chunk
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->image_data_offset = _decode_u32(data);
+                disk->data = disk->image_buffer + disk->image_data_offset;
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 8: // data_end - data = size
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                param32 = _decode_u32(data);
+                if (param32 == 0) {
+                    //  this is possible for prodos images
+                    //  use blocks * 512
+                    param32 = disk->block_count * 512;
+                }
+                disk->data_end = disk->data + param32;
+                allocation_amt += param32;
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 9: // points to the start of the comment chunk
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->comment = disk->image_buffer + _decode_u32(data);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 10: // data_end - data = size
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                param32 = _decode_u32(data);
+                disk->comment_end = disk->comment + param32;
+                allocation_amt += param32;
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 11: // points to the start of the creator chunk
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                disk->creator_data = disk->image_buffer + _decode_u32(data);
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 12: // commend_end - comment = size
+            data_size = _increment_data_ptr(data, 4, data_end);
+            if (data_size == 4) {
+                param32 = _decode_u32(data);
+                disk->creator_data_end = disk->creator + param32;
+                allocation_amt += param32;
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 13: // empty space
+            data_size = _increment_data_ptr(data, 16, data_end);
+            if (data_size == 16) {
+                ++state;
+            } else {
+                return false;
+            }
+            break;
+        case 14: // if well formed header, we shouldn't get here
+            return true;
+        }
+        data += data_size;
+    }
+    return false;
 }
 
-static void _clem_nib_write_one(struct ClemensNibEncoder *encoder,
-                                uint8_t value) {
-  _clem_nib_write_bytes(encoder, 1, 8, value);
+bool clem_2img_build_image(struct Clemens2IMGDisk *disk, uint8_t *image, uint8_t *image_end) {
+    uint8_t *image_cur = image;
+    size_t image_size = image_end - image;
+    size_t source_size = disk->data_end - disk->data;
+    size_t creator_size = disk->creator_data_end - disk->creator_data;
+    size_t comment_size = disk->comment_end - disk->comment;
+    uint32_t flags;
+    bool overlapped;
+
+    if (image_end < disk->image_buffer) {
+        overlapped = false;
+    } else if (image >= disk->image_buffer + disk->image_buffer_length) {
+        overlapped = false;
+    } else if (image < disk->image_buffer ||
+               (image == disk->image_buffer &&
+                image_end == disk->image_buffer + disk->image_buffer_length)) {
+        overlapped = true;
+    } else {
+        /* some overlap where data will be corrupted */
+        return false;
+    }
+
+    if (image_size < source_size + creator_size + comment_size + CLEM_2IMG_HEADER_BYTE_SIZE)
+        return false;
+    if (disk->format == CLEM_2IMG_FORMAT_PRODOS) {
+        if (disk->block_count * 512 != source_size)
+            return false;
+    } else if (disk->format == CLEM_2IMG_FORMAT_DOS) {
+        /* DOS 140K disks*/
+        if (source_size != 280 * 512)
+            return false;
+    } else {
+        return false;
+    }
+
+    _encode_mem(&image_cur, "2IMG", 4, overlapped);
+    _encode_mem(&image_cur, "CLEM", 4, overlapped);
+    _encode_u16(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE);
+    _encode_u16(&image_cur, disk->version);
+    _encode_u32(&image_cur, disk->format);
+    flags = 0;
+    if (disk->is_write_protected)
+        flags |= 0x80000000;
+    if (disk->dos_volume < 254)
+        flags |= (0x0100 + (disk->dos_volume & 0xff));
+    _encode_u32(&image_cur, flags);
+    if (disk->format == CLEM_2IMG_FORMAT_PRODOS) {
+        _encode_u32(&image_cur, disk->block_count);
+    } else {
+        _encode_u32(&image_cur, 0);
+    }
+    _encode_u32(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE);
+    _encode_mem(&image_cur, disk->data, source_size, overlapped);
+    if (creator_size > 0) {
+        _encode_u32(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE + source_size);
+        _encode_u32(&image_cur, (uint32_t)(creator_size));
+    } else {
+        _encode_u32(&image_cur, 0);
+        _encode_u32(&image_cur, 0);
+    }
+    if (comment_size > 0) {
+        _encode_u32(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE + source_size + creator_size);
+        _encode_u32(&image_cur, (uint32_t)(comment_size));
+    } else {
+        _encode_u32(&image_cur, 0);
+        _encode_u32(&image_cur, 0);
+    }
+    /* empty 16-byte buffer*/
+    _encode_u32(&image_cur, 0);
+    _encode_u32(&image_cur, 0);
+    _encode_u32(&image_cur, 0);
+    _encode_u32(&image_cur, 0);
+    if (image_cur - image != CLEM_2IMG_HEADER_BYTE_SIZE)
+        return false;
+
+    _encode_mem(&image_cur, disk->data, source_size, overlapped);
+    _encode_mem(&image_cur, disk->creator_data, creator_size, overlapped);
+    _encode_mem(&image_cur, disk->comment, comment_size, overlapped);
+
+    return true;
 }
 
-static void _clem_nib_encode_one_6_2(struct ClemensNibEncoder *encoder,
-                                     uint8_t value) {
-  _clem_nib_write_one(encoder, gcr_6_2_byte[value & 0x3f]);
+bool clem_2img_generate_header(struct Clemens2IMGDisk *disk, uint32_t format, uint8_t *image,
+                               uint8_t *image_end, uint32_t image_data_offset) {
+    uint32_t disk_size = (uint32_t)(image_end - image);
+
+    strncpy(disk->creator, "CLEM", sizeof(disk->creator));
+
+    /* validate that the input contains only sector data */
+    if (format == CLEM_2IMG_FORMAT_PRODOS) {
+        disk->block_count = disk_size / 512;
+        if (disk_size % 512) {
+            return false;
+        }
+    } else if (format == CLEM_2IMG_FORMAT_DOS) {
+        disk->block_count = 0;
+        if (disk_size % 256) {
+            return false;
+        }
+    }
+
+    /* TODO: support creator data and comments */
+    disk->image_buffer = image;
+    disk->image_buffer_length = disk_size;
+    disk->image_data_offset = image_data_offset;
+
+    disk->data = disk->image_buffer + disk->image_data_offset;
+    disk->data_end = disk->data + disk_size;
+
+    disk->creator_data = (char *)image + disk_size;
+    disk->creator_data_end = disk->creator_data;
+    disk->comment = (char *)image + disk_size;
+    disk->comment_end = disk->comment;
+
+    disk->version = 0x0001;
+    disk->format = format;
+    if (format == CLEM_2IMG_FORMAT_DOS) {
+        disk->dos_volume = 0xfe;
+    } else {
+        disk->dos_volume = 0x00;
+    }
+    disk->is_write_protected = true;
+    disk->is_nibblized = false;
+    return true;
 }
 
-static void _clem_nib_encode_one_4_4(struct ClemensNibEncoder *encoder,
-                                     uint8_t value) {
-  /* all unused bits are set to '1', so 4x4 encoding to preserve odd bits
-     requires shifting the bits to the right  */
-  _clem_nib_write_one(encoder, (value >> 1) | 0xaa);
-  /* even bits */
-  _clem_nib_write_one(encoder, value | 0xaa);
+static void _clem_nib_init_encoder(struct ClemensNibEncoder *encoder, uint8_t *begin,
+                                   uint8_t *end) {
+
+    encoder->begin = begin;
+    encoder->end = end;
+    encoder->bit_index = 0;
+    encoder->bit_index_end = (end - begin) * 8;
 }
 
-static void _clem_nib_encode_data_35(struct ClemensNibEncoder *encoder,
-                                     const uint8_t *buf, unsigned cnt) {
-  /* decoded bytes are encoded to GCR 6-2 8-bit bytes*/
-  uint8_t scratch0[175], scratch1[175], scratch2[175];
-  uint8_t data[524];
-  unsigned chksum[3];
-  unsigned data_idx = 0, scratch_idx = 0;
-  uint8_t v;
+static void _clem_nib_write_bytes(struct ClemensNibEncoder *encoder, unsigned cnt, unsigned bit_cnt,
+                                  uint8_t value) {
+    uint8_t *nib_cur = encoder->begin + (encoder->bit_index / 8);
+    unsigned bit_count = bit_cnt * cnt;
+    unsigned nib_bit_index_end = encoder->bit_index + bit_count;
+    unsigned bit_cnt_minus_1 = bit_cnt - 1;
+    unsigned out_shift = 7 - (encoder->bit_index % 8);
+    unsigned in_shift = 0;
 
-  assert(cnt == 512);
-  /* IIgs - 12 byte tag header is blank, but....
-     TODO: what if it isn't??  */
-  data_idx = 12;
-  memset(data, 0, 12);
-  memcpy(data + data_idx, buf, 512);
+    nib_bit_index_end %= encoder->bit_index_end;
 
-  data_idx = 0;
-
-  /* split incoming decoded nibble data into parts for encoding into the
-     final encoded buffer
-
-     shamelessly translated from Ciderpress Nibble35.cpp as the encoding
-     scheme is quite involved - you stand on the shoulders of giants.
-  */
-  chksum[0] = chksum[1] = chksum[2] = 0;
-  while (data_idx < 524) {
-    chksum[0] = (chksum[0] & 0xff) << 1;
-    if (chksum[0] & 0x100) {
-      ++chksum[0];
+    while (encoder->bit_index != nib_bit_index_end) {
+        if (value & (1 << (bit_cnt_minus_1 - in_shift))) {
+            nib_cur[0] |= (1 << out_shift);
+        } else {
+            nib_cur[0] &= ~(1 << out_shift);
+        }
+        encoder->bit_index = (encoder->bit_index + 1) % encoder->bit_index_end;
+        in_shift = (in_shift + 1) % bit_cnt;
+        out_shift = 7 - (encoder->bit_index % 8);
+        nib_cur = encoder->begin + (encoder->bit_index / 8);
     }
-    v = data[data_idx++];
-    chksum[2] += v;
-    if (chksum[0] > 0xff) {
-      ++chksum[2];
-      chksum[0] &= 0xff;
-    }
-    scratch0[scratch_idx] = (v ^ chksum[0]) & 0xff;
-    v = data[data_idx++];
-    chksum[1] += v;
-    if (chksum[2] > 0xff) {
-      ++chksum[1];
-      chksum[2] &= 0xff;
-    }
-    scratch1[scratch_idx] = (v ^ chksum[2]) & 0xff;
+}
 
-    if (data_idx < 524) {
-      v = data[data_idx++];
-      chksum[0] += v;
-      if (chksum[1] > 0xff) {
-        ++chksum[0];
-        chksum[1] &= 0xff;
-      }
-      scratch2[scratch_idx] = (v ^ chksum[1]) & 0xff;
-      ++scratch_idx;
-    }
-  }
-  scratch2[scratch_idx++] = 0;
+static void _clem_nib_encode_self_sync_ff(struct ClemensNibEncoder *encoder, unsigned cnt) {
+    _clem_nib_write_bytes(encoder, cnt, 10, 0xff);
+}
 
-  for (data_idx = 0; data_idx < scratch_idx; ++data_idx) {
-    v = (scratch0[data_idx] & 0xc0) >> 2;
-    v |= (scratch1[data_idx] & 0xc0) >> 4;
-    v |= (scratch2[data_idx] & 0xc0) >> 6;
+static void _clem_nib_write_one(struct ClemensNibEncoder *encoder, uint8_t value) {
+    _clem_nib_write_bytes(encoder, 1, 8, value);
+}
+
+static void _clem_nib_encode_one_6_2(struct ClemensNibEncoder *encoder, uint8_t value) {
+    _clem_nib_write_one(encoder, gcr_6_2_byte[value & 0x3f]);
+}
+
+static void _clem_nib_encode_one_4_4(struct ClemensNibEncoder *encoder, uint8_t value) {
+    /* all unused bits are set to '1', so 4x4 encoding to preserve odd bits
+       requires shifting the bits to the right  */
+    _clem_nib_write_one(encoder, (value >> 1) | 0xaa);
+    /* even bits */
+    _clem_nib_write_one(encoder, value | 0xaa);
+}
+
+static void _clem_nib_encode_data_35(struct ClemensNibEncoder *encoder, const uint8_t *buf,
+                                     unsigned cnt) {
+    /* decoded bytes are encoded to GCR 6-2 8-bit bytes*/
+    uint8_t scratch0[175], scratch1[175], scratch2[175];
+    uint8_t data[524];
+    unsigned chksum[3];
+    unsigned data_idx = 0, scratch_idx = 0;
+    uint8_t v;
+
+    assert(cnt == 512);
+    /* IIgs - 12 byte tag header is blank, but....
+       TODO: what if it isn't??  */
+    data_idx = 12;
+    memset(data, 0, 12);
+    memcpy(data + data_idx, buf, 512);
+
+    data_idx = 0;
+
+    /* split incoming decoded nibble data into parts for encoding into the
+       final encoded buffer
+
+       shamelessly translated from Ciderpress Nibble35.cpp as the encoding
+       scheme is quite involved - you stand on the shoulders of giants.
+    */
+    chksum[0] = chksum[1] = chksum[2] = 0;
+    while (data_idx < 524) {
+        chksum[0] = (chksum[0] & 0xff) << 1;
+        if (chksum[0] & 0x100) {
+            ++chksum[0];
+        }
+        v = data[data_idx++];
+        chksum[2] += v;
+        if (chksum[0] > 0xff) {
+            ++chksum[2];
+            chksum[0] &= 0xff;
+        }
+        scratch0[scratch_idx] = (v ^ chksum[0]) & 0xff;
+        v = data[data_idx++];
+        chksum[1] += v;
+        if (chksum[2] > 0xff) {
+            ++chksum[1];
+            chksum[2] &= 0xff;
+        }
+        scratch1[scratch_idx] = (v ^ chksum[2]) & 0xff;
+
+        if (data_idx < 524) {
+            v = data[data_idx++];
+            chksum[0] += v;
+            if (chksum[1] > 0xff) {
+                ++chksum[0];
+                chksum[1] &= 0xff;
+            }
+            scratch2[scratch_idx] = (v ^ chksum[1]) & 0xff;
+            ++scratch_idx;
+        }
+    }
+    scratch2[scratch_idx++] = 0;
+
+    for (data_idx = 0; data_idx < scratch_idx; ++data_idx) {
+        v = (scratch0[data_idx] & 0xc0) >> 2;
+        v |= (scratch1[data_idx] & 0xc0) >> 4;
+        v |= (scratch2[data_idx] & 0xc0) >> 6;
+        _clem_nib_encode_one_6_2(encoder, v);
+        _clem_nib_encode_one_6_2(encoder, scratch0[data_idx]);
+        _clem_nib_encode_one_6_2(encoder, scratch1[data_idx]);
+        if (data_idx < scratch_idx - 1) {
+            _clem_nib_encode_one_6_2(encoder, scratch2[data_idx]);
+        }
+    }
+
+    /* checksum */
+    v = (chksum[0] & 0xc0) >> 6;
+    v |= (chksum[1] & 0xc0) >> 4;
+    v |= (chksum[2] & 0xc0) >> 2;
     _clem_nib_encode_one_6_2(encoder, v);
-    _clem_nib_encode_one_6_2(encoder, scratch0[data_idx]);
-    _clem_nib_encode_one_6_2(encoder, scratch1[data_idx]);
-    if (data_idx < scratch_idx - 1) {
-      _clem_nib_encode_one_6_2(encoder, scratch2[data_idx]);
-    }
-  }
-
-  /* checksum */
-  v = (chksum[0] & 0xc0) >> 6;
-  v |= (chksum[1] & 0xc0) >> 4;
-  v |= (chksum[2] & 0xc0) >> 2;
-  _clem_nib_encode_one_6_2(encoder, v);
-  _clem_nib_encode_one_6_2(encoder, chksum[2]);
-  _clem_nib_encode_one_6_2(encoder, chksum[1]);
-  _clem_nib_encode_one_6_2(encoder, chksum[0]);
+    _clem_nib_encode_one_6_2(encoder, chksum[2]);
+    _clem_nib_encode_one_6_2(encoder, chksum[1]);
+    _clem_nib_encode_one_6_2(encoder, chksum[0]);
 }
 
 #define CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE 86
 
-static void _clem_nib_encode_data_525(struct ClemensNibEncoder *encoder,
-                                      const uint8_t *buf, unsigned cnt) {
-  /* cannot support anything by cnt = 256 bytes,  with 86 bytes to
-     contain the 2 bits nibble = 324 bytes, which is the specified data chunk
-     size of the sector on disk */
-  uint8_t enc6[256];
-  uint8_t enc2[86];
-  uint8_t right;
-  uint8_t chksum = 0;
+static void _clem_nib_encode_data_525(struct ClemensNibEncoder *encoder, const uint8_t *buf,
+                                      unsigned cnt) {
+    /* cannot support anything by cnt = 256 bytes,  with 86 bytes to
+       contain the 2 bits nibble = 324 bytes, which is the specified data chunk
+       size of the sector on disk */
+    uint8_t enc6[256];
+    uint8_t enc2[86];
+    uint8_t right;
+    uint8_t chksum = 0;
 
-  unsigned i6, i2;
-  i6 = 0;
-  for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) { /* 256 */
-    --i2;
-    enc6[i6] = buf[i6] >> 2;    /* 6 bits */
-    right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
-    right |= (buf[i6] & 2) >> 1;
-    enc2[i2] = right;
-    ++i6;
-  }
-  for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) { /* 170 */
-    --i2;
-    enc6[i6] = buf[i6] >> 2;    /* 6 bits */
-    right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
-    right |= (buf[i6] & 2) >> 1;
-    enc2[i2] |= (right << 2);
-    ++i6;
-  }
-  for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 2;) { /* 84 */
-    --i2;
-    enc6[i6] = buf[i6] >> 2;    /* 6 bits */
-    right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
-    right |= (buf[i6] & 2) >> 1;
-    enc2[i2] |= (right << 4);
-    ++i6;
-  }
-  assert(i6 == 256);
+    unsigned i6, i2;
+    i6 = 0;
+    for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) { /* 256 */
+        --i2;
+        enc6[i6] = buf[i6] >> 2;    /* 6 bits */
+        right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
+        right |= (buf[i6] & 2) >> 1;
+        enc2[i2] = right;
+        ++i6;
+    }
+    for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) { /* 170 */
+        --i2;
+        enc6[i6] = buf[i6] >> 2;    /* 6 bits */
+        right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
+        right |= (buf[i6] & 2) >> 1;
+        enc2[i2] |= (right << 2);
+        ++i6;
+    }
+    for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 2;) { /* 84 */
+        --i2;
+        enc6[i6] = buf[i6] >> 2;    /* 6 bits */
+        right = (buf[i6] & 1) << 1; /* lower 2 bits flipped */
+        right |= (buf[i6] & 2) >> 1;
+        enc2[i2] |= (right << 4);
+        ++i6;
+    }
+    assert(i6 == 256);
 
-  for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) {
-    --i2;
-    _clem_nib_encode_one_6_2(encoder, enc2[i2] ^ chksum);
-    chksum = enc2[i2];
-  }
-  for (i6 = 0; i6 < 256; ++i6) {
-    _clem_nib_encode_one_6_2(encoder, enc6[i6] ^ chksum);
-    chksum = enc6[i6];
-  }
+    for (i2 = CLEM_NIB_ENCODE_525_6_2_RIGHT_BUFFER_SIZE; i2 > 0;) {
+        --i2;
+        _clem_nib_encode_one_6_2(encoder, enc2[i2] ^ chksum);
+        chksum = enc2[i2];
+    }
+    for (i6 = 0; i6 < 256; ++i6) {
+        _clem_nib_encode_one_6_2(encoder, enc6[i6] ^ chksum);
+        chksum = enc6[i6];
+    }
 
-  _clem_nib_encode_one_6_2(encoder, chksum);
+    _clem_nib_encode_one_6_2(encoder, chksum);
 }
 
 /* Much of this implementation derives from the formatting section detailed in
@@ -501,258 +592,247 @@ static void _clem_nib_encode_data_525(struct ClemensNibEncoder *encoder,
     - in general DOS and ProDOS formatting is interchangeable at this level
 */
 bool clem_2img_nibblize_data(struct Clemens2IMGDisk *disk) {
-  unsigned clem_max_sectors_per_region[CLEM_DISK_35_NUM_REGIONS];
-  unsigned clem_track_start_per_region[CLEM_DISK_35_NUM_REGIONS + 1];
-  unsigned self_sync_gap_1_cnt = 0;
-  unsigned self_sync_gap_2_cnt = 0;
-  unsigned self_sync_gap_3_cnt = 0;
-  const unsigned(*to_logical_sector_map)[16] = NULL;
-  unsigned num_regions = 0, current_region = 0;
-  unsigned track_increment = 0;
-  unsigned track_byte_offset;
-  unsigned logical_sector_index;
-  unsigned i, qtr_track_index;
-  uint8_t *nib_begin = disk->nib->bits_data;
-  uint8_t *nib_out = nib_begin;
-  unsigned data_in_size = disk->data_end - disk->data;
-  unsigned in_sector_size;
+    unsigned clem_max_sectors_per_region[CLEM_DISK_35_NUM_REGIONS];
+    unsigned clem_track_start_per_region[CLEM_DISK_35_NUM_REGIONS + 1];
+    unsigned self_sync_gap_1_cnt = 0;
+    unsigned self_sync_gap_2_cnt = 0;
+    unsigned self_sync_gap_3_cnt = 0;
+    const unsigned(*to_logical_sector_map)[16] = NULL;
+    unsigned num_regions = 0, current_region = 0;
+    unsigned track_increment = 0;
+    unsigned track_byte_offset;
+    unsigned logical_sector_index;
+    unsigned i, qtr_track_index;
+    uint8_t *nib_begin = disk->nib->bits_data;
+    uint8_t *nib_out = nib_begin;
+    unsigned data_in_size = disk->data_end - disk->data;
+    unsigned in_sector_size;
 
-  /* disk->nib->disk_type must be set before this call
-     gap values are derived from a mix of Beneath Apple DOS and ProDOS
-          sources and Ciderpress mentions (the 3.5" equivalents, which are
-          *very* hard to derive from existing documentation) */
-  switch (disk->nib->disk_type) {
-  case CLEM_DISK_TYPE_3_5:
-    if (disk->block_count > 0) {
-      if (disk->block_count == 280) {
-        return false;
-      } else if (disk->block_count == 800) {
-        disk->nib->is_double_sided = false;
-      } else if (disk->block_count == 1600) {
-        disk->nib->is_double_sided = true;
-      } else {
-        return false;
-      }
-    } else if (data_in_size == 800 * 1024) {
-      disk->nib->is_double_sided = true;
-    } else {
-      return false;
-    }
-    /* guesswork based on gap 3 size of 36 10-bit bytes and the  */
-    self_sync_gap_1_cnt = (CLEM_DISK_35_BYTES_TRACK_GAP_1 * 8) / 10;
-    self_sync_gap_2_cnt = 4;
-    self_sync_gap_3_cnt = (CLEM_DISK_35_BYTES_TRACK_GAP_3 * 8) / 10;
-    num_regions = CLEM_DISK_35_NUM_REGIONS;
-    for (i = 0; i < num_regions; ++i) {
-      clem_max_sectors_per_region[i] = g_clem_max_sectors_per_region_35[i];
-      clem_track_start_per_region[i] = g_clem_track_start_per_region_35[i];
-    }
-    clem_track_start_per_region[num_regions] =
-        (g_clem_track_start_per_region_35[num_regions]);
-    /* 80 tracks for single sided - is this ever true?, otherwise the
-       full track listing for double sided 3.5" disks */
-    disk->nib->bit_timing_ns = 2000;
-    disk->nib->track_count = disk->nib->is_double_sided ? 160 : 80;
-    track_increment = disk->nib->is_double_sided ? 1 : 2;
-    in_sector_size = 512;
-    break;
-  case CLEM_DISK_TYPE_5_25:
-    num_regions = 1;
-    clem_max_sectors_per_region[0] = CLEM_DISK_525_NUM_SECTORS_PER_TRACK;
-    clem_track_start_per_region[0] = 0;
-    clem_track_start_per_region[1] = CLEM_DISK_LIMIT_QTR_TRACKS;
-    /* From Beneath Apple DOS/ProDOS - evaluate if DOS values should
-       reflect those from Beneath Apple DOS. - anyway these are taken
-       from Ciderpress and ROM 03 ProDOS block formatting disassembly */
-    self_sync_gap_1_cnt = 64; /* somewhere between 12-85 */
-    self_sync_gap_2_cnt = 6;  /* somewhere between 5- 10 */
-    self_sync_gap_3_cnt = 24; /* somewhere between 16-28 */
-    /* 40 tracks total - always 35 for DOS/ProDOS disks */
-    disk->nib->bit_timing_ns = 4000;
-    disk->nib->track_count = 35;
-    track_increment = 4;
-    in_sector_size = 256;
-    break;
-
-  default:
-    return false;
-  }
-
-  switch (disk->format) {
-  case CLEM_2IMG_FORMAT_PRODOS:
-    if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-      to_logical_sector_map = prodos_to_logical_sector_map_35;
-    } else {
-      to_logical_sector_map = prodos_to_logical_sector_map_525;
-    }
-    break;
-  case CLEM_2IMG_FORMAT_DOS:
-    assert(disk->nib->disk_type == CLEM_DISK_TYPE_5_25);
-    to_logical_sector_map = dos_to_logical_sector_map_525;
-    break;
-  case CLEM_2IMG_FORMAT_RAW:
-    assert(false);
-  default:
-    return false;
-  }
-
-  /* encode nibbles using the specified image format layout */
-  track_byte_offset = 0;
-  logical_sector_index = 0;
-  /* clear out meta track map to its defaults, so that we can simply assign
-     track_indices to the meta track map for 3.5 and 5.25 disks versus
-     adding extra conditionals in the below loop
-  */
-  memset(disk->nib->meta_track_map, 0xff, sizeof(disk->nib->meta_track_map));
-  memset(disk->nib->track_bits_count, 0x00,
-         sizeof(disk->nib->track_bits_count));
-  memset(disk->nib->track_byte_count, 0x00,
-         sizeof(disk->nib->track_byte_count));
-  memset(disk->nib->track_initialized, 0x00,
-         sizeof(disk->nib->track_initialized));
-  for (qtr_track_index = 0; qtr_track_index < CLEM_DISK_LIMIT_QTR_TRACKS;) {
-    //  isolate into a function for readability
-    unsigned sector_count = clem_max_sectors_per_region[current_region];
-    unsigned track_size;
-    uint8_t *data_in;
-    unsigned sector_index;
-    unsigned in_sector_index;
-    unsigned logical_track_index = qtr_track_index / 2;
-    unsigned side_index = qtr_track_index & 1;
-    unsigned nib_track_index = qtr_track_index / track_increment;
-    unsigned temp, byte_index;
-    struct ClemensNibEncoder nib_encoder;
-
-    if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-      track_size = CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(sector_count);
-    } else {
-      track_size = CLEM_DISK_525_BYTES_PER_TRACK;
-    }
-
-    if (disk->nib->bits_data + track_byte_offset + track_size >
-        disk->nib->bits_data_end) {
-      assert(false);
-      return false;
-    }
-
-    disk->nib->track_byte_offset[nib_track_index] = track_byte_offset;
-    disk->nib->track_byte_count[nib_track_index] = track_size;
-
-    /* see clem_disk.h for documentation on the 3.5" prodos format */
-    _clem_nib_init_encoder(
-        &nib_encoder, disk->nib->bits_data + track_byte_offset,
-        disk->nib->bits_data + track_byte_offset + track_size);
-
-    /* pad */
-    if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-      _clem_nib_write_one(&nib_encoder, 0xff);
-    } else {
-      logical_track_index /= 2; // tracks 0 - 39
-    }
-
-    _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_1_cnt);
-
-    for (sector_index = 0; sector_index < sector_count; ++sector_index) {
-      in_sector_index = to_logical_sector_map[current_region][sector_index];
-      data_in = disk->data +
-                (logical_sector_index + in_sector_index) * in_sector_size;
-
-      if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-        _clem_nib_write_one(&nib_encoder, 0xff);
-      }
-      /* Address */
-      _clem_nib_write_one(&nib_encoder, 0xd5);
-      _clem_nib_write_one(&nib_encoder, 0xaa);
-      _clem_nib_write_one(&nib_encoder, 0x96);
-      if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-        /* track, sector, side, format (0x22 or 0x24 - assume 0x24?) */
-        /* I THINK 0x22 = 512 byte sectors */
-        /*       - 0x24 is 524 byte sectors to allow for the 12 byte
-                        empty tag
-        */
-        unsigned side_index_35 = (side_index << 5) | (logical_track_index >> 6);
-
-        _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(logical_track_index));
-        _clem_nib_encode_one_6_2(&nib_encoder,
-                                 (uint8_t)(in_sector_index & 0xff));
-        _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(side_index_35));
-        _clem_nib_encode_one_6_2(&nib_encoder, 0x24);
-        temp = (logical_track_index ^ in_sector_index ^ side_index_35 ^ 0x24);
-        _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(temp));
-        _clem_nib_write_one(&nib_encoder, 0xde);
-        _clem_nib_write_one(&nib_encoder, 0xaa);
-        _clem_nib_write_one(&nib_encoder, 0xff);
-      } else {
-        _clem_nib_encode_one_4_4(&nib_encoder,
-                                 (uint8_t)(disk->dos_volume & 0xff));
-        _clem_nib_encode_one_4_4(&nib_encoder, logical_track_index);
-        _clem_nib_encode_one_4_4(&nib_encoder, sector_index);
-        _clem_nib_encode_one_4_4(
-            &nib_encoder,
-            (uint8_t)(disk->dos_volume ^ logical_track_index ^ sector_index));
-        _clem_nib_write_one(&nib_encoder, 0xde);
-        _clem_nib_write_one(&nib_encoder, 0xaa);
-        _clem_nib_write_one(&nib_encoder, 0xeb);
-      }
-
-      _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_2_cnt);
-
-      /* Data */
-      if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-        _clem_nib_write_one(&nib_encoder, 0xff);
-      }
-      _clem_nib_write_one(&nib_encoder, 0xd5);
-      _clem_nib_write_one(&nib_encoder, 0xaa);
-      _clem_nib_write_one(&nib_encoder, 0xad);
-      if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-        _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)in_sector_index);
-        /* TODO: handle cases where input sector data is 524 vs 512 */
-        _clem_nib_encode_data_35(&nib_encoder, data_in, 512);
-        _clem_nib_write_one(&nib_encoder, 0xde);
-        _clem_nib_write_one(&nib_encoder, 0xaa);
-        if (sector_index < sector_count - 1) {
-          _clem_nib_write_one(&nib_encoder, 0xff);
-          _clem_nib_write_one(&nib_encoder, 0xff);
-          _clem_nib_write_one(&nib_encoder, 0xff);
+    /* disk->nib->disk_type must be set before this call
+       gap values are derived from a mix of Beneath Apple DOS and ProDOS
+            sources and Ciderpress mentions (the 3.5" equivalents, which are
+            *very* hard to derive from existing documentation) */
+    switch (disk->nib->disk_type) {
+    case CLEM_DISK_TYPE_3_5:
+        if (disk->block_count > 0) {
+            if (disk->block_count == 280) {
+                return false;
+            } else if (disk->block_count == 800) {
+                disk->nib->is_double_sided = false;
+            } else if (disk->block_count == 1600) {
+                disk->nib->is_double_sided = true;
+            } else {
+                return false;
+            }
+        } else if (data_in_size == 800 * 1024) {
+            disk->nib->is_double_sided = true;
+        } else {
+            return false;
         }
-      } else {
-        _clem_nib_encode_data_525(&nib_encoder, data_in, 256);
-        _clem_nib_write_one(&nib_encoder, 0xde);
-        _clem_nib_write_one(&nib_encoder, 0xaa);
-        _clem_nib_write_one(&nib_encoder, 0xeb);
-      }
-      if (sector_index + 1 < sector_count) {
-        _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_3_cnt);
-      }
-    }
-    logical_sector_index += sector_count;
+        /* guesswork based on gap 3 size of 36 10-bit bytes and the  */
+        self_sync_gap_1_cnt = (CLEM_DISK_35_BYTES_TRACK_GAP_1 * 8) / 10;
+        self_sync_gap_2_cnt = 4;
+        self_sync_gap_3_cnt = (CLEM_DISK_35_BYTES_TRACK_GAP_3 * 8) / 10;
+        num_regions = CLEM_DISK_35_NUM_REGIONS;
+        for (i = 0; i < num_regions; ++i) {
+            clem_max_sectors_per_region[i] = g_clem_max_sectors_per_region_35[i];
+            clem_track_start_per_region[i] = g_clem_track_start_per_region_35[i];
+        }
+        clem_track_start_per_region[num_regions] = (g_clem_track_start_per_region_35[num_regions]);
+        /* 80 tracks for single sided - is this ever true?, otherwise the
+           full track listing for double sided 3.5" disks */
+        disk->nib->bit_timing_ns = 2000;
+        disk->nib->track_count = disk->nib->is_double_sided ? 160 : 80;
+        track_increment = disk->nib->is_double_sided ? 1 : 2;
+        in_sector_size = 512;
+        break;
+    case CLEM_DISK_TYPE_5_25:
+        num_regions = 1;
+        clem_max_sectors_per_region[0] = CLEM_DISK_525_NUM_SECTORS_PER_TRACK;
+        clem_track_start_per_region[0] = 0;
+        clem_track_start_per_region[1] = CLEM_DISK_LIMIT_QTR_TRACKS;
+        /* From Beneath Apple DOS/ProDOS - evaluate if DOS values should
+           reflect those from Beneath Apple DOS. - anyway these are taken
+           from Ciderpress and ROM 03 ProDOS block formatting disassembly */
+        self_sync_gap_1_cnt = 64; /* somewhere between 12-85 */
+        self_sync_gap_2_cnt = 6;  /* somewhere between 5- 10 */
+        self_sync_gap_3_cnt = 24; /* somewhere between 16-28 */
+        /* 40 tracks total - always 35 for DOS/ProDOS disks */
+        disk->nib->bit_timing_ns = 4000;
+        disk->nib->track_count = 35;
+        track_increment = 4;
+        in_sector_size = 256;
+        break;
 
-    disk->nib->track_bits_count[nib_track_index] = nib_encoder.bit_index_end;
-    disk->nib->track_initialized[nib_track_index] = 1;
-    if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
-      disk->nib->meta_track_map[qtr_track_index] = nib_track_index;
-    } else {
-      disk->nib->meta_track_map[qtr_track_index] = nib_track_index;
-      if (qtr_track_index > 0) {
-        /* track is copied onto the one quarter track before and after
-           this qtr track */
-        disk->nib->meta_track_map[qtr_track_index - 1] = nib_track_index;
-      }
-      disk->nib
-          ->meta_track_map[(qtr_track_index + 1) % CLEM_DISK_LIMIT_QTR_TRACKS] =
-          nib_track_index;
+    default:
+        return false;
     }
 
-    if (nib_track_index + 1 >= disk->nib->track_count) {
-      track_increment = CLEM_DISK_LIMIT_QTR_TRACKS - nib_track_index;
+    switch (disk->format) {
+    case CLEM_2IMG_FORMAT_PRODOS:
+        if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+            to_logical_sector_map = prodos_to_logical_sector_map_35;
+        } else {
+            to_logical_sector_map = prodos_to_logical_sector_map_525;
+        }
+        break;
+    case CLEM_2IMG_FORMAT_DOS:
+        assert(disk->nib->disk_type == CLEM_DISK_TYPE_5_25);
+        to_logical_sector_map = dos_to_logical_sector_map_525;
+        break;
+    case CLEM_2IMG_FORMAT_RAW:
+        assert(false);
+    default:
+        return false;
     }
 
-    qtr_track_index += track_increment;
-    if (qtr_track_index >= clem_track_start_per_region[current_region + 1]) {
-      ++current_region;
-    }
-    track_byte_offset += track_size;
-  }
+    /* encode nibbles using the specified image format layout */
+    track_byte_offset = 0;
+    logical_sector_index = 0;
+    /* clear out meta track map to its defaults, so that we can simply assign
+       track_indices to the meta track map for 3.5 and 5.25 disks versus
+       adding extra conditionals in the below loop
+    */
+    memset(disk->nib->meta_track_map, 0xff, sizeof(disk->nib->meta_track_map));
+    memset(disk->nib->track_bits_count, 0x00, sizeof(disk->nib->track_bits_count));
+    memset(disk->nib->track_byte_count, 0x00, sizeof(disk->nib->track_byte_count));
+    memset(disk->nib->track_initialized, 0x00, sizeof(disk->nib->track_initialized));
+    for (qtr_track_index = 0; qtr_track_index < CLEM_DISK_LIMIT_QTR_TRACKS;) {
+        //  isolate into a function for readability
+        unsigned sector_count = clem_max_sectors_per_region[current_region];
+        unsigned track_size;
+        uint8_t *data_in;
+        unsigned sector_index;
+        unsigned in_sector_index;
+        unsigned logical_track_index = qtr_track_index / 2;
+        unsigned side_index = qtr_track_index & 1;
+        unsigned nib_track_index = qtr_track_index / track_increment;
+        unsigned temp, byte_index;
+        struct ClemensNibEncoder nib_encoder;
 
-  return true;
+        if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+            track_size = CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(sector_count);
+        } else {
+            track_size = CLEM_DISK_525_BYTES_PER_TRACK;
+        }
+
+        if (disk->nib->bits_data + track_byte_offset + track_size > disk->nib->bits_data_end) {
+            assert(false);
+            return false;
+        }
+
+        disk->nib->track_byte_offset[nib_track_index] = track_byte_offset;
+        disk->nib->track_byte_count[nib_track_index] = track_size;
+
+        /* see clem_disk.h for documentation on the 3.5" prodos format */
+        _clem_nib_init_encoder(&nib_encoder, disk->nib->bits_data + track_byte_offset,
+                               disk->nib->bits_data + track_byte_offset + track_size);
+
+        /* pad */
+        if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+            _clem_nib_write_one(&nib_encoder, 0xff);
+        } else {
+            logical_track_index /= 2; // tracks 0 - 39
+        }
+
+        _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_1_cnt);
+
+        for (sector_index = 0; sector_index < sector_count; ++sector_index) {
+            in_sector_index = to_logical_sector_map[current_region][sector_index];
+            data_in = disk->data + (logical_sector_index + in_sector_index) * in_sector_size;
+
+            if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+                _clem_nib_write_one(&nib_encoder, 0xff);
+            }
+            /* Address */
+            _clem_nib_write_one(&nib_encoder, 0xd5);
+            _clem_nib_write_one(&nib_encoder, 0xaa);
+            _clem_nib_write_one(&nib_encoder, 0x96);
+            if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+                /* track, sector, side, format (0x22 or 0x24 - assume 0x24?) */
+                /* I THINK 0x22 = 512 byte sectors */
+                /*       - 0x24 is 524 byte sectors to allow for the 12 byte
+                                empty tag
+                */
+                unsigned side_index_35 = (side_index << 5) | (logical_track_index >> 6);
+
+                _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(logical_track_index));
+                _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(in_sector_index & 0xff));
+                _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(side_index_35));
+                _clem_nib_encode_one_6_2(&nib_encoder, 0x24);
+                temp = (logical_track_index ^ in_sector_index ^ side_index_35 ^ 0x24);
+                _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)(temp));
+                _clem_nib_write_one(&nib_encoder, 0xde);
+                _clem_nib_write_one(&nib_encoder, 0xaa);
+                _clem_nib_write_one(&nib_encoder, 0xff);
+            } else {
+                _clem_nib_encode_one_4_4(&nib_encoder, (uint8_t)(disk->dos_volume & 0xff));
+                _clem_nib_encode_one_4_4(&nib_encoder, logical_track_index);
+                _clem_nib_encode_one_4_4(&nib_encoder, sector_index);
+                _clem_nib_encode_one_4_4(
+                    &nib_encoder, (uint8_t)(disk->dos_volume ^ logical_track_index ^ sector_index));
+                _clem_nib_write_one(&nib_encoder, 0xde);
+                _clem_nib_write_one(&nib_encoder, 0xaa);
+                _clem_nib_write_one(&nib_encoder, 0xeb);
+            }
+
+            _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_2_cnt);
+
+            /* Data */
+            if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+                _clem_nib_write_one(&nib_encoder, 0xff);
+            }
+            _clem_nib_write_one(&nib_encoder, 0xd5);
+            _clem_nib_write_one(&nib_encoder, 0xaa);
+            _clem_nib_write_one(&nib_encoder, 0xad);
+            if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+                _clem_nib_encode_one_6_2(&nib_encoder, (uint8_t)in_sector_index);
+                /* TODO: handle cases where input sector data is 524 vs 512 */
+                _clem_nib_encode_data_35(&nib_encoder, data_in, 512);
+                _clem_nib_write_one(&nib_encoder, 0xde);
+                _clem_nib_write_one(&nib_encoder, 0xaa);
+                if (sector_index < sector_count - 1) {
+                    _clem_nib_write_one(&nib_encoder, 0xff);
+                    _clem_nib_write_one(&nib_encoder, 0xff);
+                    _clem_nib_write_one(&nib_encoder, 0xff);
+                }
+            } else {
+                _clem_nib_encode_data_525(&nib_encoder, data_in, 256);
+                _clem_nib_write_one(&nib_encoder, 0xde);
+                _clem_nib_write_one(&nib_encoder, 0xaa);
+                _clem_nib_write_one(&nib_encoder, 0xeb);
+            }
+            if (sector_index + 1 < sector_count) {
+                _clem_nib_encode_self_sync_ff(&nib_encoder, self_sync_gap_3_cnt);
+            }
+        }
+        logical_sector_index += sector_count;
+
+        disk->nib->track_bits_count[nib_track_index] = nib_encoder.bit_index_end;
+        disk->nib->track_initialized[nib_track_index] = 1;
+        if (disk->nib->disk_type == CLEM_DISK_TYPE_3_5) {
+            disk->nib->meta_track_map[qtr_track_index] = nib_track_index;
+        } else {
+            disk->nib->meta_track_map[qtr_track_index] = nib_track_index;
+            if (qtr_track_index > 0) {
+                /* track is copied onto the one quarter track before and after
+                   this qtr track */
+                disk->nib->meta_track_map[qtr_track_index - 1] = nib_track_index;
+            }
+            disk->nib->meta_track_map[(qtr_track_index + 1) % CLEM_DISK_LIMIT_QTR_TRACKS] =
+                nib_track_index;
+        }
+
+        if (nib_track_index + 1 >= disk->nib->track_count) {
+            track_increment = CLEM_DISK_LIMIT_QTR_TRACKS - nib_track_index;
+        }
+
+        qtr_track_index += track_increment;
+        if (qtr_track_index >= clem_track_start_per_region[current_region + 1]) {
+            ++current_region;
+        }
+        track_byte_offset += track_size;
+    }
+
+    return true;
 }

--- a/clem_2img.c
+++ b/clem_2img.c
@@ -319,7 +319,7 @@ bool clem_2img_build_image(struct Clemens2IMGDisk *disk, uint8_t *image, uint8_t
         _encode_u32(&image_cur, 0);
     }
     _encode_u32(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE);
-    _encode_mem(&image_cur, disk->data, source_size, overlapped);
+    _encode_u32(&image_cur, source_size);
     if (creator_size > 0) {
         _encode_u32(&image_cur, CLEM_2IMG_HEADER_BYTE_SIZE + source_size);
         _encode_u32(&image_cur, (uint32_t)(creator_size));
@@ -351,7 +351,7 @@ bool clem_2img_build_image(struct Clemens2IMGDisk *disk, uint8_t *image, uint8_t
 
 bool clem_2img_generate_header(struct Clemens2IMGDisk *disk, uint32_t format, uint8_t *image,
                                uint8_t *image_end, uint32_t image_data_offset) {
-    uint32_t disk_size = (uint32_t)(image_end - image);
+    uint32_t disk_size = (uint32_t)(image_end - image) - image_data_offset;
 
     strncpy(disk->creator, "CLEM", sizeof(disk->creator));
 
@@ -370,15 +370,15 @@ bool clem_2img_generate_header(struct Clemens2IMGDisk *disk, uint32_t format, ui
 
     /* TODO: support creator data and comments */
     disk->image_buffer = image;
-    disk->image_buffer_length = disk_size;
+    disk->image_buffer_length = (uint32_t)(image_end - image);
     disk->image_data_offset = image_data_offset;
 
     disk->data = disk->image_buffer + disk->image_data_offset;
     disk->data_end = disk->data + disk_size;
 
-    disk->creator_data = (char *)image + disk_size;
+    disk->creator_data = (char *)disk->data_end;
     disk->creator_data_end = disk->creator_data;
-    disk->comment = (char *)image + disk_size;
+    disk->comment = disk->creator_data_end;
     disk->comment_end = disk->comment;
 
     disk->version = 0x0001;

--- a/clem_2img.h
+++ b/clem_2img.h
@@ -14,9 +14,13 @@
 
 #include "clem_disk.h"
 
-#define CLEM_2IMG_FORMAT_DOS            0U
-#define CLEM_2IMG_FORMAT_PRODOS         1U
-#define CLEM_2IMG_FORMAT_RAW            2U
+#define CLEM_2IMG_FORMAT_DOS    0U
+#define CLEM_2IMG_FORMAT_PRODOS 1U
+#define CLEM_2IMG_FORMAT_RAW    2U
+
+/** Per spec, the header size preceding the disk data must be this length.  This value can be used
+ * to allocate a backing buffer for a custom 2img file. */
+#define CLEM_2IMG_HEADER_BYTE_SIZE 64
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,32 +36,32 @@ extern "C" {
 struct Clemens2IMGDisk {
     char creator[4];
     uint16_t version;
-    uint32_t format;            /**< See CLEM_2IMG_FORMAT_XXX */
-    uint32_t dos_volume;        /**< DOS Volume */
-    uint32_t block_count;       /**< Block count (ProDOS only) */
-    char* creator_data;
-    char* creator_data_end;
-    char* comment;
-    char* comment_end;
-    uint8_t* data;
-    uint8_t* data_end;
-    uint8_t* image_buffer;      /**< Backing memory buffer owned by caller */
+    uint32_t format;      /**< See CLEM_2IMG_FORMAT_XXX */
+    uint32_t dos_volume;  /**< DOS Volume */
+    uint32_t block_count; /**< Block count (ProDOS only) */
+    char *creator_data;
+    char *creator_data_end;
+    char *comment;
+    char *comment_end;
+    uint8_t *data;
+    uint8_t *data_end;
+    uint8_t *image_buffer;        /**< Backing memory buffer owned by caller */
     uint32_t image_buffer_length; /**< Length of the original memory buffer */
-    uint32_t image_data_offset; /**< Offset to original track data */
-    bool is_write_protected;    /**< Write protected image */
-    bool is_nibblized;          /**< See the clem_2img_nibblize_data call */
+    uint32_t image_data_offset;   /**< Offset to original track data */
+    bool is_write_protected;      /**< Write protected image */
+    bool is_nibblized;            /**< See the clem_2img_nibblize_data call */
 
     /* This is provided by the caller.  At the very least the nib->bits_data and
        nib->bits_data_end byte vector must be defined before calling
        clem_2img_nibblize_data.  The byte vector and metadata will be populated
        by said call.
     */
-    struct ClemensNibbleDisk* nib;
+    struct ClemensNibbleDisk *nib;
 };
 
 struct ClemensNibEncoder {
-    uint8_t* begin;
-    uint8_t* end;
+    uint8_t *begin;
+    uint8_t *end;
     unsigned bit_index;
     unsigned bit_index_end;
 };
@@ -76,9 +80,7 @@ struct ClemensNibEncoder {
  * @return true
  * @return false
  */
-bool clem_2img_parse_header(struct Clemens2IMGDisk* disk,
-                            uint8_t* image,
-                            uint8_t* image_end);
+bool clem_2img_parse_header(struct Clemens2IMGDisk *disk, uint8_t *image, uint8_t *image_end);
 
 /**
  * @brief Generates a 2IMG disk container from either ProDOS or DOS images.
@@ -92,13 +94,23 @@ bool clem_2img_parse_header(struct Clemens2IMGDisk* disk,
  * @param format See CLEM_2IMG_FORMAT_XXX
  * @param image Logical sectors based on the sector format
  * @param image_end End of the raw post-nibblized logical sector input buffer
+ * @param image_data_offset Indicates where in the input image the disk data resides
  * @return true
  * @return false
  */
-bool clem_2img_generate_header(struct Clemens2IMGDisk* disk,
-                               uint32_t format,
-                               uint8_t* image,
-                               uint8_t* image_end);
+bool clem_2img_generate_header(struct Clemens2IMGDisk *disk, uint32_t format, uint8_t *image,
+                               uint8_t *image_end, uint32_t image_data_offset);
+
+/**
+ * @brief Create a 2IMG disk buffer to serialize into a 2img file.
+ *
+ * @param disk The populated Clemens2IMGDisk struct
+ * @param image The backing buffer
+ * @param image_end
+ * @return true
+ * @return false
+ */
+bool clem_2img_build_image(struct Clemens2IMGDisk *disk, uint8_t *image, uint8_t *image_end);
 
 /**
  * @brief Runs the nibbilization pass on the disk image.
@@ -112,8 +124,7 @@ bool clem_2img_generate_header(struct Clemens2IMGDisk* disk,
  * @return false Nibbilization failed due to lack of space or invalid data from
  *      the source 2IMG (DSK, PO) data.
  */
-bool clem_2img_nibblize_data(struct Clemens2IMGDisk* disk);
-
+bool clem_2img_nibblize_data(struct Clemens2IMGDisk *disk);
 
 #ifdef __cplusplus
 }

--- a/clem_defs.h
+++ b/clem_defs.h
@@ -107,7 +107,7 @@
 #define CLEM_IIGS_BANK_SIZE               (64 * 1024)
 #define CLEM_IIGS_ROM3_SIZE               (CLEM_IIGS_BANK_SIZE * 4)
 #define CLEM_IIGS_EXPANSION_ROM_SIZE      2048
-#define CLEM_IIGS_FPI_MAIN_RAM_BANK_COUNT 16
+#define CLEM_IIGS_FPI_MAIN_RAM_BANK_LIMIT 64
 #define CLEM_IIGS_EMPTY_RAM_BANK          0x81
 
 /** Vector addresses */
@@ -149,8 +149,8 @@
 #define CLEM_IRQ_SLOT_5         (0x01000000)
 #define CLEM_IRQ_SLOT_6         (0x02000000)
 #define CLEM_IRQ_SLOT_7         (0x04000000)
-//#define CLEM_CARD_NMI (0x40000000)
-//#define CLEM_CARD_IRQ (0x80000000)
+// #define CLEM_CARD_NMI (0x40000000)
+// #define CLEM_CARD_IRQ (0x80000000)
 
 /** NMI line masks for card slot triggers */
 #define CLEM_NMI_CARD_MASK (0x000000ff)

--- a/clem_device.h
+++ b/clem_device.h
@@ -267,6 +267,20 @@ void clem_iwm_debug_stop(struct ClemensDeviceIWM *iwm);
 /**
  * @brief
  *
+ * @param unit
+ * @param unit_count
+ * @param io_flags
+ * @param out_phase
+ * @param delta_ns
+ * @return true
+ * @return false
+ */
+bool clem_smartport_bus(struct ClemensSmartPortUnit *unit, unsigned unit_count, unsigned *io_flags,
+                        unsigned *out_phase, unsigned delta_ns);
+
+/**
+ * @brief
+ *
  * @param scc
  */
 void clem_scc_reset(struct ClemensDeviceSCC *scc);

--- a/clem_disk.h
+++ b/clem_disk.h
@@ -4,25 +4,25 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define CLEM_DISK_TYPE_NONE                 0
-#define CLEM_DISK_TYPE_5_25                 1
-#define CLEM_DISK_TYPE_3_5                  2
+#define CLEM_DISK_TYPE_NONE 0
+#define CLEM_DISK_TYPE_5_25 1
+#define CLEM_DISK_TYPE_3_5  2
 
 /* value from woz spec - evaluate if this can be used for blank disks */
-#define CLEM_DISK_DEFAULT_TRACK_BIT_LENGTH_525  51200
+#define CLEM_DISK_DEFAULT_TRACK_BIT_LENGTH_525 51200
 /* value from dsk2woz2 */
-#define CLEM_DISK_BLANK_TRACK_BIT_LENGTH_525    50624
+#define CLEM_DISK_BLANK_TRACK_BIT_LENGTH_525 50624
 
 /*  Track Limit for 'nibble-like' disks (i.e. not Smartport drives) */
-#define CLEM_DISK_LIMIT_QTR_TRACKS              160
+#define CLEM_DISK_LIMIT_QTR_TRACKS 160
 /*  Always 16 sectors per track on DOS/ProDOS 5.25" disks */
-#define CLEM_DISK_525_NUM_SECTORS_PER_TRACK     16
+#define CLEM_DISK_525_NUM_SECTORS_PER_TRACK 16
 
 /*  3.5" drives have variable spin speed to maximize space - and these speeds
     are divided into regions, where outer regions have more sectors vs inner
     regions.  See the declared globals below
 */
-#define CLEM_DISK_35_NUM_REGIONS                5
+#define CLEM_DISK_35_NUM_REGIONS 5
 
 /* From ProDOS firmware for 3.5" Apple Disk Drive Format
    Routine from ROM 03 - ff/4197 - ff/428d
@@ -82,20 +82,18 @@ extern unsigned g_clem_track_start_per_region_35[CLEM_DISK_35_NUM_REGIONS + 1];
 }
 #endif
 
-#define CLEM_DISK_525_BYTES_PER_TRACK        (13 * 512)
-
-#define CLEM_DISK_35_BYTES_TRACK_GAP_1       500
-#define CLEM_DISK_35_BYTES_TRACK_GAP_3       53
-#define CLEM_DISK_35_BYTES_PER_SECTOR_BASE   728
-#define CLEM_DISK_35_BYTES_PER_SECTOR       \
+/** Note, these values are for nibbilized data that are most useful for WOZ images. */
+#define CLEM_DISK_525_BYTES_PER_TRACK      (13 * 512)
+#define CLEM_DISK_35_BYTES_TRACK_GAP_1     500
+#define CLEM_DISK_35_BYTES_TRACK_GAP_3     53
+#define CLEM_DISK_35_BYTES_PER_SECTOR_BASE 728
+#define CLEM_DISK_35_BYTES_PER_SECTOR                                                              \
     (CLEM_DISK_35_BYTES_PER_SECTOR_BASE + CLEM_DISK_35_BYTES_TRACK_GAP_3)
-#define CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(_sectors_) ( \
-    1 + (CLEM_DISK_35_BYTES_TRACK_GAP_1 - CLEM_DISK_35_BYTES_TRACK_GAP_3) + \
-    ((_sectors_) * CLEM_DISK_35_BYTES_PER_SECTOR))
-
+#define CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(_sectors_)                                            \
+    (1 + (CLEM_DISK_35_BYTES_TRACK_GAP_1 - CLEM_DISK_35_BYTES_TRACK_GAP_3) +                       \
+     ((_sectors_)*CLEM_DISK_35_BYTES_PER_SECTOR))
 #define CLEM_DISK_525_MAX_DATA_SIZE (50 * CLEM_DISK_525_BYTES_PER_TRACK)
-#define CLEM_DISK_35_MAX_DATA_SIZE (160 * CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(12))
-
+#define CLEM_DISK_35_MAX_DATA_SIZE  (160 * CLEM_DISK_35_CALC_BYTES_FROM_SECTORS(12))
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,12 +104,12 @@ extern "C" {
  *
  */
 enum ClemensDriveType {
-  kClemensDrive_Invalid = -1,
-  kClemensDrive_3_5_D1 = 0,
-  kClemensDrive_3_5_D2,
-  kClemensDrive_5_25_D1,
-  kClemensDrive_5_25_D2,
-  kClemensDrive_Count
+    kClemensDrive_Invalid = -1,
+    kClemensDrive_3_5_D1 = 0,
+    kClemensDrive_3_5_D2,
+    kClemensDrive_5_25_D1,
+    kClemensDrive_5_25_D2,
+    kClemensDrive_Count
 };
 
 /**
@@ -119,12 +117,12 @@ enum ClemensDriveType {
  *
  */
 struct ClemensNibbleDisk {
-    unsigned disk_type;                 /* see CLEM_DISK_TYPE_XXX defines */
-    unsigned bit_timing_ns;             /* time to read (and write?) */
+    unsigned disk_type;     /* see CLEM_DISK_TYPE_XXX defines */
+    unsigned bit_timing_ns; /* time to read (and write?) */
     unsigned track_count;
 
-    bool is_write_protected;            /**< Write protected data */
-    bool is_double_sided;               /**< track 1, 3, 5 represents side 2 */
+    bool is_write_protected; /**< Write protected data */
+    bool is_double_sided;    /**< track 1, 3, 5 represents side 2 */
 
     /* maps quarter tracks (for 5.25) and 80 tracks per side (for 3.25).  the
        drive head mechanism should track current head position by the meta
@@ -146,8 +144,8 @@ struct ClemensNibbleDisk {
        values within the INFO chunk (written out to max_track_size_bytes), and
        can be released upon eject
     */
-    uint8_t* bits_data;
-    uint8_t* bits_data_end;
+    uint8_t *bits_data;
+    uint8_t *bits_data_end;
 };
 
 #ifdef __cplusplus

--- a/clem_drive.c
+++ b/clem_drive.c
@@ -207,12 +207,6 @@ unsigned clem_drive_step(struct ClemensDrive *drive, unsigned *io_flags, int qtr
                          unsigned track_cur_pos, unsigned dt_ns) {
     bool is_drive_525 = (*io_flags & CLEM_IWM_FLAG_DRIVE_35) ? false : true;
     if (qtr_track_index != drive->qtr_track_index && drive->has_disk) {
-        /*
-        CLEM_LOG("IWM: Disk525[%u]: Motor: %u; Head @ (%d,%d)",
-            (*io_flags & CLEM_IWM_FLAG_DRIVE_2) ? 2 : 1,
-            (*io_flags & CLEM_IWM_FLAG_DRIVE_ON) ? 1 : 0,
-            qtr_track_index / 4, qtr_track_index % 4);
-        */
         if (drive->disk.meta_track_map[drive->qtr_track_index] !=
             drive->disk.meta_track_map[qtr_track_index]) {
             /* force lookup of the real track if the arm has changed */

--- a/clem_drive.c
+++ b/clem_drive.c
@@ -68,7 +68,7 @@
 
 */
 static int s_disk2_phase_states[8][16] = {
-    /*     00  N0  0E  NE  S0  x0  SE  xE  0W  NW  0x  Nx  SW  xW  Sx  xx */
+    /*       00  N0  0E  NE  S0  x0  SE  xE  0W  NW  0x  Nx  SW  xW  Sx  xx */
     /* N  */ {0, 0, 2, 1, 0, 0, 3, 2, -2, -1, 0, 0, -3, -2, 0, 0},
     /* NE */ {0, -1, 1, 0, 3, -1, 2, 1, -3, -2, 1, -1, 0, -3, 3, 0},
     /*  E */ {0, -2, 0, -1, 2, 0, 1, 0, 0, -3, 0, -2, 3, 0, 2, 0},
@@ -94,45 +94,45 @@ static int s_disk2_phase_states[8][16] = {
 */
 
 static void _clem_disk_reset_drive(struct ClemensDrive *drive) {
-  int rand_max = (int)(RAND_MAX * 0.30f);
-  drive->real_track_index = 0xfe;
-  drive->random_bit_index = 0;
-  drive->qtr_track_index = 0;
-  drive->status_mask_35 = 0;
+    int rand_max = (int)(RAND_MAX * 0.30f);
+    drive->real_track_index = 0xfe;
+    drive->random_bit_index = 0;
+    drive->qtr_track_index = 0;
+    drive->status_mask_35 = 0;
 
-  clem_disk_start_drive(drive);
+    clem_disk_start_drive(drive);
 
-  /* not going to change the cog orientation since this could be a soft
-     reset */
-  /* crappy method to randomize 30-ish percent ON bits (30% per WOZ
-     recommendation, subject to experimentation
-  */
-  do {
-    unsigned random_byte_index = (drive->random_bit_index / 8);
-    unsigned random_bit_shift = (drive->random_bit_index % 8);
-    if (rand() < rand_max) {
-      drive->random_bits[random_byte_index] |= (1 << random_bit_shift);
-    } else {
-      drive->random_bits[random_byte_index] &= ~(1 << random_bit_shift);
-    }
-    ++drive->random_bit_index;
-  } while (drive->random_bit_index < CLEM_IWM_DRIVE_MAX_RANDOM_BITS);
-  drive->random_bit_index = 0;
+    /* not going to change the cog orientation since this could be a soft
+       reset */
+    /* crappy method to randomize 30-ish percent ON bits (30% per WOZ
+       recommendation, subject to experimentation
+    */
+    do {
+        unsigned random_byte_index = (drive->random_bit_index / 8);
+        unsigned random_bit_shift = (drive->random_bit_index % 8);
+        if (rand() < rand_max) {
+            drive->random_bits[random_byte_index] |= (1 << random_bit_shift);
+        } else {
+            drive->random_bits[random_byte_index] &= ~(1 << random_bit_shift);
+        }
+        ++drive->random_bit_index;
+    } while (drive->random_bit_index < CLEM_IWM_DRIVE_MAX_RANDOM_BITS);
+    drive->random_bit_index = 0;
 }
 
 void clem_disk_start_drive(struct ClemensDrive *drive) {
-  drive->ctl_switch = 0;
-  drive->track_byte_index = 0;
-  drive->track_bit_shift = 0;
-  drive->pulse_ns = 0;
-  drive->read_buffer = 0;
+    drive->ctl_switch = 0;
+    drive->track_byte_index = 0;
+    drive->track_bit_shift = 0;
+    drive->pulse_ns = 0;
+    drive->read_buffer = 0;
 }
 
 void clem_disk_reset_drives(struct ClemensDriveBay *drives) {
-  _clem_disk_reset_drive(&drives->slot5[0]);
-  _clem_disk_reset_drive(&drives->slot5[1]);
-  _clem_disk_reset_drive(&drives->slot6[0]);
-  _clem_disk_reset_drive(&drives->slot6[1]);
+    _clem_disk_reset_drive(&drives->slot5[0]);
+    _clem_disk_reset_drive(&drives->slot5[1]);
+    _clem_disk_reset_drive(&drives->slot6[0]);
+    _clem_disk_reset_drive(&drives->slot6[1]);
 }
 
 /*  Mechanical Summary: 5.25"
@@ -155,147 +155,139 @@ void clem_disk_reset_drives(struct ClemensDriveBay *drives) {
          "Half-step single-coil mode"
     Mechanical Summary: 3.5"
 */
-static unsigned _clem_disk_get_track_bit_length(struct ClemensDrive *drive,
-                                                int qtr_track_index,
+static unsigned _clem_disk_get_track_bit_length(struct ClemensDrive *drive, int qtr_track_index,
                                                 bool is_drive_525) {
-  if (drive->disk.meta_track_map[qtr_track_index] != 0xff) {
-    return drive->disk
-        .track_bits_count[(drive->disk.meta_track_map[qtr_track_index])];
-  }
-  /* empty track - use a 6400 byte, 51200 bit track size per WOZ2 spec */
-  return 51200;
+    if (drive->disk.meta_track_map[qtr_track_index] != 0xff) {
+        return drive->disk.track_bits_count[(drive->disk.meta_track_map[qtr_track_index])];
+    }
+    /* empty track - use a 6400 byte, 51200 bit track size per WOZ2 spec */
+    return 51200;
 }
 
 static void _clem_disk_write_bit(struct ClemensDrive *drive, bool value) {
-  uint8_t *data = drive->disk.bits_data +
-                  (drive->disk.track_byte_offset[drive->real_track_index]);
-  if (value) {
-    data[drive->track_byte_index] |= (1 << drive->track_bit_shift);
-  } else {
-    data[drive->track_byte_index] &= ~(1 << drive->track_bit_shift);
-  }
+    uint8_t *data =
+        drive->disk.bits_data + (drive->disk.track_byte_offset[drive->real_track_index]);
+    if (value) {
+        data[drive->track_byte_index] |= (1 << drive->track_bit_shift);
+    } else {
+        data[drive->track_byte_index] &= ~(1 << drive->track_bit_shift);
+    }
 }
 
 static inline bool _clem_disk_read_bit(struct ClemensDrive *drive) {
-  uint8_t *data = drive->disk.bits_data +
-                  (drive->disk.track_byte_offset[drive->real_track_index]);
-  uint8_t byte_value = data[drive->track_byte_index];
-  return (byte_value & (1 << drive->track_bit_shift)) != 0;
+    uint8_t *data =
+        drive->disk.bits_data + (drive->disk.track_byte_offset[drive->real_track_index]);
+    uint8_t byte_value = data[drive->track_byte_index];
+    return (byte_value & (1 << drive->track_bit_shift)) != 0;
 }
 
 static inline bool _clem_disk_read_fake_bit_525(struct ClemensDrive *drive) {
-  uint8_t random_byte = (drive->random_bits[drive->random_bit_index / 8]);
-  bool random_bit = (random_byte & (1 << (drive->random_bit_index % 8))) != 0;
-  drive->random_bit_index =
-      (drive->random_bit_index + 1) % CLEM_IWM_DRIVE_MAX_RANDOM_BITS;
-  return random_bit;
+    uint8_t random_byte = (drive->random_bits[drive->random_bit_index / 8]);
+    bool random_bit = (random_byte & (1 << (drive->random_bit_index % 8))) != 0;
+    drive->random_bit_index = (drive->random_bit_index + 1) % CLEM_IWM_DRIVE_MAX_RANDOM_BITS;
+    return random_bit;
 }
 
 unsigned clem_drive_pre_step(struct ClemensDrive *drive, unsigned *io_flags) {
-  unsigned track_cur_pos =
-      (drive->track_byte_index * 8) + (7 - drive->track_bit_shift);
+    unsigned track_cur_pos = (drive->track_byte_index * 8) + (7 - drive->track_bit_shift);
 
-  *io_flags &= ~CLEM_IWM_FLAG_MASK_PRE_STEP_CLEARED;
+    *io_flags &= ~CLEM_IWM_FLAG_MASK_PRE_STEP_CLEARED;
 
-  if (!(*io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
-    drive->read_buffer = 0;
-    drive->is_spindle_on = false;
-    return CLEM_IWM_DRIVE_INVALID_TRACK_POS;
-  } else {
-    drive->is_spindle_on = true;
-  }
-  return track_cur_pos;
+    if (!(*io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
+        drive->read_buffer = 0;
+        drive->is_spindle_on = false;
+        return CLEM_IWM_DRIVE_INVALID_TRACK_POS;
+    } else {
+        drive->is_spindle_on = true;
+    }
+    return track_cur_pos;
 }
 
-unsigned clem_drive_step(struct ClemensDrive *drive, unsigned *io_flags,
-                         int qtr_track_index, unsigned track_cur_pos,
-                         unsigned dt_ns) {
-  bool is_drive_525 = (*io_flags & CLEM_IWM_FLAG_DRIVE_35) ? false : true;
-  if (qtr_track_index != drive->qtr_track_index && drive->has_disk) {
-    /*
-    CLEM_LOG("IWM: Disk525[%u]: Motor: %u; Head @ (%d,%d)",
-        (*io_flags & CLEM_IWM_FLAG_DRIVE_2) ? 2 : 1,
-        (*io_flags & CLEM_IWM_FLAG_DRIVE_ON) ? 1 : 0,
-        qtr_track_index / 4, qtr_track_index % 4);
-    */
-    if (drive->disk.meta_track_map[drive->qtr_track_index] !=
-        drive->disk.meta_track_map[qtr_track_index]) {
-      /* force lookup of the real track if the arm has changed */
-      drive->real_track_index = 0xfe;
-    }
-
-    drive->qtr_track_index = qtr_track_index;
-  }
-  if (drive->has_disk) {
-    if (drive->real_track_index == 0xfe) {
-      unsigned track_prev_len = drive->track_bit_length;
-      drive->real_track_index =
-          drive->disk.meta_track_map[drive->qtr_track_index];
-      if (drive->real_track_index != 0xff) {
-        drive->track_bit_length = _clem_disk_get_track_bit_length(
-            drive, drive->qtr_track_index, is_drive_525);
-      } else if (drive->track_bit_length == 0) {
-        /* just use the prior bit length if there's no track defined */
-        drive->track_bit_length = drive->disk.track_bits_count[0];
-      }
-      if (track_prev_len) {
-        track_cur_pos =
-            track_cur_pos * drive->track_bit_length / track_prev_len;
-      }
-    }
-  } else {
-    /* also we need to fake it being write protected?  check this? */
-    drive->qtr_track_index = qtr_track_index;
-    if (is_drive_525) {
-      *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
-    }
-  }
-  if (track_cur_pos >= drive->track_bit_length) {
-    /* wrap to beginning of track */
-    track_cur_pos -= drive->track_bit_length;
-  }
-  drive->track_byte_index = track_cur_pos / 8;
-  drive->track_bit_shift = 7 - (track_cur_pos % 8);
-  drive->pulse_ns = clem_util_timer_increment(drive->pulse_ns, 1000000, dt_ns);
-  if (!drive->has_disk) {
-    return track_cur_pos;
-  }
-  if (drive->pulse_ns >= drive->disk.bit_timing_ns) {
-    bool valid_disk_data =
-        drive->real_track_index != 0xff &&
-        drive->disk.track_initialized[drive->real_track_index];
-    *io_flags |= CLEM_IWM_FLAG_PULSE_HIGH;
-    /* read a pulse from the bitstream, following WOZ emulation suggestions
-        to emulate errors - this is effectively a copypasta from
-        https://applesaucefdc.com/woz/reference2/ */
-    drive->read_buffer <<= 1;
-    if (valid_disk_data) {
-      if (_clem_disk_read_bit(drive)) {
-        drive->read_buffer |= 0x1;
-      }
-    }
-
-    if (is_drive_525) {
-      /* 3.5" drives don't have the same hardware as the Disk II, so
-         I *think* fake bits don't apply
-      */
-      if ((drive->read_buffer & 0xf) && valid_disk_data) {
-        if (drive->read_buffer & 0x2) {
-          *io_flags |= CLEM_IWM_FLAG_READ_DATA;
+unsigned clem_drive_step(struct ClemensDrive *drive, unsigned *io_flags, int qtr_track_index,
+                         unsigned track_cur_pos, unsigned dt_ns) {
+    bool is_drive_525 = (*io_flags & CLEM_IWM_FLAG_DRIVE_35) ? false : true;
+    if (qtr_track_index != drive->qtr_track_index && drive->has_disk) {
+        /*
+        CLEM_LOG("IWM: Disk525[%u]: Motor: %u; Head @ (%d,%d)",
+            (*io_flags & CLEM_IWM_FLAG_DRIVE_2) ? 2 : 1,
+            (*io_flags & CLEM_IWM_FLAG_DRIVE_ON) ? 1 : 0,
+            qtr_track_index / 4, qtr_track_index % 4);
+        */
+        if (drive->disk.meta_track_map[drive->qtr_track_index] !=
+            drive->disk.meta_track_map[qtr_track_index]) {
+            /* force lookup of the real track if the arm has changed */
+            drive->real_track_index = 0xfe;
         }
-      } else {
-        *io_flags |= CLEM_IWM_FLAG_READ_DATA_FAKE;
-        if (_clem_disk_read_fake_bit_525(drive)) {
-          *io_flags |= CLEM_IWM_FLAG_READ_DATA;
+
+        drive->qtr_track_index = qtr_track_index;
+    }
+    if (drive->has_disk) {
+        if (drive->real_track_index == 0xfe) {
+            unsigned track_prev_len = drive->track_bit_length;
+            drive->real_track_index = drive->disk.meta_track_map[drive->qtr_track_index];
+            if (drive->real_track_index != 0xff) {
+                drive->track_bit_length =
+                    _clem_disk_get_track_bit_length(drive, drive->qtr_track_index, is_drive_525);
+            } else if (drive->track_bit_length == 0) {
+                /* just use the prior bit length if there's no track defined */
+                drive->track_bit_length = drive->disk.track_bits_count[0];
+            }
+            if (track_prev_len) {
+                track_cur_pos = track_cur_pos * drive->track_bit_length / track_prev_len;
+            }
         }
-      }
     } else {
-      if (drive->read_buffer & 0x1) {
-        *io_flags |= CLEM_IWM_FLAG_READ_DATA;
-      }
+        /* also we need to fake it being write protected?  check this? */
+        drive->qtr_track_index = qtr_track_index;
+        if (is_drive_525) {
+            *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
+        }
     }
-  }
-  return track_cur_pos;
+    if (track_cur_pos >= drive->track_bit_length) {
+        /* wrap to beginning of track */
+        track_cur_pos -= drive->track_bit_length;
+    }
+    drive->track_byte_index = track_cur_pos / 8;
+    drive->track_bit_shift = 7 - (track_cur_pos % 8);
+    drive->pulse_ns = clem_util_timer_increment(drive->pulse_ns, 1000000, dt_ns);
+    if (!drive->has_disk) {
+        return track_cur_pos;
+    }
+    if (drive->pulse_ns >= drive->disk.bit_timing_ns) {
+        bool valid_disk_data = drive->real_track_index != 0xff &&
+                               drive->disk.track_initialized[drive->real_track_index];
+        *io_flags |= CLEM_IWM_FLAG_PULSE_HIGH;
+        /* read a pulse from the bitstream, following WOZ emulation suggestions
+            to emulate errors - this is effectively a copypasta from
+            https://applesaucefdc.com/woz/reference2/ */
+        drive->read_buffer <<= 1;
+        if (valid_disk_data) {
+            if (_clem_disk_read_bit(drive)) {
+                drive->read_buffer |= 0x1;
+            }
+        }
+
+        if (is_drive_525) {
+            /* 3.5" drives don't have the same hardware as the Disk II, so
+               I *think* fake bits don't apply
+            */
+            if ((drive->read_buffer & 0xf) && valid_disk_data) {
+                if (drive->read_buffer & 0x2) {
+                    *io_flags |= CLEM_IWM_FLAG_READ_DATA;
+                }
+            } else {
+                *io_flags |= CLEM_IWM_FLAG_READ_DATA_FAKE;
+                if (_clem_disk_read_fake_bit_525(drive)) {
+                    *io_flags |= CLEM_IWM_FLAG_READ_DATA;
+                }
+            }
+        } else {
+            if (drive->read_buffer & 0x1) {
+                *io_flags |= CLEM_IWM_FLAG_READ_DATA;
+            }
+        }
+    }
+    return track_cur_pos;
 }
 
 /**
@@ -315,110 +307,104 @@ unsigned clem_drive_step(struct ClemensDrive *drive, unsigned *io_flags,
  * @param io_flags
  * @param in_phase
  */
-void clem_disk_read_and_position_head_525(struct ClemensDrive *drive,
-                                          unsigned *io_flags, unsigned in_phase,
-                                          unsigned dt_ns) {
-  int qtr_track_index = drive->qtr_track_index;
-  int qtr_track_delta;
-  unsigned track_cur_pos;
+void clem_disk_read_and_position_head_525(struct ClemensDrive *drive, unsigned *io_flags,
+                                          unsigned in_phase, unsigned dt_ns) {
+    int qtr_track_index = drive->qtr_track_index;
+    int qtr_track_delta;
+    unsigned track_cur_pos;
 
-  track_cur_pos = clem_drive_pre_step(drive, io_flags);
-  if (track_cur_pos == CLEM_IWM_DRIVE_INVALID_TRACK_POS) {
-    /* should we clear state ? */
-    return;
-  }
+    track_cur_pos = clem_drive_pre_step(drive, io_flags);
+    if (track_cur_pos == CLEM_IWM_DRIVE_INVALID_TRACK_POS) {
+        /* should we clear state ? */
+        return;
+    }
 
-  /* clamp quarter track index to 5.25" limits */
-  /* turning a cog that can be oriented in one of 8 directions */
-  qtr_track_delta =
-      (s_disk2_phase_states[drive->cog_orient & 0x7][in_phase & 0xf]);
-  drive->cog_orient = (drive->cog_orient + qtr_track_delta) % 8;
-  qtr_track_index += qtr_track_delta;
-  if (qtr_track_index < 0) {
-    CLEM_LOG("IWM: Disk525[%u]: Motor: %u; CLACK",
-             (*io_flags & CLEM_IWM_FLAG_DRIVE_2) ? 2 : 1,
-             (*io_flags & CLEM_IWM_FLAG_DRIVE_ON) ? 1 : 0);
-    qtr_track_index = 0;
-  } else if (qtr_track_index >= 160)
-    qtr_track_index = 160;
-  drive->ctl_switch = in_phase;
+    /* clamp quarter track index to 5.25" limits */
+    /* turning a cog that can be oriented in one of 8 directions */
+    qtr_track_delta = (s_disk2_phase_states[drive->cog_orient & 0x7][in_phase & 0xf]);
+    drive->cog_orient = (drive->cog_orient + qtr_track_delta) % 8;
+    qtr_track_index += qtr_track_delta;
+    if (qtr_track_index < 0) {
+        CLEM_LOG("IWM: Disk525[%u]: Motor: %u; CLACK", (*io_flags & CLEM_IWM_FLAG_DRIVE_2) ? 2 : 1,
+                 (*io_flags & CLEM_IWM_FLAG_DRIVE_ON) ? 1 : 0);
+        qtr_track_index = 0;
+    } else if (qtr_track_index >= 160)
+        qtr_track_index = 160;
+    drive->ctl_switch = in_phase;
 
-  track_cur_pos =
-      clem_drive_step(drive, io_flags, qtr_track_index, track_cur_pos, dt_ns);
+    track_cur_pos = clem_drive_step(drive, io_flags, qtr_track_index, track_cur_pos, dt_ns);
 
-  if (drive->disk.is_write_protected) {
-    *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
-  }
+    if (drive->disk.is_write_protected) {
+        *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
+    }
 }
 
-void clem_disk_update_head(struct ClemensDrive *drive, unsigned *io_flags,
-                           unsigned dt_ns) {
-  bool write_pulse = (*io_flags & CLEM_IWM_FLAG_WRITE_HEAD_ON) ==
-                     (CLEM_IWM_FLAG_WRITE_HEAD_ON);
-  bool write_transition = write_pulse != drive->write_pulse;
+void clem_disk_update_head(struct ClemensDrive *drive, unsigned *io_flags, unsigned dt_ns) {
+    bool write_pulse = (*io_flags & CLEM_IWM_FLAG_WRITE_HEAD_ON) == (CLEM_IWM_FLAG_WRITE_HEAD_ON);
+    bool write_transition = write_pulse != drive->write_pulse;
 
-  if (!(*io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
-    return;
-  }
-  if (!drive->has_disk) {
-    return;
-  }
-
-  if (!drive->disk.is_write_protected) {
-    if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST) {
-      if (drive->real_track_index != 0xff) {
-        if (!drive->disk.track_initialized[drive->real_track_index]) {
-          if (write_transition) {
-            /* first time write to an uninitialized track will start
-            writes at the beginning of the data block.  most
-            likely this occurs via formatting.
-            The first genuine byte will have its high bit will
-            always be on as defined by GCR 6-2 encoding
-            */
-            drive->disk.track_initialized[drive->real_track_index] = 1;
-            drive->track_bit_shift = 7;
-            drive->track_byte_index = 0;
-          }
-        }
-        if (drive->disk.track_initialized[drive->real_track_index]) {
-          _clem_disk_write_bit(drive, write_transition);
-        }
-      }
+    if (!(*io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
+        return;
     }
-  }
+    if (!drive->has_disk) {
+        return;
+    }
 
-  if (drive->pulse_ns >= drive->disk.bit_timing_ns) {
-    *io_flags |= CLEM_IWM_FLAG_PULSE_HIGH;
+    if (!drive->disk.is_write_protected) {
+        if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST) {
+            if (drive->real_track_index != 0xff) {
+                if (!drive->disk.track_initialized[drive->real_track_index]) {
+                    if (write_transition) {
+                        /* first time write to an uninitialized track will start
+                        writes at the beginning of the data block.  most
+                        likely this occurs via formatting.
+                        The first genuine byte will have its high bit will
+                        always be on as defined by GCR 6-2 encoding
+                        */
+                        drive->disk.track_initialized[drive->real_track_index] = 1;
+                        drive->track_bit_shift = 7;
+                        drive->track_byte_index = 0;
+                    }
+                }
+                if (drive->disk.track_initialized[drive->real_track_index]) {
+                    _clem_disk_write_bit(drive, write_transition);
+                }
+            }
+        }
+    }
 
-    /*
-    if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST &&
-        drive->data->track_initialized[drive->real_track_index]
-    ) {
-         CLEM_LOG("diskwr(%u:%u:%u): %c",
+    if (drive->pulse_ns >= drive->disk.bit_timing_ns) {
+        *io_flags |= CLEM_IWM_FLAG_PULSE_HIGH;
+
+        /*
+        if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST &&
+            drive->data->track_initialized[drive->real_track_index]
+        ) {
+             CLEM_LOG("diskwr(%u:%u:%u): %c",
+                        drive->real_track_index, drive->track_byte_index,
+        drive->track_bit_shift, write_transition ? '1': '0');
+        }
+        */
+
+        drive->write_pulse = write_pulse;
+
+        if (drive->track_bit_shift == 0) {
+            drive->track_bit_shift = 8;
+            /*
+            if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST) {
+                CLEM_LOG("diskwr(%u:%u): %02X",
                     drive->real_track_index, drive->track_byte_index,
-    drive->track_bit_shift, write_transition ? '1': '0');
+                    *(drive->data->bits_data + (
+                        drive->data->track_byte_offset[drive->real_track_index] +
+            drive->track_byte_index)));
+            }
+            */
+            ++drive->track_byte_index;
+        }
+        --drive->track_bit_shift;
+        drive->pulse_ns = 0;
+        /*drive->pulse_ns = drive->pulse_ns - drive->disk.bit_timing_ns; */
+    } else {
+        *io_flags &= ~CLEM_IWM_FLAG_PULSE_HIGH;
     }
-    */
-
-    drive->write_pulse = write_pulse;
-
-    if (drive->track_bit_shift == 0) {
-      drive->track_bit_shift = 8;
-      /*
-      if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST) {
-          CLEM_LOG("diskwr(%u:%u): %02X",
-              drive->real_track_index, drive->track_byte_index,
-              *(drive->data->bits_data + (
-                  drive->data->track_byte_offset[drive->real_track_index] +
-      drive->track_byte_index)));
-      }
-      */
-      ++drive->track_byte_index;
-    }
-    --drive->track_bit_shift;
-    drive->pulse_ns = 0;
-    /*drive->pulse_ns = drive->pulse_ns - drive->disk.bit_timing_ns; */
-  } else {
-    *io_flags &= ~CLEM_IWM_FLAG_PULSE_HIGH;
-  }
 }

--- a/clem_iwm.c
+++ b/clem_iwm.c
@@ -390,9 +390,13 @@ void clem_iwm_glu_sync(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *dri
             //  the 5.25" disk is disabled.
             iwm->enable2 = clem_smartport_bus(drives->smartport, 1, &iwm->io_flags, &iwm->out_phase,
                                               disk_delta_ns);
-            if (iwm->enable2 && iwm->state == CLEM_IWM_STATE_WRITE_DATA &&
-                (iwm->io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
-                printf("SmartPort: DATA SENT = %02X\n", iwm->data);
+            if (iwm->enable2) {
+                /*
+                if (iwm->state == CLEM_IWM_STATE_WRITE_DATA &&
+                    (iwm->io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
+                    printf("SmartPort: DATA SENT = %02X\n", iwm->data);
+                }
+                */
                 drive = NULL;
             }
         }

--- a/clem_mmio.c
+++ b/clem_mmio.c
@@ -1594,11 +1594,11 @@ void _clem_mmio_init_page_maps(ClemensMMIO *mmio, uint32_t memory_flags) {
     mmio->bank_page_map[0x00] = &mmio->fpi_main_page_map;
     mmio->bank_page_map[0x01] = &mmio->fpi_aux_page_map;
 
-    for (bank_idx = 0x02; bank_idx < CLEM_IIGS_FPI_MAIN_RAM_BANK_COUNT; ++bank_idx) {
+    for (bank_idx = 0x02; bank_idx < mmio->fpi_ram_bank_count; ++bank_idx) {
         mmio->bank_page_map[bank_idx] = &mmio->fpi_direct_page_map;
     }
     /* TODO: handle expansion RAM */
-    for (bank_idx = CLEM_IIGS_FPI_MAIN_RAM_BANK_COUNT; bank_idx < 0x80; ++bank_idx) {
+    for (bank_idx = mmio->fpi_ram_bank_count; bank_idx < 0x80; ++bank_idx) {
         mmio->bank_page_map[bank_idx] = &mmio->empty_page_map;
     }
     /* Handles unavailable banks beyond the 0x80 bank IIgs hard RAM limit */
@@ -1644,7 +1644,8 @@ void clem_mmio_restore(ClemensMMIO *mmio) {
 
 void clem_mmio_init(ClemensMMIO *mmio, struct ClemensDeviceDebugger *dev_debug,
                     struct ClemensMemoryPageMap **bank_page_map,
-                    clem_clocks_duration_t mega2_clocks_step, void *slot_expansion_rom) {
+                    clem_clocks_duration_t mega2_clocks_step, void *slot_expansion_rom,
+                    unsigned int fpi_ram_bank_count) {
     int idx;
     //  Memory map starts out without shadowing, but our call to
     //  init_page_maps will initialize the memory map on IIgs reset
@@ -1660,6 +1661,7 @@ void clem_mmio_init(ClemensMMIO *mmio, struct ClemensDeviceDebugger *dev_debug,
     mmio->last_data_address = 0xffffffff;
     mmio->bank_page_map = bank_page_map;
     mmio->emulator_detect = CLEM_MMIO_EMULATOR_DETECT_IDLE;
+    mmio->fpi_ram_bank_count = fpi_ram_bank_count;
     mmio->card_expansion_rom_index = -1;
 
     for (idx = 0; idx < 7; ++idx) {

--- a/clem_mmio.h
+++ b/clem_mmio.h
@@ -11,7 +11,8 @@ void clem_mmio_reset(ClemensMMIO *mmio, clem_clocks_duration_t mega2_clocks_step
 
 void clem_mmio_init(ClemensMMIO *mmio, struct ClemensDeviceDebugger *dev_debug,
                     struct ClemensMemoryPageMap **bank_page_map,
-                    clem_clocks_duration_t mega2_clocks_step, void *slot_expansion_rom);
+                    clem_clocks_duration_t mega2_clocks_step, void *slot_expansion_rom,
+                    unsigned int fpi_ram_bank_count);
 
 uint8_t clem_mmio_read(ClemensMMIO *mmio, struct ClemensTimeSpec *tspec, uint16_t addr,
                        uint8_t flags, bool *mega2_access);

--- a/clem_shared.h
+++ b/clem_shared.h
@@ -80,6 +80,45 @@ struct ClemensClock {
 #define clem_calc_clocks_step_from_ns(_ns_, _clocks_step_reference_)                               \
     ((clem_clocks_duration_t)((_ns_) * (_clocks_step_reference_)) / CLEM_MEGA2_CYCLE_NS)
 
+/**
+ * @brief Defines the abstract interface to SmartPort based hardware
+ *
+ * To initialize, a SmartPort implementation should provide an intialization
+ * function (for example):
+ *      my_smartport_device_initialize(struct ClemensSmartPortUnit* unit)
+ *
+ * The implemenation should initialize whatever structures it needs for the
+ * unit.  For convenience/dependency injection purposes, a 'device' pointer
+ * and 'device_id' is provided inside this struct and should be filled so that
+ * the host can access this information if needed (for debugging, internal
+ * state management, etc.)
+ *
+ */
+struct ClemensSmartPortUnit {
+    /** A unique (to the emulator) ID Identifying the Smartport device
+        implementation.   This in tandem with `device` is the custom state
+        implemented for the device (i.e A specific HD brand, etc). */
+    unsigned device_id;
+    /** Device implemented in this unit.  This must be provided at emulator startup */
+    void *device;
+    /** Smartport bus resident on a bus being reset */
+    unsigned (*bus_reset)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
+                          unsigned delta_ns);
+    /** Smartport bus resident on an enabled bus */
+    unsigned (*bus_enable)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
+                           unsigned delta_ns);
+
+    /* Note these memebers are managed by the emulator and should not be modified
+       unless you know what you're doing!
+    */
+    /** The UnitID Assigned by the host as sent via the ID Definition command*/
+    uint8_t unit_id;
+};
+
+/**
+ * @brief Defines the abstract interface to slot-based card hardware
+ *
+ */
 typedef struct {
     void *context;
     void (*io_reset)(struct ClemensClock *clock, void *context);

--- a/clem_shared.h
+++ b/clem_shared.h
@@ -81,41 +81,6 @@ struct ClemensClock {
     ((clem_clocks_duration_t)((_ns_) * (_clocks_step_reference_)) / CLEM_MEGA2_CYCLE_NS)
 
 /**
- * @brief Defines the abstract interface to SmartPort based hardware
- *
- * To initialize, a SmartPort implementation should provide an intialization
- * function (for example):
- *      my_smartport_device_initialize(struct ClemensSmartPortUnit* unit)
- *
- * The implemenation should initialize whatever structures it needs for the
- * unit.  For convenience/dependency injection purposes, a 'device' pointer
- * and 'device_id' is provided inside this struct and should be filled so that
- * the host can access this information if needed (for debugging, internal
- * state management, etc.)
- *
- */
-struct ClemensSmartPortUnit {
-    /** A unique (to the emulator) ID Identifying the Smartport device
-        implementation.   This in tandem with `device` is the custom state
-        implemented for the device (i.e A specific HD brand, etc). */
-    unsigned device_id;
-    /** Device implemented in this unit.  This must be provided at emulator startup */
-    void *device;
-    /** Smartport bus resident on a bus being reset */
-    unsigned (*bus_reset)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
-                          unsigned delta_ns);
-    /** Smartport bus resident on an enabled bus */
-    unsigned (*bus_enable)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
-                           unsigned delta_ns);
-
-    /* Note these memebers are managed by the emulator and should not be modified
-       unless you know what you're doing!
-    */
-    /** The UnitID Assigned by the host as sent via the ID Definition command*/
-    uint8_t unit_id;
-};
-
-/**
  * @brief Defines the abstract interface to slot-based card hardware
  *
  */

--- a/clem_smartport.c
+++ b/clem_smartport.c
@@ -1,5 +1,217 @@
 #include "clem_smartport.h"
+#include "clem_debug.h"
 #include "clem_defs.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+/* PH0 + PH2 ONLY */
+#define CLEM_SMARTPORT_BUS_RESET_PHASE (1 + 4)
+/* PH1 + PH3 */
+#define CLEM_SMARTPORT_BUS_ENABLE_PHASE (2 + 8)
+
+#define CLEM_SMARTPORT_UNIT_STATE_NULL  0x00000000
+#define CLEM_SMARTPORT_UNIT_STATE_READY 0x00010000
+
+/* sync bytes up to the packet begin byte*/
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET          0x00020000
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET_HEADER   0x00020001
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET_CONTENTS 0x00020002
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET_CHECKSUM 0x00020003
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET_END      0x00020004
+#define CLEM_SMARTPORT_UNIT_STATE_PACKET_BAD      0x0002ffff
+#define CLEM_SMARTPORT_UNIT_STATE_EXECUTING       0x00030000
+#define CLEM_SMARTPORT_UNIT_STATE_ACK             0x00040000
+
+#define CLEM_SMARTPORT_BUS_WRITE 1
+#define CLEM_SMARTPORT_BUS_DATA  2
+#define CLEM_SMARTPORT_BUS_REQ   4
+
+static inline void _clem_smartport_packet_state(struct ClemensSmartPortUnit *unit,
+                                                unsigned packet_state) {
+    unit->packet_state = packet_state;
+    unit->packet_state_byte_cnt = 0;
+}
+
+static void _clem_smartport_packet_decode_data(uint8_t *dest, unsigned dest_size,
+                                               const uint8_t *src, unsigned src_groups,
+                                               unsigned src_odd) {
+    // the input buffer contains encoded chunks of data:
+    //      every chunk contains the MSB of each 7-bit encoded byte in the group
+    const uint8_t *src_groups_data = src + 1;
+    uint8_t msbs = src[0] << 1;
+    uint8_t *dest_data = dest;
+    while (src_groups_data < (src + src_odd + 1) && dest_data <= (dest + dest_size)) {
+        dest_data[0] = (*src_groups_data & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        ++src_groups_data;
+        ++dest_data;
+    }
+    while (dest_data <= (dest + dest_size - 7)) {
+        msbs = src_groups_data[0] << 1;
+        dest_data[0] = (src_groups_data[1] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[1] = (src_groups_data[2] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[2] = (src_groups_data[3] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[3] = (src_groups_data[4] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[4] = (src_groups_data[5] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[5] = (src_groups_data[6] & 0x7f) | (msbs & 0x80);
+        msbs <<= 1;
+        dest_data[6] = (src_groups_data[7] & 0x7f) | (msbs & 0x80);
+        src_groups_data += 8;
+        dest_data += 7;
+    }
+}
+
+static bool _clem_smartport_handle_packet(struct ClemensSmartPortUnit *unit, unsigned delta_ns) {
+    //  Parse the decoded packet based on the packet type (For commands, obtain the command type
+    //  and parameter count, for example)
+    if (unit->packet.type == kClemensSmartPortPacketType_Command) {
+        uint8_t command_type = unit->packet.contents[0];
+        switch (command_type) {
+        case CLEM_SMARTPORT_COMMAND_INIT:
+            unit->unit_id = unit->packet.dest_unit_id;
+            unit->ph3_latch_lo = false;
+            return true;
+        default:
+            CLEM_ASSERT(false);
+            break;
+        }
+    }
+    return false;
+}
+
+static void _clem_smartport_bus_handshake(struct ClemensSmartPortUnit *unit, unsigned bus_in,
+                                          unsigned delta_ns) {
+    uint8_t *data_tail;
+    uint8_t *data_start;
+
+    if (unit->packet_state == CLEM_SMARTPORT_UNIT_STATE_EXECUTING) {
+        //  must wait until the host has marked the request as 'done' before acknowledging
+        //  packet's exectuion has completed.
+        if (_clem_smartport_handle_packet(unit, delta_ns)) {
+            unit->packet_state = CLEM_SMARTPORT_UNIT_STATE_ACK;
+        }
+    } else if (unit->packet_state == CLEM_SMARTPORT_UNIT_STATE_ACK) {
+        if (!(bus_in & CLEM_SMARTPORT_BUS_REQ)) {
+            unit->ack_hi = true;
+            unit->packet_state = CLEM_SMARTPORT_UNIT_STATE_READY;
+        }
+    }
+
+    if (!(bus_in & CLEM_SMARTPORT_BUS_REQ))
+        return;
+
+    if (bus_in & CLEM_SMARTPORT_BUS_WRITE) {
+        //  write into data buffer from the disk port
+        bool data_signal = (bus_in & CLEM_SMARTPORT_BUS_DATA) != 0;
+        if (data_signal != unit->write_signal) {
+            unit->data_reg |= 1;
+        } else {
+            unit->data_reg &= ~1;
+        }
+        unit->data_pulse_count++;
+        if ((unit->data_pulse_count % 8) == 0) {
+            unit->write_signal = data_signal;
+            if (unit->data_bit_count > 0 || (unit->data_reg & 0x01)) {
+                unit->data_bit_count++;
+                if (unit->data_bit_count >= 8) {
+                    if (unit->data_size < CLEM_SMARTPORT_DATA_BUFFER_LIMIT) {
+                        printf("SmartPort => %02X\n", unit->data_reg);
+                        unit->data[unit->data_size++] = unit->data_reg;
+                        unit->packet_state_byte_cnt++;
+                    } else {
+                        CLEM_LOG("SmartPort: Data overrun at unit %u, device %u", unit->unit_id,
+                                 unit->device_id);
+                    }
+                    unit->data_reg = 0;
+                    unit->data_bit_count = 0;
+                } else {
+                    unit->data_reg <<= 1;
+                }
+            }
+        }
+    }
+
+    if (unit->packet_state_byte_cnt < 1)
+        return;
+
+    data_start = unit->data + unit->data_size - unit->packet_state_byte_cnt;
+    data_tail = unit->data + unit->data_size;
+
+    switch (unit->packet_state) {
+    case CLEM_SMARTPORT_UNIT_STATE_READY:
+        _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET);
+        break;
+    case CLEM_SMARTPORT_UNIT_STATE_PACKET:
+        if (data_tail[-1] != 0xff) {
+            if (data_tail[-1] == 0xC3) {
+                //  save off the start of the actual packet data
+                _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_HEADER);
+                memset(&unit->packet, 0, sizeof(unit->packet));
+            } else {
+                _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_BAD);
+                CLEM_WARN("SmartPort: sync byte expected but got %02X", data_tail[-1]);
+            }
+        }
+        break;
+    case CLEM_SMARTPORT_UNIT_STATE_PACKET_HEADER:
+        if (unit->packet_state_byte_cnt == 7) {
+            //  the last two bytes of the header contain the packet length in unencoded bytes
+            //  we must calculate the encoded length of 7-bit bytes to pull in from the packet.
+            _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_CONTENTS);
+            unit->packet.source_unit_id = data_start[1] & 0x7f;
+            unit->packet.dest_unit_id = data_start[0] & 0x7f;
+            if (data_start[2] == 0x80) {
+                unit->packet.type = kClemensSmartPortPacketType_Command;
+            } else if (data_start[2] = 0x81) {
+                unit->packet.type = kClemensSmartPortPacketType_Status;
+            } else if (data_start[2] == 0x82) {
+                unit->packet.type = kClemensSmartPortPacketType_Data;
+            }
+            if (data_start[3] == 0xC0) {
+                unit->packet.is_extended = true;
+            }
+            unit->packet.status = data_start[4] & 0x7f;
+            //  get the decoded contents counts necessary to decode the odd and
+            //  7 byte groups.
+            unit->packet.contents_length = (data_tail[-1] & 0x7f) << 8;
+            unit->packet.contents_length |= (data_tail[-2] & 0x7f);
+            //  calculate encoded content length
+            unit->packet_cntr = (((unsigned)(data_tail[-1]) & 0x7f) * 7) + (data_tail[-2] & 0x7f);
+            unit->packet_cntr = (unit->packet_cntr * 8 + 6) / 7;
+        }
+        break;
+    case CLEM_SMARTPORT_UNIT_STATE_PACKET_CONTENTS:
+        if (unit->packet_state_byte_cnt == unit->packet_cntr) {
+            _clem_smartport_packet_decode_data(unit->packet.contents, unit->packet_cntr, data_start,
+                                               unit->packet.contents_length >> 8,
+                                               unit->packet.contents_length & 0xff);
+            _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_CHECKSUM);
+        }
+        break;
+    case CLEM_SMARTPORT_UNIT_STATE_PACKET_CHECKSUM:
+        if (unit->packet_state_byte_cnt == 2) {
+            //  16-bit encoded checksum (8-bit actual)
+            //  calc checksum up to (data_size - 2)
+            _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_END);
+        }
+        break;
+    case CLEM_SMARTPORT_UNIT_STATE_PACKET_END:
+        if (data_tail[-1] == 0xC8) {
+            _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_EXECUTING);
+            unit->ack_hi = false;
+        } else {
+            _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_PACKET_BAD);
+        }
+        break;
+    }
+}
 
 /*
    Bus Reset starts the unit assignment process from the host.
@@ -15,14 +227,6 @@
    device no longer forces PH3 to 0 on its output and the next device will
    pick up on the PH3 as set by the host.
 */
-bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_count,
-                             unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
-    unsigned select_bits = *out_phase;
-    if (select_bits != (1 + 4)) {
-        return false;
-    }
-    return true;
-}
 
 /*
   Bus Enable marks that all 'available' bus residents can handle SmartPort
@@ -34,15 +238,73 @@ bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_co
   Each device may have its own command handler.  They share common bus
   negotation logic with the host, which is provided below.
 */
-bool clem_smartport_do_enable(struct ClemensSmartPortUnit *unit, unsigned unit_count,
-                              unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
+
+bool clem_smartport_bus(struct ClemensSmartPortUnit *unit, unsigned unit_count, unsigned *io_flags,
+                        unsigned *out_phase, unsigned delta_ns) {
+    struct ClemensSmartPortUnit *unit_end = unit + unit_count;
     unsigned select_bits = *out_phase;
-    if (!(select_bits & 2) || !(select_bits & 8)) {
-        return false;
+    unsigned bus_state = 0;
+    bool is_bus_enabled = false;
+    bool is_ack_hi = false;
+
+    for (; unit < unit_end; unit++) {
+        if (unit->device_id == 0)
+            continue;
+        if (select_bits == CLEM_SMARTPORT_BUS_RESET_PHASE) {
+            unit->unit_id = 0x00;
+            unit->ph3_latch_lo = 1;
+            unit->bus_enabled = false;
+        } else if ((select_bits & CLEM_SMARTPORT_BUS_ENABLE_PHASE) ==
+                   CLEM_SMARTPORT_BUS_ENABLE_PHASE) {
+            if (!unit->bus_enabled) {
+                unit->data_pulse_count = 0;
+                unit->data_bit_count = 0;
+                unit->data_reg = 0x00;
+                unit->data_size = 0;
+                unit->write_signal = 0;
+                unit->ack_hi = true;
+                unit->bus_enabled = true;
+                _clem_smartport_packet_state(unit, CLEM_SMARTPORT_UNIT_STATE_READY);
+            }
+            if ((select_bits & 1) != 0) {
+                bus_state |= CLEM_SMARTPORT_BUS_REQ;
+            }
+            if (*io_flags & CLEM_IWM_FLAG_WRITE_REQUEST) {
+                bus_state |= CLEM_SMARTPORT_BUS_WRITE;
+                if (*io_flags & CLEM_IWM_FLAG_WRITE_DATA) {
+                    bus_state |= CLEM_SMARTPORT_BUS_DATA;
+                }
+            }
+            _clem_smartport_bus_handshake(unit, bus_state, delta_ns);
+        } else {
+            unit->bus_enabled = false;
+        }
+        if (unit->ph3_latch_lo) {
+            // PH3 OFF for downstream devices
+            // This should only occur after a bus reset for a device that hasn't
+            // received its ID from the hsot
+            select_bits &= ~8;
+        }
+        is_bus_enabled = unit->bus_enabled;
+        is_ack_hi = unit->ack_hi;
+        unit++;
     }
 
-    //  ACK is HIGH for now
-    *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
+    if (!is_bus_enabled) {
+        is_bus_enabled =
+            (select_bits & CLEM_SMARTPORT_BUS_ENABLE_PHASE) == CLEM_SMARTPORT_BUS_ENABLE_PHASE;
+        is_ack_hi = is_bus_enabled;
+    }
 
-    return true;
+    if (is_bus_enabled) {
+        if (is_ack_hi) {
+            *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
+        } else {
+            *io_flags &= ~CLEM_IWM_FLAG_WRPROTECT_SENSE;
+        }
+
+        printf("SmartPort: REQ: %u,  ACK: %u\n", (select_bits & 1) != 0, is_ack_hi);
+    }
+
+    return unit->bus_enabled;
 }

--- a/clem_smartport.c
+++ b/clem_smartport.c
@@ -271,8 +271,7 @@ static unsigned _clem_smartport_handle_packet(struct ClemensSmartPortUnit *unit,
         case CLEM_SMARTPORT_COMMAND_STATUS:
             CLEM_DEBUG("SmartPort: [%02X] Status", unit->unit_id);
             if (unit->device.do_status) {
-                call_status = (*unit->device.do_status)(&unit->device, &unit->packet,
-                                                        unit->packet.status, delta_ns);
+                call_status = (*unit->device.do_status)(&unit->device, &unit->packet, delta_ns);
             } else {
                 call_status = CLEM_SMARTPORT_STATUS_CODE_BAD_CTL;
             }

--- a/clem_smartport.c
+++ b/clem_smartport.c
@@ -1,0 +1,24 @@
+#include "clem_smartport.h"
+#include "clem_defs.h"
+
+bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_count,
+                             unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
+    unsigned select_bits = *out_phase;
+    if (select_bits != (1 + 4)) {
+        return false;
+    }
+    return true;
+}
+
+bool clem_smartport_do_enable(struct ClemensSmartPortUnit *unit, unsigned unit_count,
+                              unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
+    unsigned select_bits = *out_phase;
+    if (!(select_bits & 2) || !(select_bits & 8)) {
+        return false;
+    }
+
+    //  ACK is HIGH for now
+    *io_flags |= CLEM_IWM_FLAG_WRPROTECT_SENSE;
+
+    return true;
+}

--- a/clem_smartport.c
+++ b/clem_smartport.c
@@ -1,6 +1,20 @@
 #include "clem_smartport.h"
 #include "clem_defs.h"
 
+/*
+   Bus Reset starts the unit assignment process from the host.
+
+   Each device will force PH30 on its *output* phase, which is passed to the
+   next device on the daisy-chained disk port.
+
+   The host will reenable the bus and assign a unit ID to the next available
+   device in the chain. See do_enable() for details on subsequent events.
+
+   To achieve this, on do_reset(), each device maintains an 'available' flag
+   which is TRUE once it receives its ID assignment.  When 'available', the
+   device no longer forces PH3 to 0 on its output and the next device will
+   pick up on the PH3 as set by the host.
+*/
 bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_count,
                              unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
     unsigned select_bits = *out_phase;
@@ -10,6 +24,16 @@ bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_co
     return true;
 }
 
+/*
+  Bus Enable marks that all 'available' bus residents can handle SmartPort
+  commands.  See do_reset() for details on how a device becomes available.
+
+  Much of the implementation follows the SmartPort protocol diagrams in
+  Chapter 7 of the Apple IIgs firmware reference.
+
+  Each device may have its own command handler.  They share common bus
+  negotation logic with the host, which is provided below.
+*/
 bool clem_smartport_do_enable(struct ClemensSmartPortUnit *unit, unsigned unit_count,
                               unsigned *io_flags, unsigned *out_phase, unsigned delta_ns) {
     unsigned select_bits = *out_phase;

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+/** Number of drives supported at one time on the system */
+#define CLEM_SMARTPORT_DRIVE_LIMIT 1
+
 /* SmartPort devices by ID */
 #define CLEM_SMARTPORT_DEVICE_ID_NONE         0
 #define CLEM_SMARTPORT_DEVICE_ID_REFERENCE    1
@@ -28,11 +31,13 @@
  *  is imcomplete and to keep polling until its finished with one of the other
  *  result codes.
  */
-#define CLEM_SMARTPORT_STATUS_CODE_BAD_CMD 0x01
-#define CLEM_SMARTPORT_STATUS_CODE_BUS_ERR 0x06
-#define CLEM_SMARTPORT_STATUS_CODE_IO_ERR  0x27
-#define CLEM_SMARTPORT_STATUS_CODE_OFFLINE 0x2f
-#define CLEM_SMARTPORT_STATUS_CODE_WAIT    0x7f
+#define CLEM_SMARTPORT_STATUS_CODE_OK            0x00
+#define CLEM_SMARTPORT_STATUS_CODE_BAD_CMD       0x01
+#define CLEM_SMARTPORT_STATUS_CODE_BUS_ERR       0x06
+#define CLEM_SMARTPORT_STATUS_CODE_IO_ERR        0x27
+#define CLEM_SMARTPORT_STATUS_CODE_INVALID_BLOCK 0x2D
+#define CLEM_SMARTPORT_STATUS_CODE_OFFLINE       0x2f
+#define CLEM_SMARTPORT_STATUS_CODE_WAIT          0x7f
 
 #ifdef __cplusplus
 extern "C" {

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -88,7 +88,7 @@ struct ClemensSmartPortDevice {
                               unsigned delta_ns);
     /** Retrieve a status block from the device */
     uint8_t (*do_status)(struct ClemensSmartPortDevice *context,
-                         struct ClemensSmartPortPacket *packet, uint8_t status, unsigned delta_ns);
+                         struct ClemensSmartPortPacket *packet, unsigned delta_ns);
     /** Retrieve a status block from the device */
     uint8_t (*do_format)(struct ClemensSmartPortDevice *context,
                          struct ClemensSmartPortPacket *packet, unsigned delta_ns);

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -34,12 +34,12 @@ enum ClemensSmartPortPacketType {
  *
  */
 struct ClemensSmartPortPacket {
+    /** Indicates how the packet should be handled by the recipient */
+    enum ClemensSmartPortPacketType type;
     /** Where the packet originates from (0 = host, > 0 are bus residents) */
     uint8_t source_unit_id;
     /** Where the packet is going (0 = host, > 0 are bus residents)*/
     uint8_t dest_unit_id;
-    /** Indicates how the packet should be handled by the recipient */
-    enum ClemensSmartPortPacketType type;
     /** An extended SmartPort call (certain fields are extended) */
     uint8_t is_extended;
     /** Value is used by status and data packet types, and error code for commands */
@@ -48,6 +48,18 @@ struct ClemensSmartPortPacket {
     uint16_t contents_length;
     /*  Decoded contents (8-bit values) */
     uint8_t contents[CLEM_SMARTPORT_CONTENTS_LIMIT];
+};
+
+struct ClemensSmartPortDevice {
+    unsigned device_id;
+    void *device_data;
+
+    /** Smartport bus resident on a bus being reset */
+    unsigned (*bus_reset)(struct ClemensSmartPortDevice *context, unsigned phase_flags,
+                          unsigned delta_ns);
+    /** Smartport bus resident on an enabled bus */
+    unsigned (*bus_enable)(struct ClemensSmartPortDevice *context, unsigned phase_flags,
+                           unsigned delta_ns);
 };
 
 /**
@@ -65,18 +77,7 @@ struct ClemensSmartPortPacket {
  *
  */
 struct ClemensSmartPortUnit {
-    /** A unique (to the emulator) ID Identifying the Smartport device
-        implementation.   This in tandem with `device` is the custom state
-        implemented for the device (i.e A specific HD brand, etc). */
-    unsigned device_id;
-    /** Device implemented in this unit.  This must be provided at emulator startup */
-    void *device;
-    /** Smartport bus resident on a bus being reset */
-    unsigned (*bus_reset)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
-                          unsigned delta_ns);
-    /** Smartport bus resident on an enabled bus */
-    unsigned (*bus_enable)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
-                           unsigned delta_ns);
+    struct ClemensSmartPortDevice device;
 
     /* Note these memebers are managed by the emulator and should not be modified
        unless you know what you're doing!

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -1,0 +1,21 @@
+#ifndef CLEM_SMARTPORT_H
+#define CLEM_SMARTPORT_H
+
+#include "clem_shared.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_count,
+                             unsigned *io_flags, unsigned *out_phase, unsigned delta_ns);
+
+bool clem_smartport_do_enable(struct ClemensSmartPortUnit *unit, unsigned unit_count,
+                              unsigned *io_flags, unsigned *out_phase, unsigned delta_ns);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -1,18 +1,115 @@
 #ifndef CLEM_SMARTPORT_H
 #define CLEM_SMARTPORT_H
 
-#include "clem_shared.h"
-#include <stdbool.h>
+#include <stdint.h>
+
+/* SmartPort devices by ID */
+#define CLEM_SMARTPORT_DEVICE_ID_NONE         0
+#define CLEM_SMARTPORT_DEVICE_ID_REFERENCE    1
+#define CLEM_SMARTPORT_DEVICE_ID_PRODOS_HDD32 2
+
+/* TODO: reevaluate - this should be some value around 768 */
+#define CLEM_SMARTPORT_DATA_BUFFER_LIMIT 768
+/* TODO: this should suffice for block devices, but the documentation hints at
+         possibly larger values (but obviously limited by the packet size limit?)
+*/
+#define CLEM_SMARTPORT_CONTENTS_LIMIT 576
+
+/* The INIT command that sends the assigned unit ID to the target device */
+#define CLEM_SMARTPORT_COMMAND_INIT 0x05
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-bool clem_smartport_do_reset(struct ClemensSmartPortUnit *unit, unsigned unit_count,
-                             unsigned *io_flags, unsigned *out_phase, unsigned delta_ns);
+enum ClemensSmartPortPacketType {
+    kClemensSmartPortPacketType_Unknown,
+    kClemensSmartPortPacketType_Command,
+    kClemensSmartPortPacketType_Status,
+    kClemensSmartPortPacketType_Data
+};
 
-bool clem_smartport_do_enable(struct ClemensSmartPortUnit *unit, unsigned unit_count,
-                              unsigned *io_flags, unsigned *out_phase, unsigned delta_ns);
+/**
+ * @brief
+ *
+ */
+struct ClemensSmartPortPacket {
+    /** Where the packet originates from (0 = host, > 0 are bus residents) */
+    uint8_t source_unit_id;
+    /** Where the packet is going (0 = host, > 0 are bus residents)*/
+    uint8_t dest_unit_id;
+    /** Indicates how the packet should be handled by the recipient */
+    enum ClemensSmartPortPacketType type;
+    /** An extended SmartPort call (certain fields are extended) */
+    uint8_t is_extended;
+    /** Value is used by status and data packet types, and error code for commands */
+    uint8_t status;
+    /** Contents length */
+    uint16_t contents_length;
+    /*  Decoded contents (8-bit values) */
+    uint8_t contents[CLEM_SMARTPORT_CONTENTS_LIMIT];
+};
+
+/**
+ * @brief Defines the abstract interface to SmartPort based hardware
+ *
+ * To initialize, a SmartPort implementation should provide an intialization
+ * function (for example):
+ *      my_smartport_device_initialize(struct ClemensSmartPortUnit* unit)
+ *
+ * The implemenation should initialize whatever structures it needs for the
+ * unit.  For convenience/dependency injection purposes, a 'device' pointer
+ * and 'device_id' is provided inside this struct and should be filled so that
+ * the host can access this information if needed (for debugging, internal
+ * state management, etc.)
+ *
+ */
+struct ClemensSmartPortUnit {
+    /** A unique (to the emulator) ID Identifying the Smartport device
+        implementation.   This in tandem with `device` is the custom state
+        implemented for the device (i.e A specific HD brand, etc). */
+    unsigned device_id;
+    /** Device implemented in this unit.  This must be provided at emulator startup */
+    void *device;
+    /** Smartport bus resident on a bus being reset */
+    unsigned (*bus_reset)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
+                          unsigned delta_ns);
+    /** Smartport bus resident on an enabled bus */
+    unsigned (*bus_enable)(struct ClemensSmartPortUnit *context, unsigned phase_flags,
+                           unsigned delta_ns);
+
+    /* Note these memebers are managed by the emulator and should not be modified
+       unless you know what you're doing!
+    */
+    /** BUS ENABLE */
+    uint8_t bus_enabled;
+    /** PH3 is forced slow for downstream units */
+    uint8_t ph3_latch_lo;
+    /** Data register */
+    uint8_t data_reg;
+    /** Write head latch */
+    uint8_t write_signal;
+    /** The ID assigned by the host*/
+    uint8_t unit_id;
+    /** ACK signal */
+    uint8_t ack_hi;
+
+    /** Used to accumulate bytes to be serialized/unserliazed to bus */
+    unsigned data_pulse_count;
+    unsigned data_bit_count;
+
+    /** Packet processor state */
+    unsigned packet_state;
+    unsigned packet_state_byte_cnt;
+    unsigned packet_cntr;
+
+    /** Raw encoded xfer buffer */
+    unsigned data_size;
+    uint8_t data[CLEM_SMARTPORT_DATA_BUFFER_LIMIT];
+
+    /** Decoded packet */
+    struct ClemensSmartPortPacket packet;
+};
 
 #ifdef __cplusplus
 }

--- a/clem_smartport.h
+++ b/clem_smartport.h
@@ -34,6 +34,7 @@
 #define CLEM_SMARTPORT_STATUS_CODE_OK            0x00
 #define CLEM_SMARTPORT_STATUS_CODE_BAD_CMD       0x01
 #define CLEM_SMARTPORT_STATUS_CODE_BUS_ERR       0x06
+#define CLEM_SMARTPORT_STATUS_CODE_BAD_CTL       0x21
 #define CLEM_SMARTPORT_STATUS_CODE_IO_ERR        0x27
 #define CLEM_SMARTPORT_STATUS_CODE_INVALID_BLOCK 0x2D
 #define CLEM_SMARTPORT_STATUS_CODE_OFFLINE       0x2f
@@ -79,12 +80,18 @@ struct ClemensSmartPortDevice {
     uint8_t (*do_reset)(struct ClemensSmartPortDevice *context, unsigned delta_ns);
     /** Read a block from the device and store into packet when response state is returned*/
     uint8_t (*do_read_block)(struct ClemensSmartPortDevice *context,
-                             struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                             struct ClemensSmartPortPacket *packet, unsigned block_index,
                              unsigned delta_ns);
     /** Write a block to the device and store into packet when response state is returned */
     uint8_t (*do_write_block)(struct ClemensSmartPortDevice *context,
-                              struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                              struct ClemensSmartPortPacket *packet, unsigned block_index,
                               unsigned delta_ns);
+    /** Retrieve a status block from the device */
+    uint8_t (*do_status)(struct ClemensSmartPortDevice *context,
+                         struct ClemensSmartPortPacket *packet, uint8_t status, unsigned delta_ns);
+    /** Retrieve a status block from the device */
+    uint8_t (*do_format)(struct ClemensSmartPortDevice *context,
+                         struct ClemensSmartPortPacket *packet, unsigned delta_ns);
 };
 
 /**

--- a/clem_types.h
+++ b/clem_types.h
@@ -324,7 +324,7 @@ struct ClemensDeviceIWM {
     /** Drive I/O */
     unsigned io_flags;  /**< Disk port I/O flags */
     unsigned out_phase; /**< PH0-PH3 bits sent to drive */
-    bool enable2;       /**< ENABLE2 line */
+    bool enable2;       /**< Disk II disabled (enable2 high) */
 
     /** Internal Registers */
     uint8_t data;          /**< IO switch data (D0-D7) */

--- a/clem_types.h
+++ b/clem_types.h
@@ -2,6 +2,7 @@
 #define CLEM_TYPES_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "clem_defs.h"

--- a/clem_types.h
+++ b/clem_types.h
@@ -6,6 +6,7 @@
 
 #include "clem_defs.h"
 #include "clem_disk.h"
+#include "clem_smartport.h"
 
 typedef struct ClemensMachine ClemensMachine;
 typedef void (*LoggerFn)(int level, ClemensMachine *machine, const char *msg);

--- a/clem_types.h
+++ b/clem_types.h
@@ -390,9 +390,21 @@ struct ClemensDrive {
     unsigned random_bit_index;
 };
 
+struct ClemensSmartPortUnit {
+    /** A unique (to the emulator) ID Identifying the Smartport device
+        implementation.   This in tandem with `device` is the custom state
+        implemented for the device (i.e A specific HD brand, etc). */
+    unsigned device_id;
+    /** Device implemented in this unit.  This must be provided at emulator startup */
+    void *device;
+    /** The UnitID Assigned by the host as sent via the ID Definition command*/
+    uint8_t unit_id;
+};
+
 struct ClemensDriveBay {
     struct ClemensDrive slot5[2];
     struct ClemensDrive slot6[2];
+    struct ClemensSmartPortUnit smartport[1];
 };
 
 /**

--- a/clem_types.h
+++ b/clem_types.h
@@ -394,7 +394,7 @@ struct ClemensDrive {
 struct ClemensDriveBay {
     struct ClemensDrive slot5[2];
     struct ClemensDrive slot6[2];
-    struct ClemensSmartPortUnit smartport[1];
+    struct ClemensSmartPortUnit smartport[CLEM_SMARTPORT_DRIVE_LIMIT];
 };
 
 /**

--- a/clem_types.h
+++ b/clem_types.h
@@ -390,17 +390,6 @@ struct ClemensDrive {
     unsigned random_bit_index;
 };
 
-struct ClemensSmartPortUnit {
-    /** A unique (to the emulator) ID Identifying the Smartport device
-        implementation.   This in tandem with `device` is the custom state
-        implemented for the device (i.e A specific HD brand, etc). */
-    unsigned device_id;
-    /** Device implemented in this unit.  This must be provided at emulator startup */
-    void *device;
-    /** The UnitID Assigned by the host as sent via the ID Definition command*/
-    uint8_t unit_id;
-};
-
 struct ClemensDriveBay {
     struct ClemensDrive slot5[2];
     struct ClemensDrive slot6[2];

--- a/clem_types.h
+++ b/clem_types.h
@@ -454,6 +454,7 @@ typedef struct ClemensMMIO {
     uint32_t emulator_detect;   // used for the c04f emulator test (state)
     uint8_t new_video_c029;     // see kClemensMMIONewVideo_xxx
     uint8_t speed_c036;         // see kClemensMMIOSpeed_xxx
+    uint8_t fpi_ram_bank_count; // the number of RAM banks available to the memory mapper
 
     clem_clocks_duration_t clocks_step_mega2;
     uint64_t mega2_cycles;            // number of mega2 pulses/ticks since startup

--- a/docs/Smartport.md
+++ b/docs/Smartport.md
@@ -2,7 +2,9 @@
 
 All disk I/O calls from ProDOS or GS/OS, regardless of them targeting a native
 ProDOS block device (i.e. the Apple Disk 3.5") or a Smartport device, use the
-Smartport call interface.
+Slot 5 MLI.   This MLI provides two entry points for operating systems or
+applications that bypass the ProDOS application layer; the ProDOS and Smartport
+device drivers.
 
 Under the hood, these calls are forwarded to the appropriate firmware handling
 either ProDOS block devices or the Smartport device.  On Port 5 for example,
@@ -11,34 +13,115 @@ located in the $C500 block (see the Apple IIgs Firmware Reference Chapter 7 for
 specifics.)
 
 From here on, we'll assume calls are made using entry points at the above
-mentioned $C500 firmware space.
+mentioned $C500 firmware space.  Also this document focuses on devices attached
+to an Apple IIgs, but it's likely most of this is applicable to older Apple IIs
+with relevant firmware and or cards.
 
-## From IWM to Device
 
-Since the internal firmware at $C500 interfaces with the disk I/O physical port
-using the IWM IC, the emulator will handle calls to various drives at the
-same emulator subsystem (located at `clem_iwm.c`.)
+## Disk I/O and the IWM In a Nutshell
 
-Traditional disk devices on the Apple II offloaded most of its controller
-logic to application code.  The application code operated these disks using
-memory mapped I/O operations that in turn controlled the IWM.  Finally the IWM
-sent signals to the disk port and to the simple (a.k.a 'dumb') controller IC on
-the Disk II which managed the stepper motor that controlled the drive arm as
-well as the spindle motor.
+Later Apple II hardware support a slot-agnostic interface to devices physically
+connected to the external disk I/O port.  Apple //c and IIgs systems supply this
+physical port to daisy-chain both 5.25" and 3.5" drives.  For the //c this is
+restrict to the Unidisk 3.5" due to a lack of 'fast' access.
 
-The Apple Disk 3.5" introduced *slightly* more complex controller logic on the
-drive-side.  Commands were sent to the disk drive through a combination of
-setting the legacy stepper motor + drive select pins.  These commands moved
-the drive arm and operated the spindle like the legacy Disk II.  Added commands
-handled disk ejection and a few other queries.
+```
+              -----
++-----+       | P |     +-------------+                  +--------------------+
+| IWM |.......| O |=====| Apple       |==================| 5.25" Disk II      |
+|     |       | R |     | 3.5" Drives |                  | Drives             |
++-----+       | T |     +-------------+                  +--------------------+
+              -----
+```
 
-When Smartport devices were introduced, the hardware designers had to leverage
-the existing IWM.  So through a combination of certain IWM state sets and
-commands, applications can read data from or write data to a Smartport device
-without conflicting with I/O to the Apple Disk 3.5 (on Port 5.)
+Application programmers used to thinking of "Slots" 5 and 6 as physical card
+slots instead should consider these *virtual* slots accessed via the IWM
+(Integrated Woz Machine).  The IWM itself is evenetually connected to the Mega
+II/MMC which allows applications to control disk I/O access independent of
+physical port.
 
-This approach works - but has problems.  For one, in some cases this approach
-won't work on slot 6 where legacy Disk II 5.25" disk drives operate.  Because
-most 5.25" software employs copy protection by operating the drive arm in
-"non-standard" ways, certain stepper motor bit combinations must work on
-such drives that would otherwise be forwarded to a Smartport device.
+Programmers used to accessing Disk I/O via the original `BIT $C080,X` type
+instructions where `X=#$60` can continue to do so (where signals are passed
+to the IWM vs the Disk I/O card.).  This is how old Apple II+/IIe software can
+run on a IIc and IIgs without physical card slots for Disk I/O.
+
+## Smartport In a Nutshell
+
+Like IDE, SCSI and later USB, Smartport allows multiple devices to coexist on
+the same physical bus.
+
+Smartport is a legacy Apple standard for sending I/O between several devices
+on a single physical disk port.  As far as I know was used solely on Apple II
+devices specifically to allow Apple IIs to use multiple drive types beyond the
+Disk II (and Apple 3.5 Disk.)  At the same time, with Smartport it is possible
+for all of these drive types to coexist on the same physical connection, despite
+Disk II devices themselves not being Smartport compliant.
+
+Unlike Disk II which offers direct access to the drive's motor and arm,
+Smartport aware devices typically implement a series of commands on the device
+that handle this for the host.   These commands are issued by the OS to read,
+write data and query state.
+
+NOTE: Certain devices like the Apple 3.5" operate outside of the Smartport
+standard.  They have some "smart" features yet operate with less overhead and
+simpler onboard logic that Smartport devices like the Unidisk 3.5.
+
+
+## How Smartport Works
+
+Smartport relies on compliant devices that cooperate with others on the
+physical disk port.  Devices are daisy-chained as described below.  This
+chaining allows devices farther up the chain to block I/O to devices down the
+chain.
+
+```
+              -----
++-----+       | P |     +-------------+    +-----------+      +---------------+
+| IWM |.......| O |=====| Apple       |====| Smartport |======| 5.25" Disk II |
+|     |       | R |     | 3.5" Drives |    | Drive     |      | Drives        |
++-----+       | T |     +-------------+    +-----------+      +---------------+
+              -----
+```
+
+For example, when the Smartport Drive is functioning, I/O to the Disk II is
+blocked until the Smartport Drive releases its lock on the I/O lines.  As a
+consequence, this  means that any device before the Smartport can intercept
+communication on the bus.  This limitation requires that the host strictly
+controls what device is active and when it's accessed.  This control logic
+exists on the Smartport firmware or software device driver.  ProDOS by design
+abstracts the enumeration of such devices, and its arbitration between user and
+firmware.
+
+The firmware sends signals on the bus to inform Smartport devices that it's
+ready to read or write data.  These signals are specifically selected to *not*
+conflict with Disk II operation.  When the Smartport bus comes online, the
+signals that communicate this state have no practical effect on the Disk II
+drive.   The Disk II will not receive signals as long as the bus is held by
+the Smartport device and host.
+
+Note that the IWM uses a special data line to activate the Apple 3.5 Disk.  This
+line was added in later hardware (Apple IIgs and the //c+) to support the
+Apple 3.5 Drive.  Smartport devices generally did not use the 3.5 line and
+in the case of the Disk II was used as a ground line.  Likely other Smartport
+devices do the same.  This is why the Apple 3.5 drives are listed first in the
+daisy chain diagram above as to prevent other devices blocking the 3.5 line
+signal.
+
+This design allows Disk II drives to coexist with Smartport devices.  The
+details of why are discussed in the next section.
+
+## Technical
+
+### Bus Arbitration
+
+### I/O
+
+
+
+## References
+
+Apple IIgs Firmware Reference
+
+Apple IIgs Hardware Reference
+
+http://mirrors.apple2.org.za/apple.cabi.net/FAQs.and.INFO/DiskDrives/drive.order.txt

--- a/docs/Smartport.md
+++ b/docs/Smartport.md
@@ -1,0 +1,44 @@
+# Smartport on the Apple IIgs
+
+All disk I/O calls from ProDOS or GS/OS, regardless of them targeting a native
+ProDOS block device (i.e. the Apple Disk 3.5") or a Smartport device, use the
+Smartport call interface.
+
+Under the hood, these calls are forwarded to the appropriate firmware handling
+either ProDOS block devices or the Smartport device.  On Port 5 for example,
+calls are made to an entry function located somewhere in the internal firmware
+located in the $C500 block (see the Apple IIgs Firmware Reference Chapter 7 for
+specifics.)
+
+From here on, we'll assume calls are made using entry points at the above
+mentioned $C500 firmware space.
+
+## From IWM to Device
+
+Since the internal firmware at $C500 interfaces with the disk I/O physical port
+using the IWM IC, the emulator will handle calls to various drives at the
+same emulator subsystem (located at `clem_iwm.c`.)
+
+Traditional disk devices on the Apple II offloaded most of its controller
+logic to application code.  The application code operated these disks using
+memory mapped I/O operations that in turn controlled the IWM.  Finally the IWM
+sent signals to the disk port and to the simple (a.k.a 'dumb') controller IC on
+the Disk II which managed the stepper motor that controlled the drive arm as
+well as the spindle motor.
+
+The Apple Disk 3.5" introduced *slightly* more complex controller logic on the
+drive-side.  Commands were sent to the disk drive through a combination of
+setting the legacy stepper motor + drive select pins.  These commands moved
+the drive arm and operated the spindle like the legacy Disk II.  Added commands
+handled disk ejection and a few other queries.
+
+When Smartport devices were introduced, the hardware designers had to leverage
+the existing IWM.  So through a combination of certain IWM state sets and
+commands, applications can read data from or write data to a Smartport device
+without conflicting with I/O to the Apple Disk 3.5 (on Port 5.)
+
+This approach works - but has problems.  For one, in some cases this approach
+won't work on slot 6 where legacy Disk II 5.25" disk drives operate.  Because
+most 5.25" software employs copy protection by operating the drive arm in
+"non-standard" ways, certain stepper motor bit combinations must work on
+such drives that would otherwise be forwarded to a Smartport device.

--- a/emulator.h
+++ b/emulator.h
@@ -170,7 +170,11 @@ unsigned clemens_out_hex_data_from_memory(char *hex, const uint8_t *memory,
                                           unsigned out_hex_byte_limit, unsigned adr);
 
 /**
- * @brief Writes memory from the machine to the output buffer in raw bytes
+ * @brief Reads memory from the machine and copies to the output buffer in raw bytes
+ *
+ * This copies memory directly from the RAM bank, bypassing bank mapping (i.e)
+ * bank 0 reads the physical bank 0 and ignores settings such as RAMRD on the
+ * //gs.
  *
  * Note, adr is almost always 0 unless copying a portial bank.   In that case
  * if adr + out_byte_cnt > 64K, this API will copy the data into the out buffer

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -136,7 +136,8 @@ void clemens_remove_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
         return;
     memcpy(device, &mmio->active_drives.smartport[drive_index].device,
            sizeof(struct ClemensSmartPortDevice));
-    memset(device, 0, sizeof(struct ClemensSmartPortDevice));
+    memset(&mmio->active_drives.smartport[drive_index].device, 0,
+           sizeof(struct ClemensSmartPortDevice));
     mmio->active_drives.smartport[drive_index].unit_id = 0;
 }
 

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -117,6 +117,29 @@ bool clemens_eject_disk_async(ClemensMMIO *mmio, enum ClemensDriveType drive_typ
     return true;
 }
 
+bool clemens_assign_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
+                                   struct ClemensSmartPortDevice *device) {
+    if (drive_index >= CLEM_SMARTPORT_DRIVE_LIMIT)
+        return false;
+    memcpy(&mmio->active_drives.smartport[drive_index].device, device,
+           sizeof(struct ClemensSmartPortDevice));
+    return true;
+}
+
+void clemens_remove_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
+                                   struct ClemensSmartPortDevice *device) {
+    if (drive_index >= CLEM_SMARTPORT_DRIVE_LIMIT)
+        return;
+
+    if (mmio->active_drives.smartport[drive_index].device.device_id ==
+        CLEM_SMARTPORT_DEVICE_ID_NONE)
+        return;
+    memcpy(device, &mmio->active_drives.smartport[drive_index].device,
+           sizeof(struct ClemensSmartPortDevice));
+    memset(device, 0, sizeof(struct ClemensSmartPortDevice));
+    mmio->active_drives.smartport[drive_index].unit_id = 0;
+}
+
 ClemensMonitor *clemens_get_monitor(ClemensMonitor *monitor, ClemensMMIO *mmio) {
     struct ClemensVGC *vgc = &mmio->vgc;
 

--- a/emulator_mmio.h
+++ b/emulator_mmio.h
@@ -101,6 +101,36 @@ bool clemens_eject_disk_async(ClemensMMIO *mmio, enum ClemensDriveType drive_typ
                               struct ClemensNibbleDisk *disk);
 
 /**
+ * @brief Assigns a SmartPort device to one of the available SmartPort slots.
+ *
+ * Note, that the any device *contexts* are assumed to be managed by the calling
+ * application.  The device object itself is copied to one of the available slots.
+ *
+ * @param mmio
+ * @param drive_index Always 0 for now
+ * @param device This object is copied into one the available slots
+ * @return true
+ * @return false
+ */
+bool clemens_assign_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
+                                   struct ClemensSmartPortDevice *device);
+
+/**
+ * @brief Unassigned the designated SmartPort device.
+ *
+ * The device data is copied into the passed device struct and cleared from the
+ * active drive bay.
+ *
+ * @param mmio
+ * @param drive_index The device at this index is removed.
+ * @param device The assigned device is copied into this structure.
+ * @return true
+ * @return false
+ */
+void clemens_remove_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
+                                   struct ClemensSmartPortDevice *device);
+
+/**
  * @brief Forwards input from ths host machine to the ADB
  *
  * @param mmio

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(clemens_iigs
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_import_disk.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_program_trace.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_serializer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clem_smartport_disk.cpp"
     ${FMT_SOURCES}
     ${SOKOL_SOURCES}
     ${IMGUI_SOURCES})

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(clemens_iigs
         clemens_65816_render
         clemens_65816_serializer
         clemens_65816_iocards
+        clemens_65816_smartport_devices
         imgui)
 
 target_compile_features( clemens_iigs PRIVATE cxx_std_17 )

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -685,6 +685,8 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
         }
     }
 
+    mmio_.active_drives.smartport[0].device_id = CLEM_SMARTPORT_DEVICE_ID_REFERENCE;
+
     fmt::print("Starting backend thread.\n");
 
     ClemensCard *mockingboard = findMockingboardCard(&mmio_);

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -685,7 +685,7 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
         }
     }
 
-    mmio_.active_drives.smartport[0].device_id = CLEM_SMARTPORT_DEVICE_ID_REFERENCE;
+    mmio_.active_drives.smartport[0].device.device_id = CLEM_SMARTPORT_DEVICE_ID_REFERENCE;
 
     fmt::print("Starting backend thread.\n");
 

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -1170,7 +1170,7 @@ cinek::ByteBuffer ClemensBackend::loadROM(const char *romPathname) {
 }
 
 void ClemensBackend::initApple2GS() {
-    const unsigned kFPIBankCount = CLEM_IIGS_FPI_MAIN_RAM_BANK_COUNT;
+    const unsigned kFPIBankCount = CLEM_IIGS_FPI_MAIN_RAM_BANK_LIMIT;
     const uint32_t kClocksPerFastCycle = CLEM_CLOCKS_FAST_CYCLE;
     const uint32_t kClocksPerSlowCycle = CLEM_CLOCKS_MEGA2_CYCLE;
     int result =
@@ -1179,7 +1179,7 @@ void ClemensBackend::initApple2GS() {
                      slabMemory_.allocate(CLEM_IIGS_BANK_SIZE),
                      slabMemory_.allocate(CLEM_IIGS_BANK_SIZE * kFPIBankCount), kFPIBankCount);
     clem_mmio_init(&mmio_, &machine_.dev_debug, machine_.mem.bank_page_map,
-                   machine_.tspec.clocks_step_mega2, slabMemory_.allocate(2048 * 7));
+                   machine_.tspec.clocks_step_mega2, slabMemory_.allocate(2048 * 7), kFPIBankCount);
     if (result < 0) {
         fmt::print("Clemens library failed to initialize with err code (%d)\n", result);
         return;

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -153,6 +153,7 @@ class ClemensBackend {
     std::array<ClemensBackendDiskDriveState, 1> smartPortDrives_;
     std::array<ClemensSmartPortDisk, 1> smartPortDisks_;
 
+    uint64_t nextTraceSeq_;
     std::unique_ptr<ClemensProgramTrace> programTrace_;
 
     int logLevel_;

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -2,6 +2,7 @@
 #define CLEM_HOST_BACKEND_HPP
 
 #include "clem_host_shared.hpp"
+#include "clem_smartport_disk.hpp"
 
 #include "cinek/buffer.hpp"
 #include "cinek/fixedstack.hpp"
@@ -108,6 +109,10 @@ class ClemensBackend {
     bool loadDisk(ClemensDriveType driveType, bool allowBlank);
     bool saveDisk(ClemensDriveType driveType);
     void resetDisk(ClemensDriveType driveType);
+
+    void loadSmartPortDisk(unsigned driveIndex);
+    bool saveSmartPortDisk(unsigned driveIndex);
+
     cinek::ByteBuffer loadROM(const char *romPathname);
 
     //  TODO: These methods could be moved into a subclass as they are specific
@@ -145,6 +150,8 @@ class ClemensBackend {
     std::array<ClemensWOZDisk, kClemensDrive_Count> diskContainers_;
     std::array<ClemensNibbleDisk, kClemensDrive_Count> disks_;
     std::array<ClemensBackendDiskDriveState, kClemensDrive_Count> diskDrives_;
+    std::array<ClemensBackendDiskDriveState, 1> smartPortDrives_;
+    std::array<ClemensSmartPortDisk, 1> smartPortDisks_;
 
     std::unique_ptr<ClemensProgramTrace> programTrace_;
 

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -590,10 +590,11 @@ ClemensFrontend::ClemensFrontend(const cinek::ByteBuffer &systemFontLoBuffer,
     thisFrameAudioBuffer_ = cinek::ByteBuffer(new uint8_t[audioBufferSize], audioBufferSize);
 
     config_.cardNames[3] = kClemensCardMockingboardName; // load the mockingboard
+
+    config_.diskLibraryRootPath = diskLibraryRootPath_;
     // TODO: This should be selectable like regular drives - this will require some
     //       UI to make it happen
-    config_.smartPortDriveStates[0].imagePath =
-        (std::filesystem::path(diskLibraryRootPath_) / "smartport.2mg").string();
+    config_.smartPortDriveStates[0].imagePath = std::filesystem::path("smartport.2mg").string();
     backend_ = createBackend();
 
     debugMemoryEditor_.ReadFn = &ClemensFrontend::imguiMemoryEditorRead;
@@ -1308,7 +1309,8 @@ void ClemensFrontend::doMachineDiskSelection(ClemensDriveType driveType) {
             diskLibrary_.iterate([&selectedPath](const ClemensDiskLibrary::DiskEntry &entry) {
                 auto relativePath = entry.location.parent_path().filename() / entry.location.stem();
                 if (ImGui::Selectable(relativePath.string().c_str())) {
-                    selectedPath = entry.location.string();
+                    selectedPath =
+                        entry.location.parent_path().filename() / entry.location.filename();
                 }
             });
             if (!selectedPath.empty()) {

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -590,7 +590,10 @@ ClemensFrontend::ClemensFrontend(const cinek::ByteBuffer &systemFontLoBuffer,
     thisFrameAudioBuffer_ = cinek::ByteBuffer(new uint8_t[audioBufferSize], audioBufferSize);
 
     config_.cardNames[3] = kClemensCardMockingboardName; // load the mockingboard
-    config_.smartPortDriveStates[0].imagePath = "test.2mg";
+    // TODO: This should be selectable like regular drives - this will require some
+    //       UI to make it happen
+    config_.smartPortDriveStates[0].imagePath =
+        (std::filesystem::path(diskLibraryRootPath_) / "smartport.2mg").string();
     backend_ = createBackend();
 
     debugMemoryEditor_.ReadFn = &ClemensFrontend::imguiMemoryEditorRead;

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -590,7 +590,7 @@ ClemensFrontend::ClemensFrontend(const cinek::ByteBuffer &systemFontLoBuffer,
     thisFrameAudioBuffer_ = cinek::ByteBuffer(new uint8_t[audioBufferSize], audioBufferSize);
 
     config_.cardNames[3] = kClemensCardMockingboardName; // load the mockingboard
-
+    config_.smartPortDriveStates[0].imagePath = "test.2mg";
     backend_ = createBackend();
 
     debugMemoryEditor_.ReadFn = &ClemensFrontend::imguiMemoryEditorRead;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -42,6 +42,7 @@ struct ClemensBackendDiskDriveState {
 struct ClemensBackendConfig {
     enum class Type { Apple2GS };
     std::array<ClemensBackendDiskDriveState, kClemensDrive_Count> diskDriveStates;
+    std::array<ClemensBackendDiskDriveState, 1> smartPortDriveStates;
     std::array<std::string, 7> cardNames;
     std::vector<ClemensBackendBreakpoint> breakpoints;
     unsigned audioSamplesPerSecond;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -41,6 +41,7 @@ struct ClemensBackendDiskDriveState {
 
 struct ClemensBackendConfig {
     enum class Type { Apple2GS };
+    std::string diskLibraryRootPath;
     std::array<ClemensBackendDiskDriveState, kClemensDrive_Count> diskDriveStates;
     std::array<ClemensBackendDiskDriveState, 1> smartPortDriveStates;
     std::array<std::string, 7> cardNames;

--- a/host/clem_host_utils.cpp
+++ b/host/clem_host_utils.cpp
@@ -6,70 +6,66 @@
 
 static uint32_t kAddrModeSizes[kClemensCPUAddrMode_Count];
 
-
-void ClemensTraceExecutedInstruction::initialize()
-{
-  // these are 8-bit sizes that are augmented by the instruction opcode width
-  // (opc8)
-  kAddrModeSizes[kClemensCPUAddrMode_None]                        = 1;
-  kAddrModeSizes[kClemensCPUAddrMode_Immediate]                   = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_Absolute]                    = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_AbsoluteLong]                = 4;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage]                  = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPageIndirect]          = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPageIndirectLong]      = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_Absolute_X]                  = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_AbsoluteLong_X]              = 4;
-  kAddrModeSizes[kClemensCPUAddrMode_Absolute_Y]                  = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage_X]                = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage_Y]                = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage_X_Indirect]       = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage_Indirect_Y]       = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_DirectPage_IndirectLong_Y]   = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_MoveBlock]                   = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_Stack_Relative]              = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_Stack_Relative_Indirect_Y]   = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_PCRelative]                  = 2;
-  kAddrModeSizes[kClemensCPUAddrMode_PCRelativeLong]              = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_PC]                          = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_PCIndirect]                  = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_PCIndirect_X]                = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_PCLong]                      = 4;
-  kAddrModeSizes[kClemensCPUAddrMode_PCLongIndirect]              = 3;
-  kAddrModeSizes[kClemensCPUAddrMode_Operand]                     = 2;
+void ClemensTraceExecutedInstruction::initialize() {
+    // these are 8-bit sizes that are augmented by the instruction opcode width
+    // (opc8)
+    kAddrModeSizes[kClemensCPUAddrMode_None] = 1;
+    kAddrModeSizes[kClemensCPUAddrMode_Immediate] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_Absolute] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_AbsoluteLong] = 4;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPageIndirect] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPageIndirectLong] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_Absolute_X] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_AbsoluteLong_X] = 4;
+    kAddrModeSizes[kClemensCPUAddrMode_Absolute_Y] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage_X] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage_Y] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage_X_Indirect] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage_Indirect_Y] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_DirectPage_IndirectLong_Y] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_MoveBlock] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_Stack_Relative] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_Stack_Relative_Indirect_Y] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_PCRelative] = 2;
+    kAddrModeSizes[kClemensCPUAddrMode_PCRelativeLong] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_PC] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_PCIndirect] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_PCIndirect_X] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_PCLong] = 4;
+    kAddrModeSizes[kClemensCPUAddrMode_PCLongIndirect] = 3;
+    kAddrModeSizes[kClemensCPUAddrMode_Operand] = 2;
 }
 
+ClemensTraceExecutedInstruction &
+ClemensTraceExecutedInstruction::fromInstruction(const ClemensInstruction &instruction,
+                                                 const char *oper) {
+    strncpy(opcode, instruction.desc->name, sizeof(opcode));
+    strncpy(operand, oper, sizeof(operand));
+    cycles_spent = instruction.cycles_spent;
+    pc = (uint32_t(instruction.pbr) << 16) | instruction.addr;
+    size = kAddrModeSizes[instruction.desc->addr_mode];
 
-ClemensTraceExecutedInstruction& ClemensTraceExecutedInstruction::fromInstruction(
-  const ClemensInstruction& instruction,
-  const char* oper
-) {
-  strncpy(opcode, instruction.desc->name, sizeof(opcode));
-  strncpy(operand, oper, sizeof(operand));
-  cycles_spent = instruction.cycles_spent;
-  pc = (uint32_t(instruction.pbr) << 16) | instruction.addr;
-  size = kAddrModeSizes[instruction.desc->addr_mode];
-
-  return *this;
+    return *this;
 }
 
-
-ClemensCard* createCard(const char* name) {
-  ClemensCard* card = NULL;
-  if (!strcmp(name, kClemensCardMockingboardName)) {
-    card = new ClemensCard;
-    memset(card, 0, sizeof(*card));
-    clem_card_mockingboard_initialize(card);
-  }
-  return card;
+ClemensCard *createCard(const char *name) {
+    ClemensCard *card = NULL;
+    if (!strcmp(name, kClemensCardMockingboardName)) {
+        card = new ClemensCard;
+        memset(card, 0, sizeof(*card));
+        clem_card_mockingboard_initialize(card);
+    }
+    return card;
 }
 
-void destroyCard(ClemensCard* card) {
-  //  use card->io_name() to identify
-  if (!card) return;
-  const char* name = card->io_name(card->context);
-  if (!strcmp(name, kClemensCardMockingboardName)) {
-    clem_card_mockingboard_uninitialize(card);
-  }
-  delete card;
+void destroyCard(ClemensCard *card) {
+    //  use card->io_name() to identify
+    if (!card)
+        return;
+    const char *name = card->io_name(card->context);
+    if (!strcmp(name, kClemensCardMockingboardName)) {
+        clem_card_mockingboard_uninitialize(card);
+    }
+    delete card;
 }

--- a/host/clem_host_utils.hpp
+++ b/host/clem_host_utils.hpp
@@ -6,20 +6,20 @@
 #include <cstdint>
 
 struct ClemensTraceExecutedInstruction {
-  uint32_t cycles_spent;
-  uint32_t pc;
-  uint16_t size;
-  char opcode[4];
-  char operand[24];
+    uint64_t seq;
+    uint32_t cycles_spent;
+    uint32_t pc;
+    uint16_t size;
+    char opcode[4];
+    char operand[24];
 
-  static void initialize();
+    static void initialize();
 
-  ClemensTraceExecutedInstruction& fromInstruction(
-    const ClemensInstruction& instruction,
-    const char* operand);
+    ClemensTraceExecutedInstruction &fromInstruction(const ClemensInstruction &instruction,
+                                                     const char *operand);
 };
 
-ClemensCard* createCard(const char* name);
-void destroyCard(ClemensCard* card);
+ClemensCard *createCard(const char *name);
+void destroyCard(ClemensCard *card);
 
 #endif

--- a/host/clem_import_disk.cpp
+++ b/host/clem_import_disk.cpp
@@ -12,17 +12,17 @@
 
 size_t ClemensDiskImporter::calculateRequiredMemory(ClemensDriveType driveType,
                                                     size_t count) const {
-  size_t size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType) * count;
-  assert(size > 0);
-  // account for larger source disk input data - this is probably overkill but
-  // but should cover all edge cases
-  size += (size * 2);
-  // account for metadata in the output 2mgs - again overkill
-  size += (count * 1024);
-  // the actual input disk records
-  size += CK_ALIGN_SIZE_TO_ARCH(sizeof(DiskRecord) * count);
-  size += CK_ALIGN_SIZE_TO_ARCH(sizeof(ClemensNibbleDisk) * count);
-  return size;
+    size_t size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType) * count;
+    assert(size > 0);
+    // account for larger source disk input data - this is probably overkill but
+    // but should cover all edge cases
+    size += (size * 2);
+    // account for metadata in the output 2mgs - again overkill
+    size += (count * 1024);
+    // the actual input disk records
+    size += CK_ALIGN_SIZE_TO_ARCH(sizeof(DiskRecord) * count);
+    size += CK_ALIGN_SIZE_TO_ARCH(sizeof(ClemensNibbleDisk) * count);
+    return size;
 }
 
 ClemensDiskImporter::ClemensDiskImporter(ClemensDriveType driveType, size_t count)
@@ -33,147 +33,147 @@ ClemensDiskImporter::ClemensDiskImporter(ClemensDriveType driveType, size_t coun
 ClemensDiskImporter::~ClemensDiskImporter() { free(memory_.getHead()); }
 
 ClemensWOZDisk *ClemensDiskImporter::add(std::string path) {
-  std::filesystem::path fsPath = path;
-  std::ifstream input(fsPath, std::ios_base::in | std::ios_base::binary);
-  auto fsPathExtension = fsPath.extension();
-  if (input.fail()) {
-    return nullptr;
-  }
+    std::filesystem::path fsPath = path;
+    std::ifstream input(fsPath, std::ios_base::in | std::ios_base::binary);
+    auto fsPathExtension = fsPath.extension();
+    if (input.fail()) {
+        return nullptr;
+    }
 
-  input.seekg(0, std::ios_base::end);
-  size_t inputImageSize = input.tellg();
-  if (inputImageSize > memory_.remaining()) {
-    return nullptr;
-  }
+    input.seekg(0, std::ios_base::end);
+    size_t inputImageSize = input.tellg();
+    if (inputImageSize > memory_.remaining()) {
+        return nullptr;
+    }
 
-  uint8_t *bits_start = (uint8_t *)memory_.allocate(inputImageSize);
-  uint8_t *bits_end = bits_start + inputImageSize;
-  input.seekg(0);
-  input.read((char *)bits_start, inputImageSize);
-  if (input.fail() || input.bad())
-    return nullptr;
+    uint8_t *bits_start = (uint8_t *)memory_.allocate(inputImageSize);
+    uint8_t *bits_end = bits_start + inputImageSize;
+    input.seekg(0);
+    input.read((char *)bits_start, inputImageSize);
+    if (input.fail() || input.bad())
+        return nullptr;
 
-  DiskRecord *record = nullptr;
-  if (fsPathExtension == ".woz") {
-    record = parseWOZ(bits_start, bits_end);
-  } else if (fsPathExtension == ".2mg") {
-    record = parse2IMG(bits_start, bits_end);
-  } else if (fsPathExtension == ".dsk" || fsPathExtension == ".do") {
-    record = parseImage(bits_start, bits_end, CLEM_2IMG_FORMAT_DOS);
-  } else if (fsPathExtension == ".po") {
-    record = parseImage(bits_start, bits_end, CLEM_2IMG_FORMAT_PRODOS);
-  }
-  if (!record)
-    return nullptr;
-  auto fsName = fsPath.filename();
-  fsName.string().copy(record->name, sizeof(record->name), 0);
-  if (!head_) {
-    head_ = record;
+    DiskRecord *record = nullptr;
+    if (fsPathExtension == ".woz") {
+        record = parseWOZ(bits_start, bits_end);
+    } else if (fsPathExtension == ".2mg") {
+        record = parse2IMG(bits_start, bits_end);
+    } else if (fsPathExtension == ".dsk" || fsPathExtension == ".do") {
+        record = parseImage(bits_start, bits_end, CLEM_2IMG_FORMAT_DOS);
+    } else if (fsPathExtension == ".po") {
+        record = parseImage(bits_start, bits_end, CLEM_2IMG_FORMAT_PRODOS);
+    }
+    if (!record)
+        return nullptr;
+    auto fsName = fsPath.filename();
+    fsName.string().copy(record->name, sizeof(record->name), 0);
+    if (!head_) {
+        head_ = record;
+        tail_ = record;
+    } else {
+        tail_->next = record;
+    }
     tail_ = record;
-  } else {
-    tail_->next = record;
-  }
-  tail_ = record;
-  return &record->disk;
+    return &record->disk;
 }
 
 auto ClemensDiskImporter::parseWOZ(uint8_t *bits_data, uint8_t *bits_data_end) -> DiskRecord * {
-  DiskRecord *record = memory_.newItem<DiskRecord>();
-  if (!record)
-    return nullptr;
+    DiskRecord *record = memory_.newItem<DiskRecord>();
+    if (!record)
+        return nullptr;
 
-  ClemensWOZDisk *sourceDisk = &record->disk;
-  sourceDisk->nib = memory_.newItem<ClemensNibbleDisk>();
-  if (!sourceDisk->nib)
-    return nullptr;
-  size_t bits_size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType_);
-  sourceDisk->nib->bits_data = (uint8_t *)memory_.allocate(bits_size);
-  sourceDisk->nib->bits_data_end = sourceDisk->nib->bits_data + bits_size;
+    ClemensWOZDisk *sourceDisk = &record->disk;
+    sourceDisk->nib = memory_.newItem<ClemensNibbleDisk>();
+    if (!sourceDisk->nib)
+        return nullptr;
+    size_t bits_size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType_);
+    sourceDisk->nib->bits_data = (uint8_t *)memory_.allocate(bits_size);
+    sourceDisk->nib->bits_data_end = sourceDisk->nib->bits_data + bits_size;
 
-  cinek::ConstRange<uint8_t> buffer(bits_data, bits_data_end);
-  if (!ClemensDiskUtilities::parseWOZ(sourceDisk, buffer)) {
-    return nullptr;
-  }
-  record->name[0] = '\0';
-  record->next = nullptr;
-  return record;
+    cinek::ConstRange<uint8_t> buffer(bits_data, bits_data_end);
+    if (!ClemensDiskUtilities::parseWOZ(sourceDisk, buffer)) {
+        return nullptr;
+    }
+    record->name[0] = '\0';
+    record->next = nullptr;
+    return record;
 }
 
 // TODO: move equivalent 2IMG, etc parse utilities into ClemensDiskUtilities
 
 auto ClemensDiskImporter::parse2IMG(uint8_t *bits_data, uint8_t *bits_data_end) -> DiskRecord * {
-  struct Clemens2IMGDisk disk {};
-  disk.nib = memory_.newItem<ClemensNibbleDisk>();
-  if (!clem_2img_parse_header(&disk, bits_data, bits_data_end))
-    return nullptr;
+    struct Clemens2IMGDisk disk {};
+    disk.nib = memory_.newItem<ClemensNibbleDisk>();
+    if (!clem_2img_parse_header(&disk, bits_data, bits_data_end))
+        return nullptr;
 
-  return nibblizeImage(&disk);
+    return nibblizeImage(&disk);
 }
 
 auto ClemensDiskImporter::parseImage(uint8_t *bits_data, uint8_t *bits_data_end, unsigned type)
     -> DiskRecord * {
-  struct Clemens2IMGDisk disk {};
-  disk.nib = memory_.newItem<ClemensNibbleDisk>();
-  if (!clem_2img_generate_header(&disk, type, bits_data, bits_data_end))
-    return nullptr;
+    struct Clemens2IMGDisk disk {};
+    disk.nib = memory_.newItem<ClemensNibbleDisk>();
+    if (!clem_2img_generate_header(&disk, type, bits_data, bits_data_end, 0))
+        return nullptr;
 
-  return nibblizeImage(&disk);
+    return nibblizeImage(&disk);
 }
 
 auto ClemensDiskImporter::nibblizeImage(Clemens2IMGDisk *disk) -> DiskRecord * {
-  if (!disk->nib)
-    return nullptr;
+    if (!disk->nib)
+        return nullptr;
 
-  size_t bits_size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType_);
-  disk->nib->bits_data = (uint8_t *)memory_.allocate(bits_size);
-  disk->nib->bits_data_end = disk->nib->bits_data + bits_size;
-  if (disk->block_count <= 280 || (disk->data_end - disk->data) <= 140 * 1024) {
-    disk->nib->disk_type = CLEM_DISK_TYPE_5_25;
-  } else if (disk->block_count <= 1600 || (disk->data_end - disk->data) <= 800 * 1024) {
-    disk->nib->disk_type = CLEM_DISK_TYPE_3_5;
-  } else {
-    disk->nib->disk_type = CLEM_DISK_TYPE_NONE;
-  }
+    size_t bits_size = ClemensDiskUtilities::calculateNibRequiredMemory(driveType_);
+    disk->nib->bits_data = (uint8_t *)memory_.allocate(bits_size);
+    disk->nib->bits_data_end = disk->nib->bits_data + bits_size;
+    if (disk->block_count <= 280 || (disk->data_end - disk->data) <= 140 * 1024) {
+        disk->nib->disk_type = CLEM_DISK_TYPE_5_25;
+    } else if (disk->block_count <= 1600 || (disk->data_end - disk->data) <= 800 * 1024) {
+        disk->nib->disk_type = CLEM_DISK_TYPE_3_5;
+    } else {
+        disk->nib->disk_type = CLEM_DISK_TYPE_NONE;
+    }
 
-  if (!clem_2img_nibblize_data(disk))
-    return nullptr;
+    if (!clem_2img_nibblize_data(disk))
+        return nullptr;
 
-  DiskRecord *record = memory_.newItem<DiskRecord>();
-  if (!record)
-    return nullptr;
+    DiskRecord *record = memory_.newItem<DiskRecord>();
+    if (!record)
+        return nullptr;
 
+    ClemensDiskUtilities::createWOZ(&record->disk, disk->nib);
 
-  ClemensDiskUtilities::createWOZ(&record->disk, disk->nib);
-
-  record->name[0] = '\0';
-  record->next = nullptr;
-  return record;
+    record->name[0] = '\0';
+    record->next = nullptr;
+    return record;
 }
 
 bool ClemensDiskImporter::build(std::string outputDirPath) {
-  unsigned scratchBufferSize = 0;
-  for (DiskRecord *record = head_; record; record = record->next) {
-    scratchBufferSize = std::max(scratchBufferSize,
-                                 record->disk.max_track_size_bytes * record->disk.nib->track_count);
-  }
-  scratchBufferSize += 4096;
+    unsigned scratchBufferSize = 0;
+    for (DiskRecord *record = head_; record; record = record->next) {
+        scratchBufferSize = std::max(scratchBufferSize, record->disk.max_track_size_bytes *
+                                                            record->disk.nib->track_count);
+    }
+    scratchBufferSize += 4096;
 
-  uint8_t *writeBuffer = reinterpret_cast<uint8_t *>(memory_.allocate(scratchBufferSize));
-  for (DiskRecord *record = head_; record; record = record->next) {
-    size_t writeOutCount = scratchBufferSize;
-    if (!clem_woz_serialize(&record->disk, writeBuffer, &writeOutCount)) {
-      return false;
+    uint8_t *writeBuffer = reinterpret_cast<uint8_t *>(memory_.allocate(scratchBufferSize));
+    for (DiskRecord *record = head_; record; record = record->next) {
+        size_t writeOutCount = scratchBufferSize;
+        if (!clem_woz_serialize(&record->disk, writeBuffer, &writeOutCount)) {
+            return false;
+        }
+        auto outputFileName =
+            std::filesystem::path(std::string(record->name)).stem().string() + ".woz";
+        auto outputFilePath = std::filesystem::path(outputDirPath) / outputFileName;
+        std::ofstream out(outputFilePath, std::ios_base::out | std::ios_base::binary);
+        if (out.fail()) {
+            return false;
+        }
+        out.write((char *)writeBuffer, writeOutCount);
+        if (out.fail() || out.bad()) {
+            return false;
+        }
     }
-    auto outputFileName = std::filesystem::path(std::string(record->name)).stem().string() + ".woz";
-    auto outputFilePath = std::filesystem::path(outputDirPath) / outputFileName;
-    std::ofstream out(outputFilePath, std::ios_base::out | std::ios_base::binary);
-    if (out.fail()) {
-      return false;
-    }
-    out.write((char *)writeBuffer, writeOutCount);
-    if (out.fail() || out.bad()) {
-      return false;
-    }
-  }
-  return true;
+    return true;
 }

--- a/host/clem_program_trace.cpp
+++ b/host/clem_program_trace.cpp
@@ -3,302 +3,277 @@
 #include "clem_mmio_defs.h"
 
 #include <array>
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 
 #include <inttypes.h>
 
-static std::array<const char*, 0x20> kToolsetNames = {
-  "Tool Locator",
-  "Memory Manager",
-  "Miscellaneous",
-  "QuickDraw II",
-  "Desk Manager",
-  "Event Manager",
-  "Scheduler",
-  "Sound",
-  "Apple Desktop Bus",
-  "SANE",
-  "Integer Math",
-  "Text Tool",
-  "Reserved for Apple use",
-  "Window Manager",
-  "Menu Manager",
-  "Control Manager",
-  "Loader",
-  "QuickDraw II Auxillary",
-  "Print Manager",
-  "LineEdit",
-  "Dialog Manager",
-  "Scrap Manager",
-  "Standard File Operations",
-  "Disk Utilities",
-  "Note Synthensizer",
-  "Note Sequencer",
-  "Font Manager",
-  "List Manager",
-  "Unknown",
-  "Unknown",
-  "Unknown"
-};
+static std::array<const char *, 0x20> kToolsetNames = {"Tool Locator",
+                                                       "Memory Manager",
+                                                       "Miscellaneous",
+                                                       "QuickDraw II",
+                                                       "Desk Manager",
+                                                       "Event Manager",
+                                                       "Scheduler",
+                                                       "Sound",
+                                                       "Apple Desktop Bus",
+                                                       "SANE",
+                                                       "Integer Math",
+                                                       "Text Tool",
+                                                       "Reserved for Apple use",
+                                                       "Window Manager",
+                                                       "Menu Manager",
+                                                       "Control Manager",
+                                                       "Loader",
+                                                       "QuickDraw II Auxillary",
+                                                       "Print Manager",
+                                                       "LineEdit",
+                                                       "Dialog Manager",
+                                                       "Scrap Manager",
+                                                       "Standard File Operations",
+                                                       "Disk Utilities",
+                                                       "Note Synthensizer",
+                                                       "Note Sequencer",
+                                                       "Font Manager",
+                                                       "List Manager",
+                                                       "Unknown",
+                                                       "Unknown",
+                                                       "Unknown"};
 
-ClemensProgramTrace::ClemensProgramTrace() :
-  enableToolboxLogging_(false),
-  enableIWMLogging_(false)
-{
-  reset();
+ClemensProgramTrace::ClemensProgramTrace()
+    : enableToolboxLogging_(false), enableIWMLogging_(false) {
+    reset();
 }
 
-void ClemensProgramTrace::enableToolboxLogging(bool enable) {
-  enableToolboxLogging_ = enable;
-}
+void ClemensProgramTrace::enableToolboxLogging(bool enable) { enableToolboxLogging_ = enable; }
 
-void ClemensProgramTrace::enableIWMLogging(bool enable) {
-  enableIWMLogging_ = enable;
-}
+void ClemensProgramTrace::enableIWMLogging(bool enable) { enableIWMLogging_ = enable; }
 
-ClemensTraceExecutedInstruction& ClemensProgramTrace::addExecutedInstruction(
-  const ClemensInstruction& instruction,
-  const char* operand,
-  const ClemensMachine& machineState
-) {
-  /*if (machineState.cpu.regs.PC == 0x125 && machineState.cpu.regs.PBR == 0xfe) {
-    printf("TBC: %04X (%s)\n", machineState.cpu.regs.X,
-           kToolsetNames[(machineState.cpu.regs.X & 0xff)-1]);
-  }
-  */
+ClemensTraceExecutedInstruction &
+ClemensProgramTrace::addExecutedInstruction(uint64_t seq, const ClemensInstruction &instruction,
+                                            const char *operand,
+                                            const ClemensMachine &machineState) {
+    /*if (machineState.cpu.regs.PC == 0x125 && machineState.cpu.regs.PBR == 0xfe) {
+      printf("TBC: %04X (%s)\n", machineState.cpu.regs.X,
+             kToolsetNames[(machineState.cpu.regs.X & 0xff)-1]);
+    }
+    */
 
-
-
-  //  check instruction before and after our newly added instruction to see if
-  //    there's overlap
-  //    if overlap, convert those actions to misc bytes
-  //  find where in the action list to insert our instruction
-  uint32_t newCurrentActionIdx;
-  if (freeActionIndices_.empty()) {
-    actions_.emplace_back();
-    newCurrentActionIdx = actions_.size() - 1;
-  } else {
-    newCurrentActionIdx = freeActionIndices_.back();
-    freeActionIndices_.pop_back();
-  }
-
-  //  at this point, the actions_ vector will not be modified, so pointers are
-  //  ok.
-  Action* current = &actions_[newCurrentActionIdx];
-  current->inst.fromInstruction(instruction, operand);
-  memcpy(&current->regs, &machineState.cpu.regs, sizeof(ClemensCPURegs));
-  current->emulation = machineState.cpu.pins.emulation;
-
-  Action* prev = &actions_[actionCurrent_];
-  Action* next = &actions_[prev->next];
-
-  while (current) {
-    if (prev->inst.pc > current->inst.pc && prev->seq != UINT64_MAX) {
-      next = prev;
-      prev = &actions_[prev->prev];
-    } else if (current->inst.pc >= next->inst.pc && next->seq != UINT64_MAX) {
-      prev = next;
-      next = &actions_[next->next];
+    //  check instruction before and after our newly added instruction to see if
+    //    there's overlap
+    //    if overlap, convert those actions to misc bytes
+    //  find where in the action list to insert our instruction
+    uint32_t newCurrentActionIdx;
+    if (freeActionIndices_.empty()) {
+        actions_.emplace_back();
+        newCurrentActionIdx = actions_.size() - 1;
     } else {
-      //  insert after prev and before next
-      prev->next = newCurrentActionIdx;
-      next->prev = newCurrentActionIdx;
-      current->prev = (prev - actions_.data());
-      current->next = (next - actions_.data());
-      current->seq = nextSeq_;
-
-      // if our current action overlaps any neighbors, remove them
-      // this results in 'destroyed' actions if there are partial overlaps
-      // (i.e. prev instruction overlaps the current)
-      // it's POSSIBLE but highly unlikely that overlayed code overlapping
-      // existing actions would result in valid executable code... well not
-      // TOTALLY impossible.  but handling these overlaps is not trival and
-      // until needed, won't be done here.
-      if (prev->seq != UINT64_MAX) {
-        if (prev->inst.pc + prev->inst.size > current->inst.pc) {
-          freeActionIndices_.emplace_back(current->prev);
-          current->prev = prev->prev;
-          prev = &actions_[current->prev];
-          prev->next = newCurrentActionIdx;
-        }
-      }
-      if (next->seq != UINT64_MAX) {
-        if (current->inst.pc + current->inst.size > next->inst.pc) {
-          freeActionIndices_.emplace_back(current->next);
-          current->next = next->next;
-          next = &actions_[current->next];
-          next->prev = newCurrentActionIdx;
-        }
-      }
-
-      ++nextSeq_;
-      actionCurrent_ = newCurrentActionIdx;
-      current = nullptr;
-    }
-  }
-
-  current = &actions_[newCurrentActionIdx];
-  if (enableToolboxLogging_) {
-    if (instruction.opc == CLEM_OPC_JSL && instruction.bank == 0xe1 && instruction.value == 0x0000) {
-      toolboxCalls_.emplace_back();
-      toolboxCalls_.back().call = machineState.cpu.regs.X;
-      toolboxCalls_.back().pc = instruction.addr;
-      toolboxCalls_.back().pbr = instruction.pbr;
-    }
-  }
-  if (enableIWMLogging_ && machineState.cpu.pins.ioOut) {
-    if (machineState.cpu.pins.vdaOut && (
-      (machineState.cpu.pins.adr >= 0xc0e0 && machineState.cpu.pins.adr <= 0xc0ef) ||
-      machineState.cpu.pins.adr == 0xc031)
-    ) {
-      memoryOps_.emplace_back();
-      auto& ops = memoryOps_.back();
-      ops.seq = current->seq;
-      memcpy(ops.opname, instruction.desc->name, sizeof(ops.opname));
-      ops.adr = machineState.cpu.pins.adr;
-      ops.dbr = machineState.cpu.pins.bank;
-      ops.pbr = instruction.pbr;
-      ops.pc = instruction.addr;
-      ops.value = machineState.cpu.pins.data;
-    }
-  }
-
-  return current->inst;
-}
-
-void ClemensProgramTrace::reset()
-{
-  actions_.clear();
-  freeActionIndices_.clear();
-
-  actions_.emplace_back();
-  actionAnchor_ = uint32_t(actions_.size() - 1);
-  actionCurrent_ = actionAnchor_;
-  actions_[actionAnchor_].prev = actionAnchor_;
-  actions_[actionAnchor_].next = actionAnchor_;
-  actions_[actionAnchor_].seq = UINT64_MAX;
-}
-
-bool ClemensProgramTrace::exportTrace(const char* filename)
-{
-  const Action& anchor = actions_[actionAnchor_];
-  unsigned actionIndex = anchor.next;
-
-  char line[256];
-
-  FILE* fp = fopen(filename, "w");
-  if (fp) {
-    while (actionIndex != actionAnchor_) {
-      const Action& action = actions_[actionIndex];
-      char* out = &line[0];
-      size_t outLeft = sizeof(line);
-      int amt = snprintf(
-              out, outLeft,
-              "%16" PRIu64 " | %02X | %04X | (%2u) %4s %-10s | ",
-              action.seq,
-              action.inst.pc >> 16, action.inst.pc & 0xffff,
-              action.inst.cycles_spent,
-              action.inst.opcode, action.inst.operand);
-      outLeft -= amt;
-      out += amt;
-      amt = snprintf(
-              out, outLeft, "PC=%04X, PBR=%02X, DBR=%02X, S=%04X, D=%04X, e=%u, ",
-              action.regs.PC, action.regs.PBR, action.regs.DBR,
-              action.regs.S, action.regs.D, action.emulation ? 1 : 0);
-      out += amt;
-      outLeft -= amt;
-      if (action.emulation) {
-        amt = snprintf(
-                out, outLeft, "A=%02X, X=%02X, Y=%02X, %c%c*%c%c%c%c%c",
-                action.regs.A & 0xff, action.regs.X & 0xff, action.regs.Y & 0xff,
-                (action.regs.P & kClemensCPUStatus_Negative) ? '1' : '0',
-                (action.regs.P & kClemensCPUStatus_Overflow) ? '1' : '0',
-                (action.regs.P & kClemensCPUStatus_EmulatedBrk) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Decimal) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_IRQDisable) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Zero) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Carry) ? '1' : '0');
-      } else {
-          if (action.regs.P & kClemensCPUStatus_MemoryAccumulator) {
-            amt = snprintf(
-                out, outLeft, "A=%02X, ", action.regs.A & 0xff);
-          } else {
-            amt = snprintf(
-                out, outLeft, "A=%04X, ", action.regs.A);
-          }
-          out += amt;
-          outLeft -= amt;
-          if (action.regs.P & kClemensCPUStatus_Index) {
-            amt = snprintf(
-                out, outLeft, "X=%02X, Y=%02X, ", action.regs.X & 0xff, action.regs.Y & 0xff);
-          } else {
-            amt = snprintf(
-                out, outLeft, "X=%04X, Y=%04X, ", action.regs.X, action.regs.Y);
-          }
-          out += amt;
-          outLeft -= amt;
-          amt = snprintf(
-                out, outLeft, "%c%c%c%c%c%c%c%c",
-                (action.regs.P & kClemensCPUStatus_Negative) ? '1' : '0',
-                (action.regs.P & kClemensCPUStatus_Overflow) ? '1' : '0',
-                (action.regs.P & kClemensCPUStatus_MemoryAccumulator) ? '1' : '0',
-                (action.regs.P & kClemensCPUStatus_Index) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Decimal) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_IRQDisable) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Zero) ? '1' : '0',
-                (action.regs.P  & kClemensCPUStatus_Carry) ? '1' : '0');
-      }
-      out += amt;
-      outLeft -= amt;
-      out[0] = '\n';
-      out[1] = '\0';
-      fputs(line, fp);
-      actionIndex = action.next;
+        newCurrentActionIdx = freeActionIndices_.back();
+        freeActionIndices_.pop_back();
     }
 
-    if (!toolboxCalls_.empty()) {
-      fputs("\nTOOLBOX:\n=================================================\n", fp);
+    //  at this point, the actions_ vector will not be modified, so pointers are
+    //  ok.
+    Action *current = &actions_[newCurrentActionIdx];
+    current->inst.fromInstruction(instruction, operand);
+    memcpy(&current->regs, &machineState.cpu.regs, sizeof(ClemensCPURegs));
+    current->emulation = machineState.cpu.pins.emulation;
 
-      for (auto& tbc: toolboxCalls_) {
-        char* out = &line[0];
-        size_t outLeft = sizeof(line);
-        int amt;
-        unsigned toolset = tbc.call - 1;
-        if ((toolset & 0xff) >= kToolsetNames.size()) {
-          amt = snprintf(out, outLeft, "%02X:%04X CALL #%04X ???", tbc.pbr, tbc.pc, tbc.call);
+    Action *prev = &actions_[actionCurrent_];
+    Action *next = &actions_[prev->next];
+
+    while (current) {
+        if (prev->inst.pc > current->inst.pc && prev->seq != UINT64_MAX) {
+            next = prev;
+            prev = &actions_[prev->prev];
+        } else if (current->inst.pc >= next->inst.pc && next->seq != UINT64_MAX) {
+            prev = next;
+            next = &actions_[next->next];
         } else {
-          amt = snprintf(out, outLeft, "%02X:%04X CALL #%04X %s", tbc.pbr, tbc.pc, tbc.call,
-                         kToolsetNames[toolset & 0xff]);
+            //  insert after prev and before next
+            prev->next = newCurrentActionIdx;
+            next->prev = newCurrentActionIdx;
+            current->prev = (prev - actions_.data());
+            current->next = (next - actions_.data());
+            current->seq = seq;
 
+            // if our current action overlaps any neighbors, remove them
+            // this results in 'destroyed' actions if there are partial overlaps
+            // (i.e. prev instruction overlaps the current)
+            // it's POSSIBLE but highly unlikely that overlayed code overlapping
+            // existing actions would result in valid executable code... well not
+            // TOTALLY impossible.  but handling these overlaps is not trival and
+            // until needed, won't be done here.
+            if (prev->seq != UINT64_MAX) {
+                if (prev->inst.pc + prev->inst.size > current->inst.pc) {
+                    freeActionIndices_.emplace_back(current->prev);
+                    current->prev = prev->prev;
+                    prev = &actions_[current->prev];
+                    prev->next = newCurrentActionIdx;
+                }
+            }
+            if (next->seq != UINT64_MAX) {
+                if (current->inst.pc + current->inst.size > next->inst.pc) {
+                    freeActionIndices_.emplace_back(current->next);
+                    current->next = next->next;
+                    next = &actions_[current->next];
+                    next->prev = newCurrentActionIdx;
+                }
+            }
+            actionCurrent_ = newCurrentActionIdx;
+            current = nullptr;
         }
-        outLeft -= amt;
-        out += amt;
-        out[0] = '\n';
-        out[1] = '\0';
-        fputs(line, fp);
-      }
     }
 
-    if (!memoryOps_.empty()) {
-      fputs("\nOPS:\n=================================================\n", fp);
-
-      for (auto& ops: memoryOps_) {
-        char* out = &line[0];
-        size_t outLeft = sizeof(line);
-
-        int amt = snprintf(out, outLeft, "%16" PRIu64 " %02X:%04X %s $%04X %02X", ops.seq, ops.pbr,
-                           ops.pc, ops.opname, ops.adr, ops.value);
-
-        outLeft -= amt;
-        out += amt;
-        out[0] = '\n';
-        out[1] = '\0';
-        fputs(line, fp);
-      }
+    current = &actions_[newCurrentActionIdx];
+    if (enableToolboxLogging_) {
+        if (instruction.opc == CLEM_OPC_JSL && instruction.bank == 0xe1 &&
+            instruction.value == 0x0000) {
+            toolboxCalls_.emplace_back();
+            toolboxCalls_.back().call = machineState.cpu.regs.X;
+            toolboxCalls_.back().pc = instruction.addr;
+            toolboxCalls_.back().pbr = instruction.pbr;
+        }
     }
-    fclose(fp);
-  }
-  return fp != NULL;
+    if (enableIWMLogging_ && machineState.cpu.pins.ioOut) {
+        if (machineState.cpu.pins.vdaOut &&
+            ((machineState.cpu.pins.adr >= 0xc0e0 && machineState.cpu.pins.adr <= 0xc0ef) ||
+             machineState.cpu.pins.adr == 0xc031)) {
+            memoryOps_.emplace_back();
+            auto &ops = memoryOps_.back();
+            ops.seq = current->seq;
+            memcpy(ops.opname, instruction.desc->name, sizeof(ops.opname));
+            ops.adr = machineState.cpu.pins.adr;
+            ops.dbr = machineState.cpu.pins.bank;
+            ops.pbr = instruction.pbr;
+            ops.pc = instruction.addr;
+            ops.value = machineState.cpu.pins.data;
+        }
+    }
+
+    return current->inst;
+}
+
+void ClemensProgramTrace::reset() {
+    actions_.clear();
+    freeActionIndices_.clear();
+
+    actions_.emplace_back();
+    actionAnchor_ = uint32_t(actions_.size() - 1);
+    actionCurrent_ = actionAnchor_;
+    actions_[actionAnchor_].prev = actionAnchor_;
+    actions_[actionAnchor_].next = actionAnchor_;
+    actions_[actionAnchor_].seq = UINT64_MAX;
+}
+
+bool ClemensProgramTrace::exportTrace(const char *filename) {
+    const Action &anchor = actions_[actionAnchor_];
+    unsigned actionIndex = anchor.next;
+
+    char line[4096];
+
+    FILE *fp = fopen(filename, "w");
+    if (fp) {
+        while (actionIndex != actionAnchor_) {
+            const Action &action = actions_[actionIndex];
+            char *out = &line[0];
+            size_t outLeft = sizeof(line);
+            int amt = snprintf(out, outLeft, "%16" PRIu64 " | %02X | %04X | (%2u) %4s %-10s | ",
+                               action.seq, action.inst.pc >> 16, action.inst.pc & 0xffff,
+                               action.inst.cycles_spent, action.inst.opcode, action.inst.operand);
+            outLeft -= amt;
+            out += amt;
+            amt = snprintf(out, outLeft, "PC=%04X, PBR=%02X, DBR=%02X, S=%04X, D=%04X, e=%u, ",
+                           action.regs.PC, action.regs.PBR, action.regs.DBR, action.regs.S,
+                           action.regs.D, action.emulation ? 1 : 0);
+            out += amt;
+            outLeft -= amt;
+            if (action.emulation) {
+                amt = snprintf(out, outLeft, "A=%02X, X=%02X, Y=%02X, %c%c*%c%c%c%c%c",
+                               action.regs.A & 0xff, action.regs.X & 0xff, action.regs.Y & 0xff,
+                               (action.regs.P & kClemensCPUStatus_Negative) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Overflow) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_EmulatedBrk) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Decimal) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_IRQDisable) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Zero) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Carry) ? '1' : '0');
+            } else {
+                if (action.regs.P & kClemensCPUStatus_MemoryAccumulator) {
+                    amt = snprintf(out, outLeft, "A=%02X, ", action.regs.A & 0xff);
+                } else {
+                    amt = snprintf(out, outLeft, "A=%04X, ", action.regs.A);
+                }
+                out += amt;
+                outLeft -= amt;
+                if (action.regs.P & kClemensCPUStatus_Index) {
+                    amt = snprintf(out, outLeft, "X=%02X, Y=%02X, ", action.regs.X & 0xff,
+                                   action.regs.Y & 0xff);
+                } else {
+                    amt = snprintf(out, outLeft, "X=%04X, Y=%04X, ", action.regs.X, action.regs.Y);
+                }
+                out += amt;
+                outLeft -= amt;
+                amt = snprintf(out, outLeft, "%c%c%c%c%c%c%c%c",
+                               (action.regs.P & kClemensCPUStatus_Negative) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Overflow) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_MemoryAccumulator) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Index) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Decimal) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_IRQDisable) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Zero) ? '1' : '0',
+                               (action.regs.P & kClemensCPUStatus_Carry) ? '1' : '0');
+            }
+            out += amt;
+            outLeft -= amt;
+            out[0] = '\n';
+            out[1] = '\0';
+            fputs(line, fp);
+            actionIndex = action.next;
+        }
+
+        if (!toolboxCalls_.empty()) {
+            fputs("\nTOOLBOX:\n=================================================\n", fp);
+
+            for (auto &tbc : toolboxCalls_) {
+                char *out = &line[0];
+                size_t outLeft = sizeof(line);
+                int amt;
+                unsigned toolset = tbc.call - 1;
+                if ((toolset & 0xff) >= kToolsetNames.size()) {
+                    amt = snprintf(out, outLeft, "%02X:%04X CALL #%04X ???", tbc.pbr, tbc.pc,
+                                   tbc.call);
+                } else {
+                    amt = snprintf(out, outLeft, "%02X:%04X CALL #%04X %s", tbc.pbr, tbc.pc,
+                                   tbc.call, kToolsetNames[toolset & 0xff]);
+                }
+                outLeft -= amt;
+                out += amt;
+                out[0] = '\n';
+                out[1] = '\0';
+                fputs(line, fp);
+            }
+        }
+
+        if (!memoryOps_.empty()) {
+            fputs("\nOPS:\n=================================================\n", fp);
+
+            for (auto &ops : memoryOps_) {
+                char *out = &line[0];
+                size_t outLeft = sizeof(line);
+
+                int amt = snprintf(out, outLeft, "%16" PRIu64 " %02X:%04X %s $%04X %02X", ops.seq,
+                                   ops.pbr, ops.pc, ops.opname, ops.adr, ops.value);
+
+                outLeft -= amt;
+                out += amt;
+                out[0] = '\n';
+                out[1] = '\0';
+                fputs(line, fp);
+            }
+        }
+        fclose(fp);
+    }
+    return fp != NULL;
 }

--- a/host/clem_program_trace.hpp
+++ b/host/clem_program_trace.hpp
@@ -9,64 +9,61 @@
 
 #include "clem_host_utils.hpp"
 
-class ClemensProgramTrace
-{
-public:
-  ClemensProgramTrace();
+class ClemensProgramTrace {
+  public:
+    ClemensProgramTrace();
 
-  void enableToolboxLogging(bool enable);
-  void enableIWMLogging(bool enable);
+    void enableToolboxLogging(bool enable);
+    void enableIWMLogging(bool enable);
 
-  bool isToolboxLoggingEnabled() const { return enableToolboxLogging_; }
-  bool isIWMLoggingEnabled() const { return enableIWMLogging_; }
+    bool isToolboxLoggingEnabled() const { return enableToolboxLogging_; }
+    bool isIWMLoggingEnabled() const { return enableIWMLogging_; }
 
-  ClemensTraceExecutedInstruction& addExecutedInstruction(
-    const ClemensInstruction& instruction,
-    const char* operand,
-    const ClemensMachine& machineState);
+    ClemensTraceExecutedInstruction &addExecutedInstruction(uint64_t seq,
+                                                            const ClemensInstruction &instruction,
+                                                            const char *operand,
+                                                            const ClemensMachine &machineState);
 
-  void reset();
+    void reset();
 
-  bool exportTrace(const char* filename);
+    bool exportTrace(const char *filename);
 
-private:
-  uint64_t nextSeq_ = 0;
+  private:
+    //  <Execution Order> | <Bank>::<PC> | Opcode Operand
+    struct Action {
+        uint32_t prev;
+        uint32_t next;
+        uint64_t seq;
+        ClemensTraceExecutedInstruction inst;
+        ClemensCPURegs regs;
+        bool emulation;
+    };
 
-  //  <Execution Order> | <Bank>::<PC> | Opcode Operand
-  struct Action {
-    uint32_t prev;
-    uint32_t next;
-    uint64_t seq;
-    ClemensTraceExecutedInstruction inst;
-    ClemensCPURegs regs;
-    bool emulation;
-  };
+    uint32_t actionAnchor_;
+    uint32_t actionCurrent_;
+    std::vector<Action> actions_;
+    std::vector<uint32_t> freeActionIndices_;
 
-  uint32_t actionAnchor_;
-  uint32_t actionCurrent_;
-  std::vector<Action> actions_;
-  std::vector<uint32_t> freeActionIndices_;
+    struct Toolbox {
+        uint16_t call;
+        uint16_t pc;
+        uint8_t pbr;
+    };
+    std::vector<Toolbox> toolboxCalls_;
 
-  struct Toolbox {
-    uint16_t call;
-    uint16_t pc;
-    uint8_t pbr;
-  };
-  std::vector<Toolbox> toolboxCalls_;
+    struct MemoryOperation {
+        uint64_t seq;
+        char opname[4];
+        uint16_t pc;
+        uint16_t adr;
+        uint8_t pbr;
+        uint8_t dbr;
+        uint8_t value; //  this could be parts of a 16-bit value
+    };
+    std::vector<MemoryOperation> memoryOps_;
 
-  struct MemoryOperation {
-    uint64_t seq;
-    char opname[4];
-    uint16_t pc;
-    uint16_t adr;
-    uint8_t pbr;
-    uint8_t dbr;
-    uint8_t value;      //  this could be parts of a 16-bit value
-  };
-  std::vector<MemoryOperation> memoryOps_;
-
-  bool enableToolboxLogging_;
-  bool enableIWMLogging_;
+    bool enableToolboxLogging_;
+    bool enableIWMLogging_;
 };
 
 #endif

--- a/host/clem_serializer.cpp
+++ b/host/clem_serializer.cpp
@@ -1,15 +1,33 @@
 #include "clem_serializer.hpp"
 #include "clem_disk_utils.hpp"
 #include "clem_host_utils.hpp"
+#include "clem_smartport_disk.hpp"
 #include "emulator.h"
 #include "emulator_mmio.h"
 #include "serializer.h"
+#include "smartport/prodos_hdd32.h"
 
 #include "fmt/format.h"
 
 #include "iocards/mockingboard.h"
 
 namespace ClemensSerializer {
+
+void saveBackendDiskDriveState(mpack_writer_t *writer, const ClemensBackendDiskDriveState &state) {
+    mpack_write_cstr(writer, "image");
+    mpack_write_cstr(writer, state.imagePath.c_str());
+    mpack_write_cstr(writer, "ejecting");
+    mpack_write_bool(writer, state.isEjecting);
+}
+
+void loadBackendDiskDriveState(mpack_reader_t *reader, ClemensBackendDiskDriveState &state) {
+    char value[1024];
+    mpack_expect_cstr_match(reader, "image");
+    mpack_expect_cstr(reader, value, sizeof(value));
+    state.imagePath = value;
+    mpack_expect_cstr_match(reader, "ejecting");
+    state.isEjecting = mpack_expect_bool(reader);
+}
 
 void saveDiskMetadata(mpack_writer_t *writer, const ClemensWOZDisk &container,
                       const ClemensBackendDiskDriveState &state) {
@@ -20,10 +38,7 @@ void saveDiskMetadata(mpack_writer_t *writer, const ClemensWOZDisk &container,
 
     mpack_build_map(writer);
 
-    mpack_write_cstr(writer, "image");
-    mpack_write_cstr(writer, state.imagePath.c_str());
-    mpack_write_cstr(writer, "ejecting");
-    mpack_write_bool(writer, state.isEjecting);
+    saveBackendDiskDriveState(writer, state);
 
     //  we only need to serialize the WOZ INFO header since the TMAP and TRKS
     //  chunks are defined in the nibblized disk
@@ -49,13 +64,9 @@ bool loadDiskMetadata(mpack_reader_t *reader, ClemensWOZDisk &container,
     //  unserialize the WOZ header
     //  the nibbilized disk is unserialized into the machine object and is not
     //    handled here
-    char value[256];
     mpack_expect_map(reader);
-    mpack_expect_cstr_match(reader, "image");
-    mpack_expect_cstr(reader, value, sizeof(value));
-    state.imagePath = value;
-    mpack_expect_cstr_match(reader, "ejecting");
-    state.isEjecting = mpack_expect_bool(reader);
+
+    loadBackendDiskDriveState(reader, state);
 
     //  we only need to serialize the WOZ INFO header since the TMAP and TRKS
     //  chunks are defined in the nibblized disk
@@ -76,8 +87,38 @@ bool loadDiskMetadata(mpack_reader_t *reader, ClemensWOZDisk &container,
     return true;
 }
 
+void saveSmartPortMetadata(mpack_writer_t *writer, ClemensSmartPortDevice *device,
+                           const ClemensSmartPortDisk &disk,
+                           const ClemensBackendDiskDriveState &state) {
+    mpack_build_map(writer);
+
+    saveBackendDiskDriveState(writer, state);
+
+    mpack_write_cstr(writer, "disk");
+    disk.serialize(writer, device);
+
+    mpack_complete_map(writer);
+}
+
+bool loadSmartPortMetadata(mpack_reader_t *reader, ClemensSmartPortDevice *device,
+                           ClemensSmartPortDisk &disk, ClemensBackendDiskDriveState &state,
+                           ClemensSerializerAllocateCb alloc_cb, void *context) {
+    mpack_expect_map(reader);
+
+    loadBackendDiskDriveState(reader, state);
+
+    mpack_expect_cstr_match(reader, "disk");
+    disk.unserialize(reader, device, alloc_cb, context);
+
+    mpack_done_map(reader);
+
+    return true;
+}
+
 bool save(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, size_t driveCount,
-          const ClemensWOZDisk *containers, const ClemensBackendDiskDriveState *states,
+          const ClemensWOZDisk *containers, const ClemensBackendDiskDriveState *driveStates,
+          size_t smartPortCount, const ClemensSmartPortDisk *smartPortDisks,
+          const ClemensBackendDiskDriveState *smartPortStates,
           const std::vector<ClemensBackendBreakpoint> &breakpoints) {
     mpack_writer_t writer;
     //  this save buffer is probably, unnecessarily big - but it's just used for
@@ -139,9 +180,18 @@ bool save(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, si
     }
     mpack_write_cstr(&writer, "disks");
     {
-        mpack_start_array(&writer, kClemensDrive_Count);
+        mpack_start_array(&writer, driveCount);
         for (size_t driveIndex = 0; driveIndex < driveCount; ++driveIndex) {
-            saveDiskMetadata(&writer, containers[driveIndex], states[driveIndex]);
+            saveDiskMetadata(&writer, containers[driveIndex], driveStates[driveIndex]);
+        }
+        mpack_finish_array(&writer);
+    }
+    mpack_write_cstr(&writer, "smartport");
+    {
+        mpack_start_array(&writer, smartPortCount);
+        for (size_t driveIndex = 0; driveIndex < smartPortCount; ++driveIndex) {
+            saveSmartPortMetadata(&writer, &mmio->active_drives.smartport[driveIndex].device,
+                                  smartPortDisks[driveIndex], smartPortStates[driveIndex]);
         }
         mpack_finish_array(&writer);
     }
@@ -167,7 +217,9 @@ bool save(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, si
 }
 
 bool load(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, size_t driveCount,
-          ClemensWOZDisk *containers, ClemensBackendDiskDriveState *states,
+          ClemensWOZDisk *containers, ClemensBackendDiskDriveState *driveStates,
+          size_t smartPortCount, ClemensSmartPortDisk *smartPortDisks,
+          ClemensBackendDiskDriveState *smartPortStates,
           std::vector<ClemensBackendBreakpoint> &breakpoints, ClemensSerializerAllocateCb alloc_cb,
           void *context) {
     char str[256];
@@ -253,14 +305,32 @@ bool load(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, si
     //  unserialized inside clemens_unserialize_machine
     mpack_expect_cstr_match(&reader, "disks");
     {
-        mpack_expect_array(&reader);
-        for (size_t driveIndex = 0; driveIndex < driveCount; ++driveIndex) {
-            if (!loadDiskMetadata(&reader, containers[driveIndex], states[driveIndex])) {
+        unsigned count = mpack_expect_array(&reader);
+        for (size_t driveIndex = 0; driveIndex < count; ++driveIndex) {
+            if (!loadDiskMetadata(&reader, containers[driveIndex], driveStates[driveIndex])) {
                 fmt::print(
                     "Loading emulator snapshot failed due to disk image '{}' at drive '{}'.",
-                    states[driveIndex].imagePath.empty() ? "none defined"
-                                                         : states[driveIndex].imagePath,
+                    driveStates[driveIndex].imagePath.empty() ? "none defined"
+                                                              : driveStates[driveIndex].imagePath,
                     ClemensDiskUtilities::getDriveName(static_cast<ClemensDriveType>(driveIndex)));
+                return false;
+            }
+        }
+        mpack_done_array(&reader);
+    }
+
+    mpack_expect_cstr_match(&reader, "smartport");
+    {
+        unsigned count = mpack_expect_array(&reader);
+        for (size_t driveIndex = 0; driveIndex < count; ++driveIndex) {
+            if (!loadSmartPortMetadata(&reader, &mmio->active_drives.smartport[driveIndex].device,
+                                       smartPortDisks[driveIndex], smartPortStates[driveIndex],
+                                       alloc_cb, context)) {
+                fmt::print(
+                    "Loading emulator snapshot failed due to SmartPort image '{}' at drive '{}'.",
+                    driveStates[driveIndex].imagePath.empty() ? "none defined"
+                                                              : driveStates[driveIndex].imagePath,
+                    driveIndex);
                 return false;
             }
         }

--- a/host/clem_serializer.cpp
+++ b/host/clem_serializer.cpp
@@ -306,6 +306,7 @@ bool load(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, si
     mpack_expect_cstr_match(&reader, "disks");
     {
         unsigned count = mpack_expect_array(&reader);
+        count = std::min(count, (unsigned)driveCount);
         for (size_t driveIndex = 0; driveIndex < count; ++driveIndex) {
             if (!loadDiskMetadata(&reader, containers[driveIndex], driveStates[driveIndex])) {
                 fmt::print(
@@ -322,6 +323,7 @@ bool load(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, si
     mpack_expect_cstr_match(&reader, "smartport");
     {
         unsigned count = mpack_expect_array(&reader);
+        count = std::min(count, (unsigned)smartPortCount);
         for (size_t driveIndex = 0; driveIndex < count; ++driveIndex) {
             if (!loadSmartPortMetadata(&reader, &mmio->active_drives.smartport[driveIndex].device,
                                        smartPortDisks[driveIndex], smartPortStates[driveIndex],

--- a/host/clem_serializer.hpp
+++ b/host/clem_serializer.hpp
@@ -2,15 +2,23 @@
 #define CLEM_HOST_SERIALIZER_HPP
 
 #include "clem_host_shared.hpp"
+#include "clem_smartport.h"
 #include "clem_woz.h"
 
+class ClemensSmartPortDisk;
+
 namespace ClemensSerializer {
+
 bool save(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, size_t driveCount,
-          const ClemensWOZDisk *containers, const ClemensBackendDiskDriveState *states,
+          const ClemensWOZDisk *containers, const ClemensBackendDiskDriveState *driveStates,
+          size_t smartPortCount, const ClemensSmartPortDisk *smartPortDisks,
+          const ClemensBackendDiskDriveState *smartPortStates,
           const std::vector<ClemensBackendBreakpoint> &breakpoints);
 
 bool load(std::string outputPath, ClemensMachine *machine, ClemensMMIO *mmio, size_t driveCount,
-          ClemensWOZDisk *containers, ClemensBackendDiskDriveState *states,
+          ClemensWOZDisk *containers, ClemensBackendDiskDriveState *driveStates,
+          size_t smartPortCount, ClemensSmartPortDisk *smartPortDisks,
+          ClemensBackendDiskDriveState *smartPortStates,
           std::vector<ClemensBackendBreakpoint> &breakpoints, ClemensSerializerAllocateCb alloc_cb,
           void *context);
 } // namespace ClemensSerializer

--- a/host/clem_smartport_disk.cpp
+++ b/host/clem_smartport_disk.cpp
@@ -1,0 +1,76 @@
+#include "clem_smartport_disk.hpp"
+
+#include <cassert>
+
+std::vector<uint8_t> ClemensSmartPortDisk::createData(unsigned block_count) {
+    std::vector<uint8_t> data(block_count * 512 + CLEM_2IMG_HEADER_BYTE_SIZE);
+    Clemens2IMGDisk disk;
+    if (clem_2img_generate_header(&disk, CLEM_2IMG_FORMAT_PRODOS, data.data(),
+                                  data.data() + data.size(), CLEM_2IMG_HEADER_BYTE_SIZE)) {
+        if (clem_2img_build_image(&disk, disk.image_buffer,
+                                  disk.image_buffer + disk.image_buffer_length)) {
+            return data;
+        }
+        data.clear();
+    }
+    return data;
+}
+
+ClemensSmartPortDisk::ClemensSmartPortDisk() : disk_{} {}
+
+ClemensSmartPortDisk::ClemensSmartPortDisk(std::vector<uint8_t> data)
+    : disk_{}, image_(std::move(data)) {
+
+    clem_2img_parse_header(&disk_, image_.data(), image_.data() + image_.size());
+}
+
+ClemensSmartPortDisk::~ClemensSmartPortDisk() {}
+
+void ClemensSmartPortDisk::write(unsigned block_index, const uint8_t *data) {
+    if (block_index >= disk_.block_count)
+        return;
+    if (disk_.format != CLEM_2IMG_FORMAT_PRODOS)
+        return;
+
+    memcpy(disk_.data + block_index * 512, data, 512);
+}
+
+void ClemensSmartPortDisk::read(unsigned block_index, uint8_t *data) {
+    if (block_index >= disk_.block_count)
+        return;
+    if (disk_.format != CLEM_2IMG_FORMAT_PRODOS)
+        return;
+
+    memcpy(data, disk_.data + block_index * 512, 512);
+}
+
+uint8_t ClemensSmartPortDisk::doReadBlock(void *userContext, unsigned driveIndex,
+                                          unsigned blockIndex, uint8_t *buffer) {
+    return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+}
+
+uint8_t ClemensSmartPortDisk::doWriteBlock(void *userContext, unsigned driveIndex,
+                                           unsigned blockIndex, const uint8_t *buffer) {
+    return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+}
+
+uint8_t ClemensSmartPortDisk::doFlush(void *userCcontext, unsigned driveIndex) {
+    return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+}
+
+ClemensSmartPortDevice *
+ClemensSmartPortDisk::createSmartPortDevice(ClemensSmartPortDevice *device) {
+    clemensHDD_.block_limit = disk_.block_count;
+    clemensHDD_.drive_index = 0;
+    clemensHDD_.user_context = this;
+    clemensHDD_.read_block = &ClemensSmartPortDisk::doReadBlock;
+    clemensHDD_.write_block = &ClemensSmartPortDisk::doWriteBlock;
+    clemensHDD_.flush = &ClemensSmartPortDisk::doFlush;
+    clem_smartport_prodos_hdd32_initialize(device, &clemensHDD_);
+    return device;
+}
+
+void ClemensSmartPortDisk::destroySmartPortDevice(ClemensSmartPortDevice *device) {
+    assert(device->device_data == &clemensHDD_);
+    clem_smartport_prodos_hdd32_uninitialize(device);
+}

--- a/host/clem_smartport_disk.cpp
+++ b/host/clem_smartport_disk.cpp
@@ -57,7 +57,7 @@ void ClemensSmartPortDisk::read(unsigned block_index, uint8_t *data) {
     memcpy(data, disk_.data + block_index * 512, 512);
 }
 
-uint8_t ClemensSmartPortDisk::doReadBlock(void *userContext, unsigned driveIndex,
+uint8_t ClemensSmartPortDisk::doReadBlock(void *userContext, unsigned /*driveIndex */,
                                           unsigned blockIndex, uint8_t *buffer) {
     auto *self = reinterpret_cast<ClemensSmartPortDisk *>(userContext);
     const uint8_t *data_head = self->disk_.data;
@@ -67,7 +67,7 @@ uint8_t ClemensSmartPortDisk::doReadBlock(void *userContext, unsigned driveIndex
     return CLEM_SMARTPORT_STATUS_CODE_OK;
 }
 
-uint8_t ClemensSmartPortDisk::doWriteBlock(void *userContext, unsigned driveIndex,
+uint8_t ClemensSmartPortDisk::doWriteBlock(void *userContext, unsigned /*driveIndex*/,
                                            unsigned blockIndex, const uint8_t *buffer) {
     auto *self = reinterpret_cast<ClemensSmartPortDisk *>(userContext);
     uint8_t *data_head = self->disk_.data;
@@ -77,7 +77,7 @@ uint8_t ClemensSmartPortDisk::doWriteBlock(void *userContext, unsigned driveInde
     return CLEM_SMARTPORT_STATUS_CODE_OK;
 }
 
-uint8_t ClemensSmartPortDisk::doFlush(void *userCcontext, unsigned driveIndex) {
+uint8_t ClemensSmartPortDisk::doFlush(void * /*userContext*/, unsigned /*driveIndex*/) {
     return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
 }
 

--- a/host/clem_smartport_disk.hpp
+++ b/host/clem_smartport_disk.hpp
@@ -30,6 +30,10 @@ class ClemensSmartPortDisk {
     ClemensSmartPortDevice *createSmartPortDevice(ClemensSmartPortDevice *device);
     void destroySmartPortDevice(ClemensSmartPortDevice *device);
 
+    void serialize(mpack_writer_t *writer, ClemensSmartPortDevice *device) const;
+    void unserialize(mpack_reader_t *reader, ClemensSmartPortDevice *device,
+                     ClemensSerializerAllocateCb alloc_cb, void *context);
+
   private:
     static uint8_t doReadBlock(void *userContext, unsigned driveIndex, unsigned blockIndex,
                                uint8_t *buffer);

--- a/host/clem_smartport_disk.hpp
+++ b/host/clem_smartport_disk.hpp
@@ -14,7 +14,10 @@ class ClemensSmartPortDisk {
 
     ClemensSmartPortDisk();
     ClemensSmartPortDisk(std::vector<uint8_t> data);
+    ClemensSmartPortDisk(ClemensSmartPortDisk &&other);
     ~ClemensSmartPortDisk();
+
+    ClemensSmartPortDisk &operator=(ClemensSmartPortDisk &&other);
 
     void write(unsigned block_index, const uint8_t *data);
     void read(unsigned block_index, uint8_t *data);

--- a/host/clem_smartport_disk.hpp
+++ b/host/clem_smartport_disk.hpp
@@ -1,0 +1,45 @@
+#ifndef CLEM_HOST_SMARTPORT_DISK_HPP
+#define CLEM_HOST_SMARTPORT_DISK_HPP
+
+#include "clem_2img.h"
+#include "smartport/prodos_hdd32.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class ClemensSmartPortDisk {
+  public:
+    static std::vector<uint8_t> createData(unsigned block_count);
+
+    ClemensSmartPortDisk();
+    ClemensSmartPortDisk(std::vector<uint8_t> data);
+    ~ClemensSmartPortDisk();
+
+    void write(unsigned block_index, const uint8_t *data);
+    void read(unsigned block_index, uint8_t *data);
+
+    //  the underlying container
+    Clemens2IMGDisk &getDisk() { return disk_; }
+    const Clemens2IMGDisk &getDisk() const { return disk_; }
+
+    //  the Smartport interface
+    ClemensSmartPortDevice *createSmartPortDevice(ClemensSmartPortDevice *device);
+    void destroySmartPortDevice(ClemensSmartPortDevice *device);
+
+  private:
+    static uint8_t doReadBlock(void *userContext, unsigned driveIndex, unsigned blockIndex,
+                               uint8_t *buffer);
+
+    static uint8_t doWriteBlock(void *userContext, unsigned driveIndex, unsigned blockIndex,
+                                const uint8_t *buffer);
+    static uint8_t doFlush(void *userCcontext, unsigned driveIndex);
+
+  private:
+    Clemens2IMGDisk disk_;
+    std::string path_;
+    std::vector<uint8_t> image_;
+    ClemensProdosHDD32 clemensHDD_;
+};
+
+#endif

--- a/serializer.c
+++ b/serializer.c
@@ -233,8 +233,8 @@ struct ClemensSerializerRecord kSmartPortPacket[] = {
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, is_extended),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, status),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, contents_length),
-    CLEM_SERIALIZER_RECORD_BLOB(struct ClemensSmartPortPacket, contents,
-                                CLEM_SMARTPORT_CONTENTS_LIMIT),
+    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortPacket, kClemensSerializerTypeUInt8, contents,
+                                CLEM_SMARTPORT_CONTENTS_LIMIT, 0),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 
 struct ClemensSerializerRecord kSmartPortDevice[] = {
@@ -257,8 +257,8 @@ struct ClemensSerializerRecord kSmartPort[] = {
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_state_byte_cnt),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_cntr),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_size),
-    CLEM_SERIALIZER_RECORD_BLOB(struct ClemensSmartPortUnit, data,
-                                CLEM_SMARTPORT_DATA_BUFFER_LIMIT),
+    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortUnit, kClemensSerializerTypeUInt8, data, 
+                                CLEM_SMARTPORT_DATA_BUFFER_LIMIT, 0),
     CLEM_SERIALIZER_RECORD_OBJECT(struct ClemensSmartPortUnit, packet,
                                   struct ClemensSmartPortPacket, kSmartPortPacket),
     CLEM_SERIALIZER_RECORD_EMPTY()};

--- a/serializer.c
+++ b/serializer.c
@@ -250,6 +250,7 @@ struct ClemensSerializerRecord kSmartPort[] = {
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, write_signal),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, unit_id),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, ack_hi),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, command_id),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_pulse_count),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_bit_count),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_state),

--- a/serializer.c
+++ b/serializer.c
@@ -226,11 +226,49 @@ struct ClemensSerializerRecord kDrive[] = {
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDrive, random_bit_index),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 
+struct ClemensSerializerRecord kSmartPortPacket[] = {
+    CLEM_SERIALIZER_RECORD_INT32(struct ClemensSmartPortPacket, type),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, source_unit_id),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, dest_unit_id),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, is_extended),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, status),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, contents_length),
+    CLEM_SERIALIZER_RECORD_BLOB(struct ClemensSmartPortPacket, contents,
+                                CLEM_SMARTPORT_CONTENTS_LIMIT),
+    CLEM_SERIALIZER_RECORD_EMPTY()};
+
+struct ClemensSerializerRecord kSmartPortDevice[] = {
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortDevice, device_id),
+    CLEM_SERIALIZER_RECORD_EMPTY()};
+
+struct ClemensSerializerRecord kSmartPort[] = {
+    CLEM_SERIALIZER_RECORD_OBJECT(struct ClemensSmartPortUnit, device,
+                                  struct ClemensSmartPortDevice, kSmartPortDevice),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, bus_enabled),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, ph3_latch_lo),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, data_reg),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, write_signal),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, unit_id),
+    CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortUnit, ack_hi),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_pulse_count),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_bit_count),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_state),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_state_byte_cnt),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_cntr),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_size),
+    CLEM_SERIALIZER_RECORD_BLOB(struct ClemensSmartPortUnit, data,
+                                CLEM_SMARTPORT_DATA_BUFFER_LIMIT),
+    CLEM_SERIALIZER_RECORD_OBJECT(struct ClemensSmartPortUnit, packet,
+                                  struct ClemensSmartPortPacket, kSmartPortPacket),
+    CLEM_SERIALIZER_RECORD_EMPTY()};
+
 struct ClemensSerializerRecord kDriveBay[] = {
     CLEM_SERIALIZER_RECORD_ARRAY_OBJECTS(struct ClemensDriveBay, slot5, 2, struct ClemensDrive,
                                          kDrive),
     CLEM_SERIALIZER_RECORD_ARRAY_OBJECTS(struct ClemensDriveBay, slot6, 2, struct ClemensDrive,
                                          kDrive),
+    CLEM_SERIALIZER_RECORD_ARRAY_OBJECTS(struct ClemensDriveBay, smartport, 1, struct ClemensDrive,
+                                         kSmartPort),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 
 struct ClemensSerializerRecord kMMIO[] = {
@@ -478,6 +516,7 @@ static unsigned clemens_serialize_custom(mpack_writer_t *writer, void *ptr, unsi
     struct ClemensAudioMixBuffer *audio_mix_buffer;
     struct ClemensNibbleDisk *nib_disk;
     struct ClemensClock *clock;
+    struct ClemensSmartPortDevice *smartport_device;
 
     unsigned blob_size;
 

--- a/smartport/CMakeLists.txt
+++ b/smartport/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+set(SMARTPORT_DEVICE_SOURCES
+"${CMAKE_CURRENT_SOURCE_DIR}/prodos_hdd32.c")
+
+add_library(clemens_65816_smartport_devices STATIC
+${SMARTPORT_DEVICE_SOURCES})
+
+get_filename_component(
+_CLEM_INCLUDE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY
+)
+
+target_include_directories(clemens_65816_smartport_devices
+PUBLIC $<BUILD_INTERFACE:${_CLEM_INCLUDE_DIRECTORY}>)
+
+target_link_libraries(clemens_65816_smartport_devices
+    PUBLIC clemens_65816_mmio clemens_65816_serializer)

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -94,6 +94,12 @@ static uint8_t _do_status(struct ClemensSmartPortDevice *context,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct ClemensSerializerRecord kDevice[] = {
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensProdosHDD32, drive_index),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensProdosHDD32, block_limit),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensProdosHDD32, current_block_index),
+    CLEM_SERIALIZER_RECORD_EMPTY()};
+
 void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *device,
                                             struct ClemensProdosHDD32 *impl) {
 
@@ -114,12 +120,28 @@ void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *dev
 }
 
 void clem_smartport_prodos_hdd32_serialize(mpack_writer_t *writer,
-                                           struct ClemensSmartPortDevice *device) {
-    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)device->device_data;
+                                           struct ClemensSmartPortDevice *device,
+                                           const struct ClemensProdosHDD32 *hdd) {
+    struct ClemensSerializerRecord root;
+    if (device->device_id != CLEM_SMARTPORT_DEVICE_ID_PRODOS_HDD32)
+        return;
+    memset(&root, 0, sizeof(root));
+    root.type = kClemensSerializerTypeRoot;
+    root.records = &kDevice[0];
+    clemens_serialize_object(writer, (uintptr_t)hdd, &root);
 }
 
-void clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
+bool clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
                                              struct ClemensSmartPortDevice *device,
+                                             struct ClemensProdosHDD32 *hdd,
                                              ClemensSerializerAllocateCb alloc_cb, void *context) {
-    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)device->device_data;
+    struct ClemensSerializerRecord root;
+    if (device->device_id != CLEM_SMARTPORT_DEVICE_ID_PRODOS_HDD32)
+        return false;
+    memset(&root, 0, sizeof(root));
+    root.type = kClemensSerializerTypeRoot;
+    root.records = &kDevice[0];
+    clemens_unserialize_object(reader, (uintptr_t)hdd, &root, alloc_cb, context);
+    device->device_data = hdd;
+    return true;
 }

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -1,0 +1,1 @@
+int g_foo;

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -1,1 +1,1 @@
-int g_foo;
+#include "prodos_hdd32.h"

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -7,21 +7,89 @@ static uint8_t _do_reset(struct ClemensSmartPortDevice *context, unsigned delta_
 }
 
 static uint8_t _do_read_block(struct ClemensSmartPortDevice *context,
-                              struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                              struct ClemensSmartPortPacket *packet, unsigned block_index,
                               unsigned delta_ns) {
     struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
-    unsigned block_index = ((unsigned)(packet->contents[7]) << 16) |
-                           ((unsigned)(packet->contents[6]) << 8) | packet->contents[7];
     uint8_t *buffer = packet->contents;
-    uint8_t result = (*hdd->read_block)(hdd->user_context, 0, block_index, buffer);
+    uint8_t result;
+    hdd->current_block_index = block_index;
+    result =
+        (*hdd->read_block)(hdd->user_context, hdd->drive_index, hdd->current_block_index, buffer);
+    if (result == CLEM_SMARTPORT_STATUS_CODE_OK) {
+        /* Data returned, contents will be 512 bytes */
+        packet->contents_length = 512;
+    }
     return result;
 }
 /** Write a block to the device and store into packet when response state is returned */
 static uint8_t _do_write_block(struct ClemensSmartPortDevice *context,
-                               struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                               struct ClemensSmartPortPacket *packet, unsigned block_index,
                                unsigned delta_ns) {
     struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
-    return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+    uint8_t result = CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+    uint8_t *buffer = packet->contents;
+
+    if (packet->type == kClemensSmartPortPacketType_Command) {
+        hdd->current_block_index = block_index;
+        result = CLEM_SMARTPORT_STATUS_CODE_OK;
+    } else {
+        result = (*hdd->write_block)(hdd->user_context, hdd->drive_index, hdd->current_block_index,
+                                     buffer);
+        if (result == CLEM_SMARTPORT_STATUS_CODE_OK) {
+            packet->contents_length = 512;
+        }
+    }
+
+    return result;
+}
+
+static uint8_t _do_status(struct ClemensSmartPortDevice *context,
+                          struct ClemensSmartPortPacket *packet, uint8_t status,
+                          unsigned delta_ns) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
+    uint16_t clen = 0;
+    uint8_t result = CLEM_SMARTPORT_STATUS_CODE_OK;
+
+    switch (status) {
+    case 0x00:                           /* 4 byte device status */
+        packet->contents[clen++] = 0xf8; /* block, r/w, online, formattable */
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit) & 0xff);
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit >> 8) & 0xff);
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit >> 16) & 0xff);
+        packet->contents_length = clen;
+        break;
+    case 0x01: /* Control Information Block */
+        result = CLEM_SMARTPORT_STATUS_CODE_BAD_CTL;
+    case 0x03: /* DIB */
+        packet->contents[clen++] = 0xf8;
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit) & 0xff);
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit >> 8) & 0xff);
+        packet->contents[clen++] = (uint8_t)((hdd->block_limit >> 16) & 0xff);
+        packet->contents[clen++] = 12;
+        packet->contents[clen++] = 'C';
+        packet->contents[clen++] = 'L';
+        packet->contents[clen++] = 'E';
+        packet->contents[clen++] = 'M';
+        packet->contents[clen++] = 'H';
+        packet->contents[clen++] = 'D';
+        packet->contents[clen++] = 'D';
+        packet->contents[clen++] = '0';
+        packet->contents[clen++] = '4';
+        packet->contents[clen++] = '_';
+        packet->contents[clen++] = 'S';
+        packet->contents[clen++] = 'P';
+        packet->contents[clen++] = ' ';
+        packet->contents[clen++] = ' ';
+        packet->contents[clen++] = ' ';
+        packet->contents[clen++] = ' ';
+        packet->contents[clen++] = 0x02;
+        packet->contents[clen++] = 0x20; /* this is a very basic hard drive?*/
+        packet->contents[clen++] = 0x01; /* firmware version */
+        packet->contents[clen++] = 0x00;
+        packet->contents_length = clen;
+        break;
+    }
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -34,6 +102,8 @@ void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *devic
     device->do_reset = &_do_reset;
     device->do_read_block = &_do_read_block;
     device->do_write_block = &_do_write_block;
+    device->do_status = &_do_status;
+    device->do_format = NULL;
 }
 
 void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device) {

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -2,13 +2,54 @@
 #include "clem_debug.h"
 #include "serializer.h"
 
+static uint8_t _do_reset(struct ClemensSmartPortDevice *context, unsigned delta_ns) {
+    return CLEM_SMARTPORT_STATUS_CODE_OK;
+}
+
+static uint8_t _do_read_block(struct ClemensSmartPortDevice *context,
+                              struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                              unsigned delta_ns) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
+    unsigned block_index = ((unsigned)(packet->contents[7]) << 16) |
+                           ((unsigned)(packet->contents[6]) << 8) | packet->contents[7];
+    uint8_t *buffer = packet->contents;
+    uint8_t result = (*hdd->read_block)(hdd->user_context, 0, block_index, buffer);
+    return result;
+}
+/** Write a block to the device and store into packet when response state is returned */
+static uint8_t _do_write_block(struct ClemensSmartPortDevice *context,
+                               struct ClemensSmartPortPacket *packet, uint8_t unit_id,
+                               unsigned delta_ns) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
+    return CLEM_SMARTPORT_STATUS_CODE_OFFLINE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *device,
-                                            struct ClemensProdosHDD32 *impl) {}
-void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device) {}
+                                            struct ClemensProdosHDD32 *impl) {
+
+    device->device_id = CLEM_SMARTPORT_DEVICE_ID_PRODOS_HDD32;
+    device->device_data = impl;
+    device->do_reset = &_do_reset;
+    device->do_read_block = &_do_read_block;
+    device->do_write_block = &_do_write_block;
+}
+
+void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)device->device_data;
+    if (hdd->flush) {
+        (*hdd->flush)(hdd->user_context, hdd->drive_index);
+    }
+}
 
 void clem_smartport_prodos_hdd32_serialize(mpack_writer_t *writer,
-                                           struct ClemensSmartPortDevice *device) {}
+                                           struct ClemensSmartPortDevice *device) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)device->device_data;
+}
 
 void clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
                                              struct ClemensSmartPortDevice *device,
-                                             ClemensSerializerAllocateCb alloc_cb, void *context) {}
+                                             ClemensSerializerAllocateCb alloc_cb, void *context) {
+    struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)device->device_data;
+}

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -1,1 +1,14 @@
 #include "prodos_hdd32.h"
+#include "clem_debug.h"
+#include "serializer.h"
+
+void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *device,
+                                            struct ClemensProdosHDD32 *impl) {}
+void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device) {}
+
+void clem_smartport_prodos_hdd32_serialize(mpack_writer_t *writer,
+                                           struct ClemensSmartPortDevice *device) {}
+
+void clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
+                                             struct ClemensSmartPortDevice *device,
+                                             ClemensSerializerAllocateCb alloc_cb, void *context) {}

--- a/smartport/prodos_hdd32.c
+++ b/smartport/prodos_hdd32.c
@@ -44,11 +44,11 @@ static uint8_t _do_write_block(struct ClemensSmartPortDevice *context,
 }
 
 static uint8_t _do_status(struct ClemensSmartPortDevice *context,
-                          struct ClemensSmartPortPacket *packet, uint8_t status,
-                          unsigned delta_ns) {
+                          struct ClemensSmartPortPacket *packet, unsigned delta_ns) {
     struct ClemensProdosHDD32 *hdd = (struct ClemensProdosHDD32 *)context->device_data;
     uint16_t clen = 0;
     uint8_t result = CLEM_SMARTPORT_STATUS_CODE_OK;
+    uint8_t status = packet->contents[4];
 
     switch (status) {
     case 0x00:                           /* 4 byte device status */

--- a/smartport/prodos_hdd32.h
+++ b/smartport/prodos_hdd32.h
@@ -1,0 +1,21 @@
+#ifndef CLEM_SMARTPORT_PRODOS_HDD32_H
+#define CLEM_SMARTPORT_PRODOS_HDD32_H
+
+#include "clem_shared.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ClemensProdosHDD32 {
+    unsigned foo;
+};
+
+void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortUnit *unit,
+                                            struct ClemensProdosHDD32 *device);
+void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortUnit *unit);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/smartport/prodos_hdd32.h
+++ b/smartport/prodos_hdd32.h
@@ -2,6 +2,7 @@
 #define CLEM_SMARTPORT_PRODOS_HDD32_H
 
 #include "clem_shared.h"
+#include "clem_smartport.h"
 
 typedef struct mpack_writer_t mpack_writer_t;
 typedef struct mpack_reader_t mpack_reader_t;
@@ -10,14 +11,29 @@ typedef struct mpack_reader_t mpack_reader_t;
 extern "C" {
 #endif
 
+/**
+ * @brief Defines a shallow implementation of a simple Hard Drive interface
+ */
 struct ClemensProdosHDD32 {
     void *user_context;
     unsigned drive_index;
     unsigned block_limit;
-    unsigned (*read_block)(void *user_context, unsigned drive_index, unsigned block_index,
-                           uint8_t *buffer);
-    unsigned (*write_block)(void *user_context, unsigned drive_index, unsigned block_index,
-                            const uint8_t *buffer);
+
+    /**
+     * @brief Callback to read a block of data from the host resident drive
+     *
+     */
+    uint8_t (*read_block)(void *user_context, unsigned drive_index, unsigned block_index,
+                          uint8_t *buffer);
+    /**
+     * @brief Call to write data to the host resident drive
+     *
+     */
+    uint8_t (*write_block)(void *user_context, unsigned drive_index, unsigned block_index,
+                           const uint8_t *buffer);
+    /** Flush the host resideent device (write all contents, etc - This is optional depending on
+     *  how read_block and write_block were implemented.*/
+    uint8_t (*flush)(void *user_context, unsigned drive_index);
 };
 
 void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *device,

--- a/smartport/prodos_hdd32.h
+++ b/smartport/prodos_hdd32.h
@@ -18,6 +18,7 @@ struct ClemensProdosHDD32 {
     void *user_context;
     unsigned drive_index;
     unsigned block_limit;
+    unsigned current_block_index;
 
     /**
      * @brief Callback to read a block of data from the host resident drive

--- a/smartport/prodos_hdd32.h
+++ b/smartport/prodos_hdd32.h
@@ -3,17 +3,31 @@
 
 #include "clem_shared.h"
 
+typedef struct mpack_writer_t mpack_writer_t;
+typedef struct mpack_reader_t mpack_reader_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct ClemensProdosHDD32 {
-    unsigned foo;
+    void *user_context;
+    unsigned drive_index;
+    unsigned block_limit;
+    unsigned (*read_block)(void *user_context, unsigned drive_index, unsigned block_index,
+                           uint8_t *buffer);
+    unsigned (*write_block)(void *user_context, unsigned drive_index, unsigned block_index,
+                            const uint8_t *buffer);
 };
 
-void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortUnit *unit,
-                                            struct ClemensProdosHDD32 *device);
-void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortUnit *unit);
+void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *device,
+                                            struct ClemensProdosHDD32 *impl);
+void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device);
+void clem_smartport_prodos_hdd32_serialize(mpack_writer_t *writer,
+                                           struct ClemensSmartPortDevice *device);
+void clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
+                                             struct ClemensSmartPortDevice *device,
+                                             ClemensSerializerAllocateCb alloc_cb, void *context);
 
 #ifdef __cplusplus
 }

--- a/smartport/prodos_hdd32.h
+++ b/smartport/prodos_hdd32.h
@@ -4,6 +4,8 @@
 #include "clem_shared.h"
 #include "clem_smartport.h"
 
+#include <stdbool.h>
+
 typedef struct mpack_writer_t mpack_writer_t;
 typedef struct mpack_reader_t mpack_reader_t;
 
@@ -41,9 +43,11 @@ void clem_smartport_prodos_hdd32_initialize(struct ClemensSmartPortDevice *devic
                                             struct ClemensProdosHDD32 *impl);
 void clem_smartport_prodos_hdd32_uninitialize(struct ClemensSmartPortDevice *device);
 void clem_smartport_prodos_hdd32_serialize(mpack_writer_t *writer,
-                                           struct ClemensSmartPortDevice *device);
-void clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
+                                           struct ClemensSmartPortDevice *device,
+                                           const struct ClemensProdosHDD32 *hdd);
+bool clem_smartport_prodos_hdd32_unserialize(mpack_reader_t *reader,
                                              struct ClemensSmartPortDevice *device,
+                                             struct ClemensProdosHDD32 *hdd,
                                              ClemensSerializerAllocateCb alloc_cb, void *context);
 
 #ifdef __cplusplus

--- a/tests/test_gameport.c
+++ b/tests/test_gameport.c
@@ -5,6 +5,7 @@
 #include "clem_mmio_defs.h"
 
 #include <stdio.h>
+#include <string.h>
 
 //  This test just checks the 'ADB' component for gameport functionality (i.e.
 //  not the CPU side)


### PR DESCRIPTION
* Emulated IWM and Disk Port emulation of the SmartPort protocol 
* `clem_smartport.h` contains the interface between emulator and host for implementing a device
* `clem_smartport.c` contains the SmartPort protocol implementation
* Includes a sample "ProDOS HDD" SmartPort device implementation
* Upped emulated machine RAM from 1024K to 4096K
* Serialization of SmartPort device