### PR TITLE
ADB, IWM and UI polish for usability and reporting of status (Ctrl-Apple-ESC)

### DIFF
--- a/clem_defs.h
+++ b/clem_defs.h
@@ -471,16 +471,16 @@
 #define CLEM_ADB_KEY_BACKQUOTE  0x32
 #define CLEM_ADB_KEY_DELETE     0x33
 /* Skipped 0x34 */
-#define CLEM_ADB_KEY_ESCAPE        0x35
-#define CLEM_ADB_KEY_LCTRL         0x36
-#define CLEM_ADB_KEY_COMMAND_APPLE 0x37
-#define CLEM_ADB_KEY_LSHIFT        0x38
-#define CLEM_ADB_KEY_CAPSLOCK      0x39
-#define CLEM_ADB_KEY_OPTION        0x3A
-#define CLEM_ADB_KEY_LEFT          0x3B
-#define CLEM_ADB_KEY_RIGHT         0x3C
-#define CLEM_ADB_KEY_DOWN          0x3D
-#define CLEM_ADB_KEY_UP            0x3E
+#define CLEM_ADB_KEY_ESCAPE             0x35
+#define CLEM_ADB_KEY_LCTRL              0x36
+#define CLEM_ADB_KEY_COMMAND_OPEN_APPLE 0x37
+#define CLEM_ADB_KEY_LSHIFT             0x38
+#define CLEM_ADB_KEY_CAPSLOCK           0x39
+#define CLEM_ADB_KEY_OPTION             0x3A
+#define CLEM_ADB_KEY_LEFT               0x3B
+#define CLEM_ADB_KEY_RIGHT              0x3C
+#define CLEM_ADB_KEY_DOWN               0x3D
+#define CLEM_ADB_KEY_UP                 0x3E
 /* Skipped 0x3F */
 /* Skipped 0x40 */
 #define CLEM_ADB_KEY_PAD_DECIMAL 0x41

--- a/clem_drive.c
+++ b/clem_drive.c
@@ -193,13 +193,6 @@ unsigned clem_drive_pre_step(struct ClemensDrive *drive, unsigned *io_flags) {
 
     *io_flags &= ~CLEM_IWM_FLAG_MASK_PRE_STEP_CLEARED;
 
-    if (!(*io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
-        drive->read_buffer = 0;
-        drive->is_spindle_on = false;
-        return CLEM_IWM_DRIVE_INVALID_TRACK_POS;
-    } else {
-        drive->is_spindle_on = true;
-    }
     return track_cur_pos;
 }
 
@@ -309,6 +302,7 @@ void clem_disk_read_and_position_head_525(struct ClemensDrive *drive, unsigned *
         /* should we clear state ? */
         return;
     }
+    drive->is_spindle_on = true;
 
     /* clamp quarter track index to 5.25" limits */
     /* turning a cog that can be oriented in one of 8 directions */

--- a/clem_iwm.c
+++ b/clem_iwm.c
@@ -346,8 +346,19 @@ static bool _clem_iwm_lss(struct ClemensDeviceIWM *iwm, struct ClemensClock *clo
     return (iwm->lss_state & 0x8) != 0;
 }
 
-static void _clem_drive_off(struct ClemensDeviceIWM *iwm) {
-    iwm->io_flags &= ~CLEM_IWM_FLAG_DRIVE_ON;
+static void _clem_iwm_drive_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *drives,
+                                   unsigned io_flags) {
+    struct ClemensDrive *drive;
+    if (io_flags == iwm->io_flags)
+        return;
+    drive = _clem_iwm_select_drive(iwm, drives);
+    if (drive)
+        drive->is_spindle_on = false;
+    iwm->io_flags = io_flags;
+}
+
+static void _clem_drive_off(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *drives) {
+    _clem_iwm_drive_switch(iwm, drives, iwm->io_flags & ~CLEM_IWM_FLAG_DRIVE_ON);
     CLEM_DEBUG("IWM: turning drive off now");
 }
 
@@ -462,7 +473,7 @@ void clem_iwm_glu_sync(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *dri
         iwm->ns_drive_hold = clem_util_timer_decrement(iwm->ns_drive_hold, delta_ns);
         if (iwm->ns_drive_hold == 0 || iwm->timer_1sec_disabled) {
             CLEM_LOG("IWM: turning drive off in sync");
-            _clem_drive_off(iwm);
+            _clem_drive_off(iwm, drives);
         }
     }
 
@@ -487,7 +498,7 @@ void _clem_iwm_io_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *d
     case CLEM_MMIO_REG_IWM_DRIVE_DISABLE:
         if (iwm->io_flags & CLEM_IWM_FLAG_DRIVE_ON) {
             if (iwm->timer_1sec_disabled) {
-                _clem_drive_off(iwm);
+                _clem_drive_off(iwm, drives);
             } else if (iwm->ns_drive_hold == 0) {
                 iwm->ns_drive_hold = CLEM_1SEC_NS;
             }
@@ -496,7 +507,7 @@ void _clem_iwm_io_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *d
     case CLEM_MMIO_REG_IWM_DRIVE_ENABLE:
         if (!(iwm->io_flags & CLEM_IWM_FLAG_DRIVE_ON)) {
             CLEM_DEBUG("IWM: turning drive on");
-            iwm->io_flags |= CLEM_IWM_FLAG_DRIVE_ON;
+            _clem_iwm_drive_switch(iwm, drives, iwm->io_flags | CLEM_IWM_FLAG_DRIVE_ON);
             _clem_iwm_reset_lss(iwm, drives, clock);
         } else if (iwm->ns_drive_hold > 0) {
             iwm->ns_drive_hold = 0;
@@ -506,9 +517,9 @@ void _clem_iwm_io_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *d
         /*if (!(iwm->io_flags & CLEM_IWM_FLAG_DRIVE_1)) {
         }
         */
-        iwm->io_flags &= ~CLEM_IWM_FLAG_DRIVE_2;
+        _clem_iwm_drive_switch(iwm, drives, iwm->io_flags & ~CLEM_IWM_FLAG_DRIVE_2);
         if (!(iwm->io_flags & CLEM_IWM_FLAG_DRIVE_1)) {
-            iwm->io_flags |= CLEM_IWM_FLAG_DRIVE_1;
+            _clem_iwm_drive_switch(iwm, drives, iwm->io_flags | CLEM_IWM_FLAG_DRIVE_1);
             _clem_iwm_reset_lss(iwm, drives, clock);
         }
         break;
@@ -517,11 +528,9 @@ void _clem_iwm_io_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *d
         if (!(iwm->io_flags & CLEM_IWM_FLAG_DRIVE_2)) {
         }
         */
-
-        iwm->io_flags &= ~CLEM_IWM_FLAG_DRIVE_1;
+        _clem_iwm_drive_switch(iwm, drives, iwm->io_flags & ~CLEM_IWM_FLAG_DRIVE_1);
         if (!(iwm->io_flags & CLEM_IWM_FLAG_DRIVE_2)) {
-            iwm->io_flags |= CLEM_IWM_FLAG_DRIVE_2;
-            ;
+            _clem_iwm_drive_switch(iwm, drives, iwm->io_flags | CLEM_IWM_FLAG_DRIVE_2);
             _clem_iwm_reset_lss(iwm, drives, clock);
         }
         break;
@@ -615,12 +624,12 @@ void clem_iwm_write_switch(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay 
         if (value & 0x40) {
             if (!(old_io_flags & CLEM_IWM_FLAG_DRIVE_35)) {
                 CLEM_DEBUG("IWM: setting 3.5 drive mode");
-                iwm->io_flags |= CLEM_IWM_FLAG_DRIVE_35;
+                _clem_iwm_drive_switch(iwm, drives, iwm->io_flags | CLEM_IWM_FLAG_DRIVE_35);
             }
         } else {
             if (old_io_flags & CLEM_IWM_FLAG_DRIVE_35) {
                 CLEM_DEBUG("IWM: setting 5.25 drive mode");
-                iwm->io_flags &= ~CLEM_IWM_FLAG_DRIVE_35;
+                _clem_iwm_drive_switch(iwm, drives, iwm->io_flags & ~CLEM_IWM_FLAG_DRIVE_35);
             }
         }
         if (value & 0x3f) {

--- a/clem_iwm.c
+++ b/clem_iwm.c
@@ -419,7 +419,8 @@ void clem_iwm_glu_sync(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *dri
                         drive->write_pulse = false;
                 }
             }
-            if ((iwm->state & CLEM_IWM_STATE_WRITE_MASK) && iwm->async_write_mode) {
+            if ((iwm->state & CLEM_IWM_STATE_WRITE_MASK) && iwm->async_write_mode &&
+                ((iwm->io_flags & CLEM_IWM_FLAG_DRIVE_35) || iwm->enable2)) {
                 write_signal = _clem_iwm_lss_write_async(iwm, clock, disk_delta_ns);
             } else {
                 write_signal = _clem_iwm_lss(iwm, &next_clock);

--- a/clem_mmio_defs.h
+++ b/clem_mmio_defs.h
@@ -1,3 +1,5 @@
+#ifndef CLEM_MMIO_DEFS_H
+#define CLEM_MMIO_DEFS_H
 
 //  These flags refer to bank 0 memory switches for address bit 17
 //  0 = Main Bank, 1 = Aux Bank ZP, Stack and Language Card
@@ -339,3 +341,8 @@
 #define CLEM_MMIO_EMULATOR_DETECT_IDLE    0
 #define CLEM_MMIO_EMULATOR_DETECT_START   1
 #define CLEM_MMIO_EMULATOR_DETECT_VERSION 2
+
+/** Definitions for the Battery RAM used to access values from the ClemensDeviceRTC component */
+#define CLEM_RTC_BRAM_SYSTEM_SPEED 0x20
+
+#endif

--- a/clem_types.h
+++ b/clem_types.h
@@ -135,7 +135,8 @@ struct ClemensDeviceADB {
 
     uint8_t ram[256]; /**< Microcontroller RAM */
 
-    uint32_t irq_line; /**< IRQ flags passed to machine */
+    uint32_t irq_dispatch; /* IRQ should be dispatched next sync */
+    uint32_t irq_line;     /**< IRQ flags passed to machine */
 };
 
 struct ClemensDeviceSCC {

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -14,12 +14,15 @@ This is a running todo list.
 * Emulator detection of ROM version through introspection
 * Speed up disk access when reading/writing (fast mode for emulation)
 * Smartport Hard Drive Support
-* ROM 01
 * Joystick/Paddle Support
 * Refactor tests with new test backend
+* ADB fixes (control panel hotkey and some fixes regarding ADB keyboard status and interrupts)
 
 ### Miscellaneous
 
+* ROM 01 and Introspect ROM version from binary
+* Introspect Mouse Position from memory in E1/E0 (may depend on ROM version) for
+  emulation without mouselock
 * CYA vs MEGA2 I/O access speeds
   * Some CYA registers are still "slow" so resolve these so they run at the IIgs
     fast speed

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -58,6 +58,12 @@ struct ClemensDrive *clemens_drive_get(ClemensMMIO *mmio, enum ClemensDriveType 
     return drive;
 }
 
+struct ClemensSmartPortUnit *clemens_smartport_unit_get(ClemensMMIO *mmio, unsigned unit_index) {
+    if (unit_index >= CLEM_SMARTPORT_DRIVE_LIMIT)
+        return NULL;
+    return &mmio->active_drives.smartport[unit_index];
+}
+
 bool clemens_assign_disk(ClemensMMIO *mmio, enum ClemensDriveType drive_type,
                          struct ClemensNibbleDisk *disk) {
     struct ClemensDrive *drive = clemens_drive_get(mmio, drive_type);

--- a/emulator_mmio.h
+++ b/emulator_mmio.h
@@ -70,6 +70,15 @@ struct ClemensDrive *clemens_drive_get(ClemensMMIO *mmio, enum ClemensDriveType 
  *
  * @param mmio
  * @param drive_type
+ * @return struct ClemensDrive*
+ */
+struct ClemensSmartPortUnit *clemens_smartport_unit_get(ClemensMMIO *mmio, unsigned unit_index);
+
+/**
+ * @brief
+ *
+ * @param mmio
+ * @param drive_type
  * @param disk
  * @return true
  * @return false

--- a/emulator_mmio.h
+++ b/emulator_mmio.h
@@ -15,15 +15,17 @@ extern "C" {
  * unit testing, and to allow emulation of other 65816 devices.
  *
  * @param clem
+ * @param mmio
  */
 void clemens_emulate_mmio(ClemensMachine *clem, ClemensMMIO *mmio);
 
 /**
- * @brief
+ * @brief Returns the emulated system's clocks per second
  *
- * @param clem
- * @param is_slow_speed
- * @return uint64_t
+ * @param mmio The MMIO component
+ * @param is_slow_speed (Required) Points to a boolean indicating current system speed as read from
+ *                      the SPEED register (not BRAM)
+ * @return uint64_t The clocks per second
  */
 uint64_t clemens_clocks_per_second(ClemensMMIO *mmio, bool *is_slow_speed);
 

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -959,6 +959,21 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
                     }
                 }
             }
+            for (auto diskDriveIt = smartPortDrives_.begin(); diskDriveIt != smartPortDrives_.end();
+                 ++diskDriveIt) {
+                auto &diskDrive = *diskDriveIt;
+                auto driveIndex = unsigned(diskDriveIt - smartPortDrives_.begin());
+                // auto *clemensUnit = clemens_smartport_unit_get(&mmio_, driveIndex);
+                //  TODO: detect SmartPort drive status - enable2 only detects if the
+                //        whole bus is active - which may be fine for now since we just support one
+                //        SmartPort drive!
+                diskDrive.isSpinning = mmio_.dev_iwm.enable2;
+                diskDrive.isWriteProtected = false;
+                diskDrive.saveFailed = false;
+                if (diskDrive.isEjecting) {
+                    //  TODO: SmartPort drive ejection
+                }
+            }
             updateSeqNo = true;
         }
 

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -1044,6 +1044,7 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
                 publishedState.bpHitIndex = *hitBreakpoint;
             }
             publishedState.diskDrives = diskDrives_.data();
+            publishedState.smartDrives = smartPortDrives_.data();
             publishedState.commandFailed = std::move(commandFailed);
             publishedState.commandType = std::move(commandType);
             publishedState.message = std::move(debugMessage);

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -913,11 +913,7 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
                 if (stepsRemaining.has_value()) {
                     stepsRemaining = *stepsRemaining - 1;
                 }
-
                 //  TODO: MMIO bypass
-
-                //  TODO: check breakpoints, etc
-
                 if (!breakpoints_.empty()) {
                     if ((hitBreakpoint = checkHitBreakpoint()).has_value()) {
                         stepsRemaining = 0;

--- a/host/clem_display.cpp
+++ b/host/clem_display.cpp
@@ -216,7 +216,7 @@ ClemensDisplayProvider::ClemensDisplayProvider(const cinek::ByteBuffer &systemFo
         kAlternateSetToGlyph[i] = (0x140 + i) | ((0x140 + i) << 16);
         kAlternateSetToGlyph[i + 0x20] = (0x120 + i) | ((0x120 + i) << 16);
         kAlternateSetToGlyph[i + 0x40] = (0x80 + i) | ((0x80 + i) << 16);
-        kAlternateSetToGlyph[i + 0x60] = (0x60 + i) | ((0x160 + i) << 16);
+        kAlternateSetToGlyph[i + 0x60] = (0x160 + i) | ((0x160 + i) << 16);
         kAlternateSetToGlyph[i + 0x80] = (0x40 + i) | ((0x40 + i) << 16);
         kAlternateSetToGlyph[i + 0xA0] = (0x20 + i) | ((0x20 + i) << 16);
         kAlternateSetToGlyph[i + 0xC0] = (0x40 + i) | ((0x40 + i) << 16);
@@ -642,7 +642,6 @@ auto ClemensDisplay::renderTextPlane(DrawVertex *vertices, const ClemensVideo &v
         int row = i + video.scanline_start;
         const uint8_t *scanline = memory + video.scanlines[row].offset;
         for (int j = 0; j < video.scanline_byte_cnt; ++j) {
-            //  TODO: handle flashing chars
             unsigned glyphIndex;
             const uint8_t charIndex = scanline[j];
             if (useAlternateCharacterSet) {

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -1401,6 +1401,23 @@ void ClemensFrontend::doMachineSmartDriveSelection(unsigned driveIndex) {
         ImGui::Selectable(imageName);
         ImGui::EndCombo();
     }
+    ImGui::SameLine();
+    //  TODO: repeated code but fix when we ensure this works for SmartPort drives
+    const ImColor kRed(255, 0, 0, 255);
+    const ImColor kDark(64, 64, 64, 255);
+    ImGuiStyle &style = ImGui::GetStyle();
+    ImVec2 screenPos = ImGui::GetCursorScreenPos();
+    const float lineHeight = ImGui::GetTextLineHeightWithSpacing();
+    const float circleRadius = ImGui::GetTextLineHeight() * 0.5f;
+    screenPos.x += style.ItemSpacing.x;
+    screenPos.y += lineHeight * 0.5f;
+    ImGui::Dummy(ImVec2(lineHeight, lineHeight));
+    ImDrawList *drawList = ImGui::GetWindowDrawList();
+    if (drive.isSpinning) {
+        drawList->AddCircleFilled(screenPos, circleRadius, kRed);
+    } else {
+        drawList->AddCircleFilled(screenPos, circleRadius, kDark);
+    }
 }
 
 void ClemensFrontend::doMachineSmartDriveStatus(unsigned /*driveIndex */) {
@@ -2151,23 +2168,6 @@ void ClemensFrontend::doMachineInfoBar(ImVec2 rootAnchor, ImVec2 rootSize) {
         ImGui::Text("Move mouse into view for key input");
     }
 
-    /*
-
-    if (emulatorHasMouseFocus_ && emulatorHasKeyboardFocus_) {
-        ImGui::TextUnformatted("Input:ALL");
-    } else if (emulatorHasMouseFocus_) {
-        ImGui::TextUnformatted("Input:MOUSE");
-    } else if (emulatorHasKeyboardFocus_) {
-        ImGui::TextUnformatted("Input:KEYS");
-    } else {
-        ImGui::TextUnformatted("Input:NONE");
-    }
-
-
-    cursorPos.x = ImGui::GetCursorStartPos().x + rootSize.x * 0.5f;
-    ImGui::SameLine(cursorPos.x, 0.0f);
-    ImGui::TextUnformatted("BLAH");
-    */
     ImGui::End();
 }
 

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -633,6 +633,11 @@ void ClemensFrontend::input(ClemensInputEvent input) {
     }
 }
 
+void ClemensFrontend::lostFocus() {
+    emulatorHasMouseFocus_ = false;
+    emulatorHasKeyboardFocus_ = false;
+}
+
 std::unique_ptr<ClemensBackend> ClemensFrontend::createBackend() {
     constexpr unsigned refreshFrequency_ = 60;
     auto backend = std::make_unique<ClemensBackend>(

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -52,6 +52,8 @@ class ClemensFrontend {
     void doMachineDiskDisplay();
     void doMachineDiskSelection(ClemensDriveType driveType);
     void doMachineDiskStatus(ClemensDriveType driveType);
+    void doMachineSmartDriveSelection(unsigned driveIndex);
+    void doMachineSmartDriveStatus(unsigned driveIndex);
     void doMachineCPUInfoDisplay();
     void doMachineViewLayout(ImVec2 rootAnchor, ImVec2 rootSize, float screenU, float screenV);
     void doMachineTerminalLayout(ImVec2 rootAnchor, ImVec2 rootSize);
@@ -149,6 +151,7 @@ class ClemensFrontend {
         int logLevel;
 
         std::array<ClemensBackendDiskDriveState, kClemensDrive_Count> diskDrives;
+        std::array<ClemensBackendDiskDriveState, CLEM_SMARTPORT_DRIVE_LIMIT> smartDrives;
 
         float emulatorSpeedMhz;
         ClemensClock emulatorClock;

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -58,6 +58,7 @@ class ClemensFrontend {
     void doMachineSmartDriveStatus(unsigned driveIndex);
     void doMachineCPUInfoDisplay();
     void doMachineViewLayout(ImVec2 rootAnchor, ImVec2 rootSize, float screenU, float screenV);
+    void doMachineInfoBar(ImVec2 rootAnchor, ImVec2 rootSize);
     void doMachineTerminalLayout(ImVec2 rootAnchor, ImVec2 rootSize);
 
     void layoutTerminalLines();
@@ -147,6 +148,7 @@ class ClemensFrontend {
         uint8_t *memoryView = nullptr;
         uint8_t *ioPage = nullptr;
         uint8_t *docRAM = nullptr;
+        uint8_t *bram = nullptr;
         LogOutputNode *logNode = nullptr;
         ClemensBackendBreakpoint *breakpoints = nullptr;
         unsigned breakpointCount = 0;

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -36,6 +36,8 @@ class ClemensFrontend {
     void frame(int width, int height, double deltaTime, FrameAppInterop &interop);
     //  application input from OS
     void input(ClemensInputEvent input);
+    //  application lost focus
+    void lostFocus();
 
   private:
     template <typename TBufferType> friend struct FormatView;

--- a/host/clem_host_app.cpp
+++ b/host/clem_host_app.cpp
@@ -21,320 +21,306 @@
 #include "clem_front.hpp"
 
 #define SOKOL_IMPL
-#include "sokol/sokol_time.h"
 #include "sokol/sokol_app.h"
 #include "sokol/sokol_audio.h"
 #include "sokol/sokol_gfx.h"
 #include "sokol/sokol_glue.h"
 #include "sokol/sokol_imgui.h"
+#include "sokol/sokol_time.h"
 
+#include "fonts/font_bloada1024.h"
 #include "fonts/font_printchar21.h"
 #include "fonts/font_prnumber3.h"
-#include "fonts/font_bloada1024.h"
 
 static uint64_t g_lastTime = 0;
-static ClemensFrontend* g_Host = nullptr;
+static ClemensFrontend *g_Host = nullptr;
 static sg_pass_action g_sgPassAction;
 static unsigned g_ADBKeyToggleMask = 0;
 
 std::array<int16_t, 512> g_sokolToADBKey;
 
-cinek::ByteBuffer loadFont(const char* pathname) {
-  cinek::ByteBuffer buffer;
-  if (!strcasecmp(pathname, "fonts/PrintChar21.ttf")) {
-    buffer = cinek::ByteBuffer(PrintChar21_ttf, PrintChar21_ttf_len, PrintChar21_ttf_len);
-  } else if (!strcasecmp(pathname, "fonts/PRNumber3.ttf")) {
-    buffer = cinek::ByteBuffer(PRNumber3_ttf, PRNumber3_ttf_len, PRNumber3_ttf_len);
-  }
-  return buffer;
+cinek::ByteBuffer loadFont(const char *pathname) {
+    cinek::ByteBuffer buffer;
+    if (!strcasecmp(pathname, "fonts/PrintChar21.ttf")) {
+        buffer = cinek::ByteBuffer(PrintChar21_ttf, PrintChar21_ttf_len, PrintChar21_ttf_len);
+    } else if (!strcasecmp(pathname, "fonts/PRNumber3.ttf")) {
+        buffer = cinek::ByteBuffer(PRNumber3_ttf, PRNumber3_ttf_len, PRNumber3_ttf_len);
+    }
+    return buffer;
 }
 
-static void imguiFontSetup(const cinek::ByteBuffer& systemFontLoBuffer,
-                           const cinek::ByteBuffer& systemFontHiBuffer) {
-  auto& io = ImGui::GetIO();
+static void imguiFontSetup(const cinek::ByteBuffer &systemFontLoBuffer,
+                           const cinek::ByteBuffer &systemFontHiBuffer) {
+    auto &io = ImGui::GetIO();
     // add fonts
-  io.Fonts->Clear();
+    io.Fonts->Clear();
 
-  ImFontConfig font_cfg;
-  font_cfg.FontDataOwnedByAtlas = false;
+    ImFontConfig font_cfg;
+    font_cfg.FontDataOwnedByAtlas = false;
 
+    strncpy(font_cfg.Name, "A2Lo", sizeof(font_cfg.Name));
+    io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t *>(systemFontLoBuffer.getHead()),
+                                   systemFontLoBuffer.getSize(), 16.0f, &font_cfg);
+    strncpy(font_cfg.Name, "A2Hi", sizeof(font_cfg.Name));
+    io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t *>(systemFontHiBuffer.getHead()),
+                                   systemFontHiBuffer.getSize(), 16.0f, &font_cfg);
 
-  strncpy(font_cfg.Name, "A2Lo", sizeof(font_cfg.Name));
-  io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t*>(systemFontLoBuffer.getHead()),
-                                 systemFontLoBuffer.getSize(),
-                                 16.0f, &font_cfg);
-  strncpy(font_cfg.Name, "A2Hi", sizeof(font_cfg.Name));
-  io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t*>(systemFontHiBuffer.getHead()),
-                                 systemFontHiBuffer.getSize(),
-                                 16.0f, &font_cfg);
-
-  if (!io.Fonts->IsBuilt()) {
-    unsigned char *font_pixels;
-    int font_width, font_height;
-    io.Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
-    sg_image_desc img_desc;
-    memset(&img_desc, 0, sizeof(img_desc));
-    img_desc.width = font_width;
-    img_desc.height = font_height;
-    img_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
-    img_desc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
-    img_desc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
-    img_desc.min_filter = SG_FILTER_LINEAR;
-    img_desc.mag_filter = SG_FILTER_LINEAR;
-    img_desc.data.subimage[0][0].ptr = font_pixels;
-    img_desc.data.subimage[0][0].size = (size_t)(font_width * font_height) * sizeof(uint32_t);
-    img_desc.label = "sokol-imgui-font";
-    _simgui.img = sg_make_image(&img_desc);
-    io.Fonts->TexID = (ImTextureID)(uintptr_t)_simgui.img.id;
-  }
+    if (!io.Fonts->IsBuilt()) {
+        unsigned char *font_pixels;
+        int font_width, font_height;
+        io.Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
+        sg_image_desc img_desc;
+        memset(&img_desc, 0, sizeof(img_desc));
+        img_desc.width = font_width;
+        img_desc.height = font_height;
+        img_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
+        img_desc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+        img_desc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+        img_desc.min_filter = SG_FILTER_LINEAR;
+        img_desc.mag_filter = SG_FILTER_LINEAR;
+        img_desc.data.subimage[0][0].ptr = font_pixels;
+        img_desc.data.subimage[0][0].size = (size_t)(font_width * font_height) * sizeof(uint32_t);
+        img_desc.label = "sokol-imgui-font";
+        _simgui.img = sg_make_image(&img_desc);
+        io.Fonts->TexID = (ImTextureID)(uintptr_t)_simgui.img.id;
+    }
 }
 
 static void initDirectories() {
-  std::filesystem::create_directory(CLEM_HOST_LIBRARY_DIR);
-  std::filesystem::create_directory(CLEM_HOST_SNAPSHOT_DIR);
-  std::filesystem::create_directory(CLEM_HOST_TRACES_DIR);
+    std::filesystem::create_directory(CLEM_HOST_LIBRARY_DIR);
+    std::filesystem::create_directory(CLEM_HOST_SNAPSHOT_DIR);
+    std::filesystem::create_directory(CLEM_HOST_TRACES_DIR);
 }
 
-static void onInit()
-{
-  stm_setup();
-  initDirectories();
+static void onInit() {
+    stm_setup();
+    initDirectories();
 
 #if CLEMENS_PLATFORM_WINDOWS
-  CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    CoInitializeEx(NULL, COINIT_MULTITHREADED);
 #endif
 
-  sg_desc desc = {};
-  desc.context = sapp_sgcontext();
-  sg_setup(desc);
+    sg_desc desc = {};
+    desc.context = sapp_sgcontext();
+    sg_setup(desc);
 
-  g_sgPassAction.colors[0].action = SG_ACTION_CLEAR;
-  g_sgPassAction.colors[0].value = { 0.0f, 0.5f, 0.75f, 1.0f };
+    g_sgPassAction.colors[0].action = SG_ACTION_CLEAR;
+    g_sgPassAction.colors[0].value = {0.0f, 0.5f, 0.75f, 1.0f};
 
-  simgui_desc_t simguiDesc = {};
-  simguiDesc.no_default_font = true;
-  simgui_setup(simguiDesc);
+    simgui_desc_t simguiDesc = {};
+    simguiDesc.no_default_font = true;
+    simgui_setup(simguiDesc);
 
-  g_sokolToADBKey.fill(-1);
-  g_sokolToADBKey[SAPP_KEYCODE_SPACE] = CLEM_ADB_KEY_SPACE;
-  g_sokolToADBKey[SAPP_KEYCODE_APOSTROPHE] = CLEM_ADB_KEY_APOSTRAPHE;
-  g_sokolToADBKey[SAPP_KEYCODE_COMMA] = CLEM_ADB_KEY_COMMA;
-  g_sokolToADBKey[SAPP_KEYCODE_MINUS] = CLEM_ADB_KEY_MINUS;
-  g_sokolToADBKey[SAPP_KEYCODE_PERIOD] = CLEM_ADB_KEY_PERIOD;
-  g_sokolToADBKey[SAPP_KEYCODE_SLASH] = CLEM_ADB_KEY_FWDSLASH;
-  g_sokolToADBKey[SAPP_KEYCODE_0] = CLEM_ADB_KEY_0;
-  g_sokolToADBKey[SAPP_KEYCODE_1] = CLEM_ADB_KEY_1;
-  g_sokolToADBKey[SAPP_KEYCODE_2] = CLEM_ADB_KEY_2;
-  g_sokolToADBKey[SAPP_KEYCODE_3] = CLEM_ADB_KEY_3;
-  g_sokolToADBKey[SAPP_KEYCODE_4] = CLEM_ADB_KEY_4;
-  g_sokolToADBKey[SAPP_KEYCODE_5] = CLEM_ADB_KEY_5;
-  g_sokolToADBKey[SAPP_KEYCODE_6] = CLEM_ADB_KEY_6;
-  g_sokolToADBKey[SAPP_KEYCODE_7] = CLEM_ADB_KEY_7;
-  g_sokolToADBKey[SAPP_KEYCODE_8] = CLEM_ADB_KEY_8;
-  g_sokolToADBKey[SAPP_KEYCODE_9] = CLEM_ADB_KEY_9;
-  g_sokolToADBKey[SAPP_KEYCODE_SEMICOLON] = CLEM_ADB_KEY_SEMICOLON;
-  g_sokolToADBKey[SAPP_KEYCODE_EQUAL] = CLEM_ADB_KEY_EQUALS;
-  g_sokolToADBKey[SAPP_KEYCODE_A] = CLEM_ADB_KEY_A;
-  g_sokolToADBKey[SAPP_KEYCODE_B] = CLEM_ADB_KEY_B;
-  g_sokolToADBKey[SAPP_KEYCODE_C] = CLEM_ADB_KEY_C;
-  g_sokolToADBKey[SAPP_KEYCODE_D] = CLEM_ADB_KEY_D;
-  g_sokolToADBKey[SAPP_KEYCODE_E] = CLEM_ADB_KEY_E;
-  g_sokolToADBKey[SAPP_KEYCODE_F] = CLEM_ADB_KEY_F;
-  g_sokolToADBKey[SAPP_KEYCODE_G] = CLEM_ADB_KEY_G;
-  g_sokolToADBKey[SAPP_KEYCODE_H] = CLEM_ADB_KEY_H;
-  g_sokolToADBKey[SAPP_KEYCODE_I] = CLEM_ADB_KEY_I;
-  g_sokolToADBKey[SAPP_KEYCODE_J] = CLEM_ADB_KEY_J;
-  g_sokolToADBKey[SAPP_KEYCODE_K] = CLEM_ADB_KEY_K;
-  g_sokolToADBKey[SAPP_KEYCODE_L] = CLEM_ADB_KEY_L;
-  g_sokolToADBKey[SAPP_KEYCODE_M] = CLEM_ADB_KEY_M;
-  g_sokolToADBKey[SAPP_KEYCODE_N] = CLEM_ADB_KEY_N;
-  g_sokolToADBKey[SAPP_KEYCODE_O] = CLEM_ADB_KEY_O;
-  g_sokolToADBKey[SAPP_KEYCODE_P] = CLEM_ADB_KEY_P;
-  g_sokolToADBKey[SAPP_KEYCODE_Q] = CLEM_ADB_KEY_Q;
-  g_sokolToADBKey[SAPP_KEYCODE_R] = CLEM_ADB_KEY_R;
-  g_sokolToADBKey[SAPP_KEYCODE_S] = CLEM_ADB_KEY_S;
-  g_sokolToADBKey[SAPP_KEYCODE_T] = CLEM_ADB_KEY_T;
-  g_sokolToADBKey[SAPP_KEYCODE_U] = CLEM_ADB_KEY_U;
-  g_sokolToADBKey[SAPP_KEYCODE_V] = CLEM_ADB_KEY_V;
-  g_sokolToADBKey[SAPP_KEYCODE_W] = CLEM_ADB_KEY_W;
-  g_sokolToADBKey[SAPP_KEYCODE_X] = CLEM_ADB_KEY_X;
-  g_sokolToADBKey[SAPP_KEYCODE_Y] = CLEM_ADB_KEY_Y;
-  g_sokolToADBKey[SAPP_KEYCODE_Z] = CLEM_ADB_KEY_Z;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT_BRACKET] = CLEM_ADB_KEY_LBRACKET;
-  g_sokolToADBKey[SAPP_KEYCODE_BACKSLASH] = CLEM_ADB_KEY_LBRACKET;
-  g_sokolToADBKey[SAPP_KEYCODE_RIGHT_BRACKET] = CLEM_ADB_KEY_LBRACKET;
-  g_sokolToADBKey[SAPP_KEYCODE_GRAVE_ACCENT] = CLEM_ADB_KEY_BACKQUOTE;
-  g_sokolToADBKey[SAPP_KEYCODE_ESCAPE] = CLEM_ADB_KEY_ESCAPE;
-  g_sokolToADBKey[SAPP_KEYCODE_ENTER] = CLEM_ADB_KEY_RETURN;
-  g_sokolToADBKey[SAPP_KEYCODE_TAB] = CLEM_ADB_KEY_TAB;
-  g_sokolToADBKey[SAPP_KEYCODE_BACKSPACE] = CLEM_ADB_KEY_DELETE;
-  g_sokolToADBKey[SAPP_KEYCODE_INSERT] = CLEM_ADB_KEY_HELP_INSERT;
-  g_sokolToADBKey[SAPP_KEYCODE_DELETE] = CLEM_ADB_KEY_DELETE;
-  g_sokolToADBKey[SAPP_KEYCODE_RIGHT] = CLEM_ADB_KEY_RIGHT;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT] = CLEM_ADB_KEY_LEFT;
-  g_sokolToADBKey[SAPP_KEYCODE_DOWN] = CLEM_ADB_KEY_DOWN;
-  g_sokolToADBKey[SAPP_KEYCODE_UP] = CLEM_ADB_KEY_UP;
-  g_sokolToADBKey[SAPP_KEYCODE_PAGE_UP] = CLEM_ADB_KEY_PAGEUP;
-  g_sokolToADBKey[SAPP_KEYCODE_PAGE_DOWN] = CLEM_ADB_KEY_PAGEDOWN;
-  g_sokolToADBKey[SAPP_KEYCODE_HOME] = CLEM_ADB_KEY_HOME;
-  g_sokolToADBKey[SAPP_KEYCODE_END] = CLEM_ADB_KEY_END;
-  g_sokolToADBKey[SAPP_KEYCODE_CAPS_LOCK] = CLEM_ADB_KEY_CAPSLOCK;
-  g_sokolToADBKey[SAPP_KEYCODE_NUM_LOCK] = CLEM_ADB_KEY_PAD_CLEAR_NUMLOCK;
-  g_sokolToADBKey[SAPP_KEYCODE_F1] = CLEM_ADB_KEY_F1;
-  g_sokolToADBKey[SAPP_KEYCODE_F2] = CLEM_ADB_KEY_F2;
-  g_sokolToADBKey[SAPP_KEYCODE_F3] = CLEM_ADB_KEY_F3;
-  g_sokolToADBKey[SAPP_KEYCODE_F4] = CLEM_ADB_KEY_F4;
-  g_sokolToADBKey[SAPP_KEYCODE_F5] = CLEM_ADB_KEY_F5;
-  g_sokolToADBKey[SAPP_KEYCODE_F6] = CLEM_ADB_KEY_F6;
-  g_sokolToADBKey[SAPP_KEYCODE_F7] = CLEM_ADB_KEY_F7;
-  g_sokolToADBKey[SAPP_KEYCODE_F8] = CLEM_ADB_KEY_F8;
-  g_sokolToADBKey[SAPP_KEYCODE_F9] = CLEM_ADB_KEY_F9;
-  g_sokolToADBKey[SAPP_KEYCODE_F10] = CLEM_ADB_KEY_F10;
-  g_sokolToADBKey[SAPP_KEYCODE_F11] = CLEM_ADB_KEY_RESET;
-  g_sokolToADBKey[SAPP_KEYCODE_F12] = CLEM_ADB_KEY_ESCAPE;
-  g_sokolToADBKey[SAPP_KEYCODE_F13] = CLEM_ADB_KEY_F13;
-  g_sokolToADBKey[SAPP_KEYCODE_F14] = CLEM_ADB_KEY_F14;
-  g_sokolToADBKey[SAPP_KEYCODE_F15] = CLEM_ADB_KEY_F15;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_0] = CLEM_ADB_KEY_PAD_0;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_1] = CLEM_ADB_KEY_PAD_1;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_2] = CLEM_ADB_KEY_PAD_2;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_3] = CLEM_ADB_KEY_PAD_3;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_4] = CLEM_ADB_KEY_PAD_4;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_5] = CLEM_ADB_KEY_PAD_5;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_6] = CLEM_ADB_KEY_PAD_6;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_7] = CLEM_ADB_KEY_PAD_7;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_8] = CLEM_ADB_KEY_PAD_8;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_9] = CLEM_ADB_KEY_PAD_9;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_DECIMAL] = CLEM_ADB_KEY_PAD_DECIMAL;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_DIVIDE] = CLEM_ADB_KEY_PAD_DIVIDE;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_MULTIPLY] = CLEM_ADB_KEY_PAD_MULTIPLY;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_SUBTRACT] = CLEM_ADB_KEY_PAD_MINUS;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_ADD] = CLEM_ADB_KEY_PAD_PLUS;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_ENTER] = CLEM_ADB_KEY_PAD_ENTER;
-  g_sokolToADBKey[SAPP_KEYCODE_KP_EQUAL] = CLEM_ADB_KEY_PAD_EQUALS;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT_SHIFT] = CLEM_ADB_KEY_LSHIFT;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT_CONTROL] = CLEM_ADB_KEY_LCTRL;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT_ALT] = CLEM_ADB_KEY_OPTION;
-  g_sokolToADBKey[SAPP_KEYCODE_LEFT_SUPER] = CLEM_ADB_KEY_COMMAND_APPLE;
-  g_sokolToADBKey[SAPP_KEYCODE_RIGHT_SHIFT] = CLEM_ADB_KEY_RSHIFT;
-  g_sokolToADBKey[SAPP_KEYCODE_RIGHT_CONTROL] = CLEM_ADB_KEY_RCTRL;
-  g_sokolToADBKey[SAPP_KEYCODE_RIGHT_ALT] = CLEM_ADB_KEY_ROPTION;
-  //g_sokolToADBKey[SAPP_KEYCODE_RIGHT_SUPER] = CLEM_ADB_KEY_COMMAND_APPLE;
+    g_sokolToADBKey.fill(-1);
+    g_sokolToADBKey[SAPP_KEYCODE_SPACE] = CLEM_ADB_KEY_SPACE;
+    g_sokolToADBKey[SAPP_KEYCODE_APOSTROPHE] = CLEM_ADB_KEY_APOSTRAPHE;
+    g_sokolToADBKey[SAPP_KEYCODE_COMMA] = CLEM_ADB_KEY_COMMA;
+    g_sokolToADBKey[SAPP_KEYCODE_MINUS] = CLEM_ADB_KEY_MINUS;
+    g_sokolToADBKey[SAPP_KEYCODE_PERIOD] = CLEM_ADB_KEY_PERIOD;
+    g_sokolToADBKey[SAPP_KEYCODE_SLASH] = CLEM_ADB_KEY_FWDSLASH;
+    g_sokolToADBKey[SAPP_KEYCODE_0] = CLEM_ADB_KEY_0;
+    g_sokolToADBKey[SAPP_KEYCODE_1] = CLEM_ADB_KEY_1;
+    g_sokolToADBKey[SAPP_KEYCODE_2] = CLEM_ADB_KEY_2;
+    g_sokolToADBKey[SAPP_KEYCODE_3] = CLEM_ADB_KEY_3;
+    g_sokolToADBKey[SAPP_KEYCODE_4] = CLEM_ADB_KEY_4;
+    g_sokolToADBKey[SAPP_KEYCODE_5] = CLEM_ADB_KEY_5;
+    g_sokolToADBKey[SAPP_KEYCODE_6] = CLEM_ADB_KEY_6;
+    g_sokolToADBKey[SAPP_KEYCODE_7] = CLEM_ADB_KEY_7;
+    g_sokolToADBKey[SAPP_KEYCODE_8] = CLEM_ADB_KEY_8;
+    g_sokolToADBKey[SAPP_KEYCODE_9] = CLEM_ADB_KEY_9;
+    g_sokolToADBKey[SAPP_KEYCODE_SEMICOLON] = CLEM_ADB_KEY_SEMICOLON;
+    g_sokolToADBKey[SAPP_KEYCODE_EQUAL] = CLEM_ADB_KEY_EQUALS;
+    g_sokolToADBKey[SAPP_KEYCODE_A] = CLEM_ADB_KEY_A;
+    g_sokolToADBKey[SAPP_KEYCODE_B] = CLEM_ADB_KEY_B;
+    g_sokolToADBKey[SAPP_KEYCODE_C] = CLEM_ADB_KEY_C;
+    g_sokolToADBKey[SAPP_KEYCODE_D] = CLEM_ADB_KEY_D;
+    g_sokolToADBKey[SAPP_KEYCODE_E] = CLEM_ADB_KEY_E;
+    g_sokolToADBKey[SAPP_KEYCODE_F] = CLEM_ADB_KEY_F;
+    g_sokolToADBKey[SAPP_KEYCODE_G] = CLEM_ADB_KEY_G;
+    g_sokolToADBKey[SAPP_KEYCODE_H] = CLEM_ADB_KEY_H;
+    g_sokolToADBKey[SAPP_KEYCODE_I] = CLEM_ADB_KEY_I;
+    g_sokolToADBKey[SAPP_KEYCODE_J] = CLEM_ADB_KEY_J;
+    g_sokolToADBKey[SAPP_KEYCODE_K] = CLEM_ADB_KEY_K;
+    g_sokolToADBKey[SAPP_KEYCODE_L] = CLEM_ADB_KEY_L;
+    g_sokolToADBKey[SAPP_KEYCODE_M] = CLEM_ADB_KEY_M;
+    g_sokolToADBKey[SAPP_KEYCODE_N] = CLEM_ADB_KEY_N;
+    g_sokolToADBKey[SAPP_KEYCODE_O] = CLEM_ADB_KEY_O;
+    g_sokolToADBKey[SAPP_KEYCODE_P] = CLEM_ADB_KEY_P;
+    g_sokolToADBKey[SAPP_KEYCODE_Q] = CLEM_ADB_KEY_Q;
+    g_sokolToADBKey[SAPP_KEYCODE_R] = CLEM_ADB_KEY_R;
+    g_sokolToADBKey[SAPP_KEYCODE_S] = CLEM_ADB_KEY_S;
+    g_sokolToADBKey[SAPP_KEYCODE_T] = CLEM_ADB_KEY_T;
+    g_sokolToADBKey[SAPP_KEYCODE_U] = CLEM_ADB_KEY_U;
+    g_sokolToADBKey[SAPP_KEYCODE_V] = CLEM_ADB_KEY_V;
+    g_sokolToADBKey[SAPP_KEYCODE_W] = CLEM_ADB_KEY_W;
+    g_sokolToADBKey[SAPP_KEYCODE_X] = CLEM_ADB_KEY_X;
+    g_sokolToADBKey[SAPP_KEYCODE_Y] = CLEM_ADB_KEY_Y;
+    g_sokolToADBKey[SAPP_KEYCODE_Z] = CLEM_ADB_KEY_Z;
+    g_sokolToADBKey[SAPP_KEYCODE_LEFT_BRACKET] = CLEM_ADB_KEY_LBRACKET;
+    g_sokolToADBKey[SAPP_KEYCODE_BACKSLASH] = CLEM_ADB_KEY_LBRACKET;
+    g_sokolToADBKey[SAPP_KEYCODE_RIGHT_BRACKET] = CLEM_ADB_KEY_LBRACKET;
+    g_sokolToADBKey[SAPP_KEYCODE_GRAVE_ACCENT] = CLEM_ADB_KEY_BACKQUOTE;
+    g_sokolToADBKey[SAPP_KEYCODE_ESCAPE] = CLEM_ADB_KEY_ESCAPE;
+    g_sokolToADBKey[SAPP_KEYCODE_ENTER] = CLEM_ADB_KEY_RETURN;
+    g_sokolToADBKey[SAPP_KEYCODE_TAB] = CLEM_ADB_KEY_TAB;
+    g_sokolToADBKey[SAPP_KEYCODE_BACKSPACE] = CLEM_ADB_KEY_DELETE;
+    g_sokolToADBKey[SAPP_KEYCODE_INSERT] = CLEM_ADB_KEY_HELP_INSERT;
+    g_sokolToADBKey[SAPP_KEYCODE_DELETE] = CLEM_ADB_KEY_DELETE;
+    g_sokolToADBKey[SAPP_KEYCODE_RIGHT] = CLEM_ADB_KEY_RIGHT;
+    g_sokolToADBKey[SAPP_KEYCODE_LEFT] = CLEM_ADB_KEY_LEFT;
+    g_sokolToADBKey[SAPP_KEYCODE_DOWN] = CLEM_ADB_KEY_DOWN;
+    g_sokolToADBKey[SAPP_KEYCODE_UP] = CLEM_ADB_KEY_UP;
+    g_sokolToADBKey[SAPP_KEYCODE_PAGE_UP] = CLEM_ADB_KEY_PAGEUP;
+    g_sokolToADBKey[SAPP_KEYCODE_PAGE_DOWN] = CLEM_ADB_KEY_PAGEDOWN;
+    g_sokolToADBKey[SAPP_KEYCODE_HOME] = CLEM_ADB_KEY_HOME;
+    g_sokolToADBKey[SAPP_KEYCODE_END] = CLEM_ADB_KEY_END;
+    g_sokolToADBKey[SAPP_KEYCODE_CAPS_LOCK] = CLEM_ADB_KEY_CAPSLOCK;
+    g_sokolToADBKey[SAPP_KEYCODE_NUM_LOCK] = CLEM_ADB_KEY_PAD_CLEAR_NUMLOCK;
+    g_sokolToADBKey[SAPP_KEYCODE_F1] = CLEM_ADB_KEY_F1;
+    g_sokolToADBKey[SAPP_KEYCODE_F2] = CLEM_ADB_KEY_F2;
+    g_sokolToADBKey[SAPP_KEYCODE_F3] = CLEM_ADB_KEY_F3;
+    g_sokolToADBKey[SAPP_KEYCODE_F4] = CLEM_ADB_KEY_F4;
+    g_sokolToADBKey[SAPP_KEYCODE_F5] = CLEM_ADB_KEY_F5;
+    g_sokolToADBKey[SAPP_KEYCODE_F6] = CLEM_ADB_KEY_F6;
+    g_sokolToADBKey[SAPP_KEYCODE_F7] = CLEM_ADB_KEY_F7;
+    g_sokolToADBKey[SAPP_KEYCODE_F8] = CLEM_ADB_KEY_F8;
+    g_sokolToADBKey[SAPP_KEYCODE_F9] = CLEM_ADB_KEY_F9;
+    g_sokolToADBKey[SAPP_KEYCODE_F10] = CLEM_ADB_KEY_F10;
+    g_sokolToADBKey[SAPP_KEYCODE_F11] = CLEM_ADB_KEY_F11;
+    g_sokolToADBKey[SAPP_KEYCODE_F12] = CLEM_ADB_KEY_RESET;
+    g_sokolToADBKey[SAPP_KEYCODE_F13] = CLEM_ADB_KEY_F13;
+    g_sokolToADBKey[SAPP_KEYCODE_F14] = CLEM_ADB_KEY_F14;
+    g_sokolToADBKey[SAPP_KEYCODE_F15] = CLEM_ADB_KEY_F15;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_0] = CLEM_ADB_KEY_PAD_0;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_1] = CLEM_ADB_KEY_PAD_1;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_2] = CLEM_ADB_KEY_PAD_2;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_3] = CLEM_ADB_KEY_PAD_3;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_4] = CLEM_ADB_KEY_PAD_4;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_5] = CLEM_ADB_KEY_PAD_5;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_6] = CLEM_ADB_KEY_PAD_6;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_7] = CLEM_ADB_KEY_PAD_7;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_8] = CLEM_ADB_KEY_PAD_8;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_9] = CLEM_ADB_KEY_PAD_9;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_DECIMAL] = CLEM_ADB_KEY_PAD_DECIMAL;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_DIVIDE] = CLEM_ADB_KEY_PAD_DIVIDE;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_MULTIPLY] = CLEM_ADB_KEY_PAD_MULTIPLY;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_SUBTRACT] = CLEM_ADB_KEY_PAD_MINUS;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_ADD] = CLEM_ADB_KEY_PAD_PLUS;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_ENTER] = CLEM_ADB_KEY_PAD_ENTER;
+    g_sokolToADBKey[SAPP_KEYCODE_KP_EQUAL] = CLEM_ADB_KEY_PAD_EQUALS;
+    g_sokolToADBKey[SAPP_KEYCODE_LEFT_SHIFT] = CLEM_ADB_KEY_LSHIFT;
+    g_sokolToADBKey[SAPP_KEYCODE_LEFT_CONTROL] = CLEM_ADB_KEY_LCTRL;
+    g_sokolToADBKey[SAPP_KEYCODE_LEFT_ALT] = CLEM_ADB_KEY_OPTION;
+    g_sokolToADBKey[SAPP_KEYCODE_RIGHT_SHIFT] = CLEM_ADB_KEY_RSHIFT;
+    g_sokolToADBKey[SAPP_KEYCODE_RIGHT_CONTROL] = CLEM_ADB_KEY_RCTRL;
+    g_sokolToADBKey[SAPP_KEYCODE_RIGHT_ALT] = CLEM_ADB_KEY_COMMAND_OPEN_APPLE;
 
-  auto systemFontLoBuffer = loadFont("fonts/PrintChar21.ttf");
-  auto systemFontHiBuffer = loadFont("fonts/PRNumber3.ttf");
-  imguiFontSetup(systemFontLoBuffer, systemFontHiBuffer);
-  g_Host = new ClemensFrontend(systemFontLoBuffer, systemFontHiBuffer);
+    auto systemFontLoBuffer = loadFont("fonts/PrintChar21.ttf");
+    auto systemFontHiBuffer = loadFont("fonts/PRNumber3.ttf");
+    imguiFontSetup(systemFontLoBuffer, systemFontHiBuffer);
+    g_Host = new ClemensFrontend(systemFontLoBuffer, systemFontHiBuffer);
 }
 
-static void onFrame()
-{
-  const int frameWidth = sapp_width();
-  const int frameHeight = sapp_height();
+static void onFrame() {
+    const int frameWidth = sapp_width();
+    const int frameHeight = sapp_height();
 
-  uint64_t deltaTicks = stm_laptime(&g_lastTime);
-  double deltaTime = stm_sec(deltaTicks);
+    uint64_t deltaTicks = stm_laptime(&g_lastTime);
+    double deltaTime = stm_sec(deltaTicks);
 
-  simgui_frame_desc_t imguiFrameDesc = {};
-  imguiFrameDesc.delta_time = deltaTime;
-  imguiFrameDesc.dpi_scale = 1.0f;
-  imguiFrameDesc.width = frameWidth;
-  imguiFrameDesc.height = frameHeight;
+    simgui_frame_desc_t imguiFrameDesc = {};
+    imguiFrameDesc.delta_time = deltaTime;
+    imguiFrameDesc.dpi_scale = 1.0f;
+    imguiFrameDesc.width = frameWidth;
+    imguiFrameDesc.height = frameHeight;
 
-  simgui_new_frame(imguiFrameDesc);
+    simgui_new_frame(imguiFrameDesc);
 
-  ClemensFrontend::FrameAppInterop interop;
-  interop.mouseLock = sapp_mouse_locked();
-  g_Host->frame(frameWidth, frameHeight, deltaTime, interop);
-  sapp_lock_mouse(interop.mouseLock);
+    ClemensFrontend::FrameAppInterop interop;
+    interop.mouseLock = sapp_mouse_locked();
+    g_Host->frame(frameWidth, frameHeight, deltaTime, interop);
+    sapp_lock_mouse(interop.mouseLock);
 
-  sg_begin_default_pass(&g_sgPassAction, frameWidth, frameHeight);
-  simgui_render();
-  sg_end_pass();
-  sg_commit();
+    sg_begin_default_pass(&g_sgPassAction, frameWidth, frameHeight);
+    simgui_render();
+    sg_end_pass();
+    sg_commit();
 }
 
-static void onEvent(const sapp_event* evt)
-{
-  struct ClemensInputEvent clemInput {};
-  switch (evt->type) {
+static void onEvent(const sapp_event *evt) {
+    struct ClemensInputEvent clemInput {};
+    switch (evt->type) {
     case SAPP_EVENTTYPE_KEY_DOWN:
-      clemInput.value_a = g_sokolToADBKey[evt->key_code];
-      clemInput.type = kClemensInputType_KeyDown;
-      break;
+        clemInput.value_a = g_sokolToADBKey[evt->key_code];
+        clemInput.type = kClemensInputType_KeyDown;
+        break;
     case SAPP_EVENTTYPE_KEY_UP:
-      clemInput.value_a = g_sokolToADBKey[evt->key_code];
-      clemInput.type = kClemensInputType_KeyUp;
-      break;
+        clemInput.value_a = g_sokolToADBKey[evt->key_code];
+        clemInput.type = kClemensInputType_KeyUp;
+        break;
     case SAPP_EVENTTYPE_MOUSE_DOWN:
-      clemInput.type = kClemensInputType_MouseButtonDown;
-      if (evt->mouse_button == SAPP_MOUSEBUTTON_LEFT) {
-        clemInput.value_a |= 0x01;
-        clemInput.value_b |= 0x01;
-      }
-      break;
+        clemInput.type = kClemensInputType_MouseButtonDown;
+        if (evt->mouse_button == SAPP_MOUSEBUTTON_LEFT) {
+            clemInput.value_a |= 0x01;
+            clemInput.value_b |= 0x01;
+        }
+        break;
     case SAPP_EVENTTYPE_MOUSE_UP:
-      clemInput.type = kClemensInputType_MouseButtonUp;
-      if (evt->mouse_button == SAPP_MOUSEBUTTON_LEFT) {
-        clemInput.value_a |= 0x01;
-        clemInput.value_b |= 0x01;
-      }
-      break;
+        clemInput.type = kClemensInputType_MouseButtonUp;
+        if (evt->mouse_button == SAPP_MOUSEBUTTON_LEFT) {
+            clemInput.value_a |= 0x01;
+            clemInput.value_b |= 0x01;
+        }
+        break;
     case SAPP_EVENTTYPE_MOUSE_MOVE:
-      clemInput.type = kClemensInputType_MouseMove;
-      clemInput.value_a = (int16_t)(std::floor(evt->mouse_dx));
-      clemInput.value_b = (int16_t)(std::floor(evt->mouse_dy));
-      break;
+        clemInput.type = kClemensInputType_MouseMove;
+        clemInput.value_a = (int16_t)(std::floor(evt->mouse_dx));
+        clemInput.value_b = (int16_t)(std::floor(evt->mouse_dy));
+        break;
     default:
-      clemInput.type = kClemensInputType_None;
-      break;
-  }
-  if (clemInput.type != kClemensInputType_None) {
-    if (evt->modifiers & SAPP_MODIFIER_CAPS) {
-      g_ADBKeyToggleMask |= CLEM_ADB_KEYB_TOGGLE_CAPS_LOCK;
-    } else {
-      g_ADBKeyToggleMask &= ~CLEM_ADB_KEYB_TOGGLE_CAPS_LOCK;
+        clemInput.type = kClemensInputType_None;
+        break;
     }
-    clemInput.adb_key_toggle_mask = g_ADBKeyToggleMask;
-    g_Host->input(clemInput);
-  }
+    if (clemInput.type != kClemensInputType_None) {
+        if (evt->modifiers & SAPP_MODIFIER_CAPS) {
+            g_ADBKeyToggleMask |= CLEM_ADB_KEYB_TOGGLE_CAPS_LOCK;
+        } else {
+            g_ADBKeyToggleMask &= ~CLEM_ADB_KEYB_TOGGLE_CAPS_LOCK;
+        }
+        clemInput.adb_key_toggle_mask = g_ADBKeyToggleMask;
+        g_Host->input(clemInput);
+    }
 
-  simgui_handle_event(evt);
+    simgui_handle_event(evt);
 }
 
-static void onCleanup()
-{
-  delete g_Host;
+static void onCleanup() {
+    delete g_Host;
 
-  g_Host = nullptr;
+    g_Host = nullptr;
 
 #if CLEMENS_PLATFORM_WINDOWS
-  CoUninitialize();
+    CoUninitialize();
 #endif
-  simgui_shutdown();
-  sg_shutdown();
+    simgui_shutdown();
+    sg_shutdown();
 }
 
-static void onFail(const char* msg)
-{
-  printf("app failure: %s", msg);
-}
+static void onFail(const char *msg) { printf("app failure: %s", msg); }
 
+sapp_desc sokol_main(int /*argc*/, char *[] /*argv[]*/) {
+    sapp_desc sapp = {};
 
-sapp_desc sokol_main(int /*argc*/, char*[] /*argv[]*/)
-{
-  sapp_desc sapp = {};
+    sapp.width = 1440;
+    sapp.height = 900;
+    sapp.init_cb = &onInit;
+    sapp.frame_cb = &onFrame;
+    sapp.cleanup_cb = &onCleanup;
+    sapp.event_cb = &onEvent;
+    sapp.fail_cb = &onFail;
+    sapp.window_title = "Clemens IIgs Developer";
+    sapp.win32_console_create = true;
+    sapp.win32_console_attach = true;
 
-  sapp.width = 1440;
-  sapp.height = 900;
-  sapp.init_cb = &onInit;
-  sapp.frame_cb = &onFrame;
-  sapp.cleanup_cb = &onCleanup;
-  sapp.event_cb = &onEvent;
-  sapp.fail_cb = &onFail;
-  sapp.window_title = "Clemens IIgs Developer";
-  sapp.win32_console_create = true;
-  sapp.win32_console_attach = true;
-
-  return sapp;
+    return sapp;
 }

--- a/host/clem_host_app.cpp
+++ b/host/clem_host_app.cpp
@@ -43,7 +43,6 @@ static bool g_escapeKeyDown = false;
 static sapp_keycode onKeyDown(const sapp_event *evt) {
     if (evt->modifiers & (SAPP_MODIFIER_CTRL + SAPP_MODIFIER_ALT)) {
         if (evt->key_code == SAPP_KEYCODE_F1 && !g_escapeKeyDown) {
-            printf("ESCAPE DOWN\n");
             g_escapeKeyDown = true;
             return SAPP_KEYCODE_ESCAPE;
         }
@@ -58,7 +57,6 @@ static sapp_keycode onKeyDown(const sapp_event *evt) {
 static sapp_keycode onKeyUp(const sapp_event *evt) {
     if (g_escapeKeyDown) {
         if (evt->key_code == SAPP_KEYCODE_F1) {
-            printf("ESCAPE UP\n");
             g_escapeKeyDown = false;
             return SAPP_KEYCODE_ESCAPE;
         } else if (evt->key_code == SAPP_KEYCODE_ESCAPE) {

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -135,6 +135,7 @@ struct ClemensBackendState {
     const ClemensBackendBreakpoint *bpBufferEnd;
     std::optional<unsigned> bpHitIndex;
     const ClemensBackendDiskDriveState *diskDrives;
+    const ClemensBackendDiskDriveState *smartDrives;
     const ClemensBackendExecutedInstruction *logInstructionStart;
     const ClemensBackendExecutedInstruction *logInstructionEnd;
 

--- a/serializer.c
+++ b/serializer.c
@@ -201,6 +201,7 @@ struct ClemensSerializerRecord kADB[] = {
     CLEM_SERIALIZER_RECORD_OBJECT(struct ClemensDeviceADB, gameport, struct ClemensDeviceGameport,
                                   kGameport),
     CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensDeviceADB, kClemensSerializerTypeUInt8, ram, 256, 0),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDeviceADB, irq_dispatch),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDeviceADB, irq_line),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 
@@ -233,8 +234,8 @@ struct ClemensSerializerRecord kSmartPortPacket[] = {
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, is_extended),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, status),
     CLEM_SERIALIZER_RECORD_UINT8(struct ClemensSmartPortPacket, contents_length),
-    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortPacket, kClemensSerializerTypeUInt8, contents,
-                                CLEM_SMARTPORT_CONTENTS_LIMIT, 0),
+    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortPacket, kClemensSerializerTypeUInt8,
+                                 contents, CLEM_SMARTPORT_CONTENTS_LIMIT, 0),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 
 struct ClemensSerializerRecord kSmartPortDevice[] = {
@@ -257,8 +258,8 @@ struct ClemensSerializerRecord kSmartPort[] = {
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_state_byte_cnt),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, packet_cntr),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensSmartPortUnit, data_size),
-    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortUnit, kClemensSerializerTypeUInt8, data, 
-                                CLEM_SMARTPORT_DATA_BUFFER_LIMIT, 0),
+    CLEM_SERIALIZER_RECORD_ARRAY(struct ClemensSmartPortUnit, kClemensSerializerTypeUInt8, data,
+                                 CLEM_SMARTPORT_DATA_BUFFER_LIMIT, 0),
     CLEM_SERIALIZER_RECORD_OBJECT(struct ClemensSmartPortUnit, packet,
                                   struct ClemensSmartPortPacket, kSmartPortPacket),
     CLEM_SERIALIZER_RECORD_EMPTY()};


### PR DESCRIPTION
Some ADB cleanup for better IRQ status reporting and feedback via IO register $C026.   Side effect is a working "Option

Also some general UI polish that should help users understand the current emulator state (drive status, input, etc.)

- Ctrl-Apple-F1 triggers the Desktop Manager UI (when Ctrl is pressed, F1 becomes Escape)
- Various ADB fixes to return data via $C026 and IRQ reporting of data events
- Drive Spindle status fixes when switching between drives in the IWM
- GS/OS 5.25 drive detection fix - Drive returns fake bits when no disk is in the drive
- Reflect drive status in the emulator
- Reflect input status in emulator (mouse-lock, keyboard focus) within the view
- Fixed incorrect flashing characters with alternate character set