### PR TITLE
Fast Disk Emulation when IWM is active and disk is spinning

### DIFF
--- a/clem_device.h
+++ b/clem_device.h
@@ -218,6 +218,16 @@ void clem_iwm_glu_sync(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *dri
                        struct ClemensClock *clock);
 
 /**
+ * @brief Returns if the IWM is actively in read or write mode to a specific drive
+ *
+ * @param iwm
+ * @param drives
+ * @return true
+ * @return false
+ */
+bool clem_iwm_is_active(struct ClemensDeviceIWM *iwm, struct ClemensDriveBay *drives);
+
+/**
  * @brief Executed from the memory subsystem for MMIO
  *
  * @param iwm IWM data

--- a/clem_mmio_types.h
+++ b/clem_mmio_types.h
@@ -278,6 +278,8 @@ struct ClemensDeviceIWM {
     clem_clocks_time_t last_clocks_ts;
     /** Used for async write timing */
     clem_clocks_time_t last_write_clocks_ts;
+    /** Used for determining if applications are actually using the IWM for RW disk access*/
+    uint32_t data_access_time_ns;
 
     /** Drive I/O */
     unsigned io_flags;  /**< Disk port I/O flags */

--- a/emulator.h
+++ b/emulator.h
@@ -3,6 +3,8 @@
 
 #include "clem_types.h"
 
+#define clemens_is_irq_enabled(_clem_) (!((_clem_)->cpu.P & kClemensCPUStatus_IRQDisable))
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -147,6 +147,10 @@ void clemens_remove_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
     mmio->active_drives.smartport[drive_index].unit_id = 0;
 }
 
+bool clemens_is_drive_io_active(ClemensMMIO *mmio) {
+    return clem_iwm_is_active(&mmio->dev_iwm, &mmio->active_drives);
+}
+
 ClemensMonitor *clemens_get_monitor(ClemensMonitor *monitor, ClemensMMIO *mmio) {
     struct ClemensVGC *vgc = &mmio->vgc;
 

--- a/emulator_mmio.h
+++ b/emulator_mmio.h
@@ -142,6 +142,20 @@ void clemens_remove_smartport_disk(ClemensMMIO *mmio, unsigned drive_index,
                                    struct ClemensSmartPortDevice *device);
 
 /**
+ * @brief If the IWM is actively reading or writing to a drive, returns true.
+ *
+ * This can be used by the emulator to turn on fast emulation when reading
+ * from a disk.
+ *
+ * Criteria for this state depends on a combination of IWM states.
+ *
+ * @param mmio
+ * @return true The IWM is actively reading or writing to a drive
+ * @return false No drive access
+ */
+bool clemens_is_drive_io_active(ClemensMMIO *mmio);
+
+/**
  * @brief Forwards input from ths host machine to the ADB
  *
  * @param mmio

--- a/host/clem_audio.cpp
+++ b/host/clem_audio.cpp
@@ -5,147 +5,157 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "fmt/core.h"
+
 //  TODO: optimize when needed per platform
 
 ClemensAudioDevice::ClemensAudioDevice()
-    : queuedFrameBuffer_(nullptr), queuedFrameHead_(0), queuedFrameTail_(0),
-      queuedFrameLimit_(0), queuedFrameStride_(0) {
-
-}
+    : queuedFrameBuffer_(nullptr), queuedFrameHead_(0), queuedFrameTail_(0), queuedFrameLimit_(0),
+      queuedFrameStride_(0) {}
 
 ClemensAudioDevice::~ClemensAudioDevice() { stop(); }
 
 void ClemensAudioDevice::start() {
-  saudio_desc audioDesc = {};
-  audioDesc.sample_rate = 48000;
-  audioDesc.num_channels = 2;
-  audioDesc.buffer_frames = 2048;
-  audioDesc.stream_userdata_cb = &ClemensAudioDevice::mixAudio;
-  audioDesc.user_data = this;
-  saudio_setup(audioDesc);
+    saudio_desc audioDesc = {};
+    audioDesc.sample_rate = 48000;
+    audioDesc.num_channels = 2;
+    audioDesc.buffer_frames = 2048;
+    audioDesc.stream_userdata_cb = &ClemensAudioDevice::mixAudio;
+    audioDesc.user_data = this;
+    saudio_setup(audioDesc);
 
-  queuedFrameHead_ = 0;
-  queuedFrameTail_ = 0;
-  if (saudio_isvalid()) {
-    queuedFrameStride_ = 2 * sizeof(float);
-    queuedFrameLimit_ = saudio_sample_rate() / 2;
-    queuedFrameBuffer_ = new uint8_t[queuedFrameLimit_ * queuedFrameStride_];
-  } else {
-    queuedFrameStride_ = 0;
-    queuedFrameLimit_ = 0;
-    queuedFrameBuffer_ = nullptr;
-  }
+    queuedFrameHead_ = 0;
+    queuedFrameTail_ = 0;
+    if (saudio_isvalid()) {
+        queuedFrameStride_ = 2 * sizeof(float);
+        queuedFrameLimit_ = saudio_sample_rate() / 2;
+        queuedFrameBuffer_ = new uint8_t[queuedFrameLimit_ * queuedFrameStride_];
+        fmt::print("ClemensAudioDevice queuedFrameBuffer {} khz, frame limit = {}, stride = {}\n",
+                   audioDesc.sample_rate / 1000.0f, queuedFrameLimit_, queuedFrameStride_);
+    } else {
+        queuedFrameStride_ = 0;
+        queuedFrameLimit_ = 0;
+        queuedFrameBuffer_ = nullptr;
+    }
 }
 
 void ClemensAudioDevice::stop() {
-  if (saudio_isvalid()) {
-    saudio_shutdown();
-    delete[] queuedFrameBuffer_;
-    queuedFrameBuffer_ = nullptr;
-  }
+    if (saudio_isvalid()) {
+        saudio_shutdown();
+        delete[] queuedFrameBuffer_;
+        queuedFrameBuffer_ = nullptr;
+    }
 }
 
-unsigned ClemensAudioDevice::getAudioFrequency() const {
-  return saudio_sample_rate();
-}
-unsigned ClemensAudioDevice::getBufferStride() const {
-  return queuedFrameStride_;
-}
+unsigned ClemensAudioDevice::getAudioFrequency() const { return saudio_sample_rate(); }
+unsigned ClemensAudioDevice::getBufferStride() const { return queuedFrameStride_; }
 
 unsigned ClemensAudioDevice::queue(ClemensAudio &audio, float /*deltaTime */) {
-  if (!audio.frame_count || !queuedFrameBuffer_)
-    return 0;
+    if (!audio.frame_count || !queuedFrameBuffer_)
+        return 0;
 
-  //  the audio data layout of our queue must be the same as the data coming
-  //  in from the emulated device.  conversion between formats occurs during
-  //  the actual mix.
-  assert(audio.frame_stride == queuedFrameStride_);
+    //  the audio data layout of our queue must be the same as the data coming
+    //  in from the emulated device.  conversion between formats occurs during
+    //  the actual mix.
+    assert(audio.frame_stride == queuedFrameStride_);
 
-  //  update will mutex mixAudio, which is necessary when running the mixer
-  //  callbacks in the core audio thread.
-  unsigned audioInUsed = 0;
-  {
+    //  update will mutex mixAudio, which is necessary when running the mixer
+    //  callbacks in the core audio thread.
+    unsigned audioInUsed = 0;
+    {
+        std::lock_guard<std::mutex> lk(queuedFrameMutex_);
+
+        //  the input comes from a flat buffer, so ignore the buffer frame limit.
+        //   TODO: Don't think we're going to support wraparound here, so look into better
+        //         ways for the API to illustrate this.
+        uint32_t audioInHead = audio.frame_start;
+        uint32_t audioInEnd = audio.frame_total;
+        uint32_t audioInTail = audio.frame_start + audio.frame_count;
+        if (audioInTail > audioInEnd) {
+            audioInTail -= audioInTail;
+        }
+        uint32_t audioInAvailable = audio.frame_count;
+        uint32_t audioOutAvailable = queuedFrameLimit_ - queuedFrameTail_;
+
+        assert(audioInTail >= audioInHead);
+
+        if (audioInAvailable > audioOutAvailable && queuedFrameHead_ > 0) {
+            //  adjust audioOut queue so that all frames *already* mixed are removed
+            //  which will free up some space
+            if (queuedFrameHead_ != queuedFrameTail_) {
+                memmove(queuedFrameBuffer_,
+                        queuedFrameBuffer_ + (queuedFrameHead_ * queuedFrameStride_),
+                        (queuedFrameTail_ - queuedFrameHead_) * queuedFrameStride_);
+                queuedFrameTail_ -= queuedFrameHead_;
+            } else {
+                queuedFrameTail_ = 0;
+            }
+            queuedFrameHead_ = 0;
+            audioOutAvailable = queuedFrameLimit_ - queuedFrameTail_;
+        }
+        if (audioInAvailable > audioOutAvailable) {
+            //  copy only the amount we can to the output - so we don't have to
+            //  bounds check against our queued output buffer when copying data.
+            audioInAvailable = audioOutAvailable;
+        }
+
+        //  copy occurs from at most two windows in the input (re: ring buffer), to
+        //  the single output window.
+        uint8_t *audioOut = queuedFrameBuffer_ + queuedFrameTail_ * queuedFrameStride_;
+        uint8_t *audioIn = audio.data + audioInHead * audio.frame_stride;
+
+        uint32_t audioInCount = audioInTail - audioInHead;
+        assert(audioInHead + audioInAvailable <= audioInEnd);
+        /*
+        if (audioInHead + audioInAvailable > audioInEnd) {
+            audioInCount = audioInEnd - audioInHead;
+            memcpy(audioOut, audioIn, audioInCount * audio.frame_stride);
+            queuedFrameTail_ += audioInCount;
+            audioOut = queuedFrameBuffer_ + queuedFrameTail_ * queuedFrameStride_;
+            audioIn = audio.data;
+            audioInAvailable -= audioInCount;
+            audioInUsed += audioInCount;
+            audioInHead = 0;
+        }
+        */
+        uint32_t framesOutCount = std::min(audioOutAvailable, audioInCount);
+        // memset(audioOut, 0xea, audioInCount * audio.frame_stride);
+        memcpy(audioOut, audioIn, framesOutCount * audio.frame_stride);
+        queuedFrameTail_ += framesOutCount;
+        audioInAvailable -= framesOutCount;
+        audioInUsed += framesOutCount;
+        if (audioInAvailable > 0) {
+            fmt::print("ClemensAudioDevice: {} frames not queued for playback, output = {}\n",
+                       audioInAvailable, framesOutCount);
+        }
+    }
+
+    return audioInUsed;
+}
+
+void ClemensAudioDevice::mixClemensAudio(float *audioOut, int num_frames, int num_channels) {
     std::lock_guard<std::mutex> lk(queuedFrameMutex_);
+    //  clemens generates an output mix == to the hardware mixer to avoid having
+    //  to upsample here.
+    uint32_t queuedAvailable = queuedFrameTail_ - queuedFrameHead_;
+    if (queuedAvailable != 0) {
+        auto frameLimit = std::min(queuedAvailable, (uint32_t)num_frames);
+        const uint8_t *inData = queuedFrameBuffer_ + queuedFrameHead_ * queuedFrameStride_;
+        float *frameOut = audioOut;
 
-    //  the input comes from a ring buffer
-    uint32_t audioInHead = audio.frame_start;
-    uint32_t audioInTail =
-        (audio.frame_start + audio.frame_count) % audio.frame_total;
-    uint32_t audioInEnd = audio.frame_total;
-    uint32_t audioInAvailable = audio.frame_count;
-    uint32_t audioOutAvailable = queuedFrameLimit_ - queuedFrameTail_;
-
-    if (audioInAvailable > audioOutAvailable && queuedFrameHead_ > 0) {
-      //  adjust audioOut queue so that all frames *already* mixed are removed
-      //  which will free up some space
-      if (queuedFrameHead_ != queuedFrameTail_) {
-        memmove(queuedFrameBuffer_,
-                queuedFrameBuffer_ + (queuedFrameHead_ * queuedFrameStride_),
-                (queuedFrameTail_ - queuedFrameHead_) * queuedFrameStride_);
-        queuedFrameTail_ -= queuedFrameHead_;
-      } else {
-        queuedFrameTail_ = 0;
-      }
-      queuedFrameHead_ = 0;
-      audioOutAvailable = queuedFrameTail_ - queuedFrameLimit_;
+        for (uint32_t frameIndex = 0; frameIndex < frameLimit; ++frameIndex) {
+            auto *frameIn = reinterpret_cast<const float *>(inData);
+            inData += queuedFrameStride_;
+            frameOut[0] = frameIn[0];
+            frameOut[1] = frameIn[1];
+            frameOut += num_channels;
+        }
+        queuedFrameHead_ += frameLimit;
     }
-    if (audioInAvailable > audioOutAvailable) {
-      //  copy only the amount we can to the output - so we don't have to
-      //  bounds check against our queued output buffer when copying data.
-      audioInAvailable = audioOutAvailable;
-    }
-
-    //  copy occurs from at most two windows in the input (re: ring buffer), to
-    //  the single output window.
-    uint8_t *audioOut =
-        queuedFrameBuffer_ + queuedFrameTail_ * queuedFrameStride_;
-    uint8_t *audioIn = audio.data + audioInHead * audio.frame_stride;
-
-    uint32_t audioInCount;
-    if (audioInHead + audioInAvailable > audioInEnd) {
-      audioInCount = audioInEnd - audioInHead;
-      memcpy(audioOut, audioIn, audioInCount * audio.frame_stride);
-      queuedFrameTail_ += audioInCount;
-      audioOut = queuedFrameBuffer_ + queuedFrameTail_ * queuedFrameStride_;
-      audioIn = audio.data;
-      audioInAvailable -= audioInCount;
-      audioInUsed += audioInCount;
-      audioInHead = 0;
-    }
-    audioInCount = std::min(audioInAvailable, audioInTail - audioInHead);
-
-    memcpy(audioOut, audioIn, audioInCount * audio.frame_stride);
-    queuedFrameTail_ += audioInCount;
-    audioInAvailable -= audioInCount;
-    audioInUsed += audioInCount;
-    assert(audioInAvailable == 0);
- }
-
-  return audioInUsed;
 }
 
-void ClemensAudioDevice::mixClemensAudio(float* audioOut, int num_frames, int num_channels) {
-  std::lock_guard<std::mutex> lk(queuedFrameMutex_);
-  //  clemens generates an output mix == to the hardware mixer to avoid having
-  //  to upsample here.
-  uint32_t queuedAvailable = queuedFrameTail_ - queuedFrameHead_;
-  if (queuedAvailable != 0) {
-    auto frameLimit = std::min(queuedAvailable, (uint32_t)num_frames);
-    const uint8_t *inData = queuedFrameBuffer_ + queuedFrameHead_ * queuedFrameStride_;
-    float* frameOut = audioOut;
-    for (uint32_t frameIndex = 0; frameIndex < frameLimit; ++frameIndex) {
-      auto *frameIn = reinterpret_cast<const float *>(inData);
-      inData += queuedFrameStride_;
-      frameOut[0] = frameIn[0];
-      frameOut[1] = frameIn[1];
-      frameOut += num_channels;
-    }
-    queuedFrameHead_ += frameLimit;
-  }
-}
-
-void ClemensAudioDevice::mixAudio(float* buffer, int num_frames, int num_channels,
-                                  void* user_data) {
-  auto *audio = reinterpret_cast<ClemensAudioDevice *>(user_data);
-  audio->mixClemensAudio(buffer, num_frames, num_channels);
+void ClemensAudioDevice::mixAudio(float *buffer, int num_frames, int num_channels,
+                                  void *user_data) {
+    auto *audio = reinterpret_cast<ClemensAudioDevice *>(user_data);
+    audio->mixClemensAudio(buffer, num_frames, num_channels);
 }

--- a/host/clem_audio.hpp
+++ b/host/clem_audio.hpp
@@ -23,6 +23,7 @@ class ClemensAudioDevice {
 
     void mixClemensAudio(float *buffer, int num_frames, int num_channels);
 
+    // audio sent to the hardware mixer
     uint8_t *queuedFrameBuffer_;
     uint32_t queuedFrameHead_;
     uint32_t queuedFrameTail_;

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -27,15 +27,8 @@ static constexpr unsigned kLogOutputLineLimit = 1024;
 static constexpr unsigned kSmartPortDiskBlockCount = 32 * 1024 * 2; // 32 MB blocks
 
 struct ClemensRunSampler {
-    //  our method of keeping the simulation in sync with real time is to rely
-    //  on two counters
-    //    - sDT = simulation counter that ticks at a fixed rate, and
-    //    - aDT = real-time timer that counts the actual time passed
-    //
-    //  if aDT < sDT, then sleep the amount of time needed to catch up with sDT
-    //  if aDT >= sDT, then clamp aDT to sDT
-    std::chrono::microseconds fixedTimeInterval;
-    std::chrono::microseconds actualTimeInterval;
+    std::chrono::microseconds referenceFrameTimer;
+    std::chrono::microseconds actualFrameTimer;
     std::chrono::microseconds sampledFrameTime;
 
     double sampledFramesPerSecond;
@@ -48,17 +41,19 @@ struct ClemensRunSampler {
     cinek::CircularBuffer<clem_clocks_duration_t, 120> cyclesBuffer;
 
     double sampledEmulatorSpeedMhz;
+    double actualEmulatorSpeedMhz;
 
     ClemensRunSampler() { reset(); }
 
     void reset() {
-        fixedTimeInterval = std::chrono::microseconds::zero();
-        actualTimeInterval = std::chrono::microseconds::zero();
+        referenceFrameTimer = std::chrono::microseconds::zero();
+        actualFrameTimer = std::chrono::microseconds::zero();
         sampledFrameTime = std::chrono::microseconds::zero();
         sampledClocksSpent = 0;
         sampledCyclesSpent = 0;
         sampledFramesPerSecond = 0.0f;
         sampledEmulatorSpeedMhz = 0.0f;
+        actualEmulatorSpeedMhz = 0.0f;
         frameTimeBuffer.clear();
         clocksBuffer.clear();
         cyclesBuffer.clear();
@@ -67,20 +62,30 @@ struct ClemensRunSampler {
     void update(std::chrono::microseconds fixedFrameInterval,
                 std::chrono::microseconds actualFrameInterval, clem_clocks_duration_t clocksSpent,
                 unsigned cyclesSpent) {
-        fixedTimeInterval += fixedFrameInterval;
-        actualTimeInterval += actualFrameInterval;
-        //  see notes at the head of this class for how delta times are calculated
-        //  in an attempt to maintain a fixed frame rate on systems where sleep()
-        //  delays can overshoot the desired sleep time (Windows especially.)
-        if (actualTimeInterval < fixedTimeInterval) {
-            std::this_thread::sleep_for(fixedTimeInterval - actualTimeInterval);
-            fixedTimeInterval -= actualTimeInterval;
-            actualTimeInterval = std::chrono::microseconds::zero();
-        } else {
+
+        // Our goal is to keep the actualFrameTimer roughly in sync with the referenceFrameTimer.
+        // Given how thread scheduling differs between platforms and machines, it's expected the
+        // "actual" timer will overshoot and undershoot the reference timer during a run.
+        // This method will attempt to keep up using a timer delay.
+
+        referenceFrameTimer += fixedFrameInterval;
+        actualFrameTimer += actualFrameInterval;
+
+        if (actualFrameTimer >= referenceFrameTimer) {
+            //  Our runner is taking too long, so try to catch up.
+            //
             std::this_thread::yield();
-            if (actualTimeInterval - fixedFrameInterval > std::chrono::microseconds(500000)) {
-                actualTimeInterval = fixedTimeInterval = std::chrono::microseconds::zero();
+            if (actualFrameTimer - referenceFrameTimer > std::chrono::microseconds(500000)) {
+                //  TODO: Check whether this value increases over time - means we have a slow
+                //  machine.  This hack below will reset the timers to cap the delay
+                actualFrameTimer = referenceFrameTimer = std::chrono::microseconds::zero();
             }
+        } else {
+            // Our runner is faster than the machine speed.  Keep our runner at the desired
+            // framerate.
+            std::this_thread::sleep_for(referenceFrameTimer - actualFrameTimer);
+            referenceFrameTimer -= actualFrameTimer;
+            actualFrameTimer = std::chrono::microseconds::zero();
         }
 
         if (frameTimeBuffer.isFull()) {
@@ -120,6 +125,7 @@ struct ClemensRunSampler {
             sampledEmulatorSpeedMhz =
                 1.023 * double(CLEM_CLOCKS_MEGA2_CYCLE * sampledCyclesSpent) / sampledClocksSpent;
         }
+        // TODO: calculate # cycles per second = actual mhz (for fast emulation mode)
     }
 };
 
@@ -729,6 +735,8 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
     ClemensBackendState publishedState{};
     publishedState.results.reserve(8);
 
+    double emulatorTimeScalar = 1.0; //  used for fast emulation
+
     while (!isTerminated) {
         bool isRunning = !stepsRemaining.has_value() || *stepsRemaining > 0;
         bool publishState = false;
@@ -885,9 +893,18 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
 
             clemens_rtc_set(&mmio_, (unsigned)epoch_time_1904);
 
+            // TODO: this should be an adaptive scalar to support a variety of devices.
+            // Though if the emulator runs hot (cannot execute the desired cycles in enough time),
+            // that shouldn't matter too much given that this 'speed boost' is meant to be
+            // temporary, and the emulator should catch up once the IWM is inactive.
+            if (clemens_is_drive_io_active(&mmio_)) {
+                emulatorTimeScalar = 8.0;
+            } else {
+                emulatorTimeScalar = 1.0;
+            }
             auto lastClocksSpent = machine_.tspec.clocks_spent;
             int64_t clocksPerTimeslice =
-                calculateClocksPerTimeslice(&mmio_, emulatorRefreshFrequency);
+                calculateClocksPerTimeslice(&mmio_, emulatorRefreshFrequency) * emulatorTimeScalar;
 
             clocksRemainingInTimeslice += clocksPerTimeslice;
 
@@ -1062,6 +1079,7 @@ void ClemensBackend::main(PublishStateDelegate publishDelegate) {
             }
             publishedState.debugMemoryPage = debugMemoryPage_;
             publishedState.emulatorSpeedMhz = runSampler.sampledEmulatorSpeedMhz;
+            publishedState.fastEmulationOn = emulatorTimeScalar > 1.0f;
             publishedState.message = std::move(debugMessage);
 
             // send the published state to our listener

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -689,7 +689,7 @@ void ClemensFrontend::lostFocus() {
 }
 
 std::unique_ptr<ClemensBackend> ClemensFrontend::createBackend() {
-    constexpr unsigned refreshFrequency_ = 60;
+    constexpr unsigned refreshFrequency_ = 30;
     auto romPath = std::filesystem::path(config_.dataDirectory) / config_.romFilename;
     auto backend = std::make_unique<ClemensBackend>(
         romPath.string(), backendConfig_,
@@ -1155,7 +1155,7 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
         audioFrame.frame_stride = frameReadState_.audioFrame.frame_stride;
         audioFrame.frame_start = 0;
         audioFrame.frame_count = thisFrameAudioBuffer_.getSize() / audioFrame.frame_stride;
-        audioFrame.frame_total = thisFrameAudioBuffer_.getCapacity() / audioFrame.frame_stride;
+        audioFrame.frame_total = thisFrameAudioBuffer_.getSize() / audioFrame.frame_stride;
         audio_.queue(audioFrame, deltaTime);
         thisFrameAudioBuffer_.reset();
     }
@@ -2749,8 +2749,8 @@ void ClemensFrontend::doMachineViewLayout(ImVec2 rootAnchor, ImVec2 rootSize, fl
         //  This logic is rather convoluted - we have two focus types and this logic is
         //  an attempt to determine the user's intent regarding where keyboard and mouse
         //  input goes (to the emulator vs GUI.)  Basically if the mouse pointer is in
-        //  the emulator view, all keyboard input goes to the view.  If the user mouse-clicks
-        //  inside the emulator view, all input goes to the view.
+        //  the emulator view, all keyboard input goes to the view.  If the user
+        //  mouse-clicks inside the emulator view, all input goes to the view.
         if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !emulatorHasMouseFocus_) {
             emulatorHasMouseFocus_ = ImGui::IsWindowHovered();
         }
@@ -3719,10 +3719,10 @@ void ClemensFrontend::cmdLog(std::string_view operand) {
     auto levelName = std::find_if(logLevelNames.begin(), logLevelNames.end(),
                                   [&operand](const char *name) { return operand == name; });
     if (levelName == logLevelNames.end()) {
-        CLEM_TERM_COUT.format(
-            TerminalLine::Error,
-            "Log level '{}' is not one of the following: DEBUG, INFO, WARN, UNIMPL or FATAL",
-            operand);
+        CLEM_TERM_COUT.format(TerminalLine::Error,
+                              "Log level '{}' is not one of the following: DEBUG, INFO, "
+                              "WARN, UNIMPL or FATAL",
+                              operand);
         return;
     }
     backend_->debugLogLevel(int(levelName - logLevelNames.begin()));

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -689,7 +689,7 @@ void ClemensFrontend::lostFocus() {
 }
 
 std::unique_ptr<ClemensBackend> ClemensFrontend::createBackend() {
-    constexpr unsigned refreshFrequency_ = 30;
+    constexpr unsigned refreshFrequency_ = 60;
     auto romPath = std::filesystem::path(config_.dataDirectory) / config_.romFilename;
     auto backend = std::make_unique<ClemensBackend>(
         romPath.string(), backendConfig_,

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -162,6 +162,7 @@ struct ClemensBackendState {
     uint8_t debugMemoryPage;
 
     float emulatorSpeedMhz;
+    bool fastEmulationOn;
 
     // valid if a debugMessage() command was issued from the frontend
     std::optional<std::string> message;

--- a/serializer.c
+++ b/serializer.c
@@ -151,6 +151,7 @@ struct ClemensSerializerRecord kSCC[] = {
 struct ClemensSerializerRecord kIWM[] = {
     CLEM_SERIALIZER_RECORD_CLOCKS(struct ClemensDeviceIWM, last_clocks_ts),
     CLEM_SERIALIZER_RECORD_CLOCKS(struct ClemensDeviceIWM, last_write_clocks_ts),
+    CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDeviceIWM, data_access_time_ns),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDeviceIWM, io_flags),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensDeviceIWM, out_phase),
     CLEM_SERIALIZER_RECORD_BOOL(struct ClemensDeviceIWM, enable2),


### PR DESCRIPTION
This implements most of what's spec'ed out in issue https://github.com/samkusin/clemens_iigs/issues/53.   

This PR does not check for IRQ nor does it silence the A2 speaker.

Instead, given a spinning disk, an arbitrary delay (similar to the 1 second rule for 5.25" disk access/spin) is instituted where if there's no IWM data access (read or write) within a set period of time.   This may be problematic for applications that check user-input during disk access (especially in GS applications.).  Some experimentation and dogfooding needed to fix bugs.

Will also need an option to disable this emulation in the emulator host.