### PR TITLE
Double Hires artifacts and pixel offset fixes

### DIFF
--- a/render.c
+++ b/render.c
@@ -303,117 +303,6 @@ static void _render_hires(const ClemensVideo *video, const uint8_t *memory, uint
 //
 //  TODO: optimize using lookup tables
 //
-static inline bool jk_ff(bool j, bool k, bool q) {
-    if (!j && !k)
-        return q;
-    if (!j && k)
-        return 0;
-    if (j && !k)
-        return 1;
-    return !q;
-}
-/*
-static void a2hgrToColorMap2x2(uint8_t *pixout_y0, uint8_t *pixout_y1, const uint8_t *scanline,
-                               int scanlineByteCnt) {
-    int pixinByteCounter = 0;
-    int pixinBitCounter = 0;
-    uint8_t pixinByte = *scanline;
-    uint8_t shifter = 0;
-    uint8_t barrel = 0;
-    uint8_t latch = 0;
-    bool jk0 = false;
-    bool jk1 = false;
-
-    scanlineByteCnt <<= 1;
-    while (pixinByteCounter < scanlineByteCnt) {
-        bool pixinBit = (pixinByte & 0x1);
-        bool colorChanged0 = (pixinBit && !(shifter & 0x2));
-        unsigned barrelShift = (pixinBitCounter % 4);
-        barrel = shifter >> barrelShift;
-        barrel |= (shifter << (4 - barrelShift));
-        barrel &= 0xf;
-
-        uint8_t selected = (jk0 || jk1) ? latch : barrel;
-        uint8_t pixout = (latch << 4) + 8;
-        *(pixout0++) = pixout;
-        *(pixout1++) = pixout;
-
-        //  next clock
-        jk0 = jk_ff(colorChanged0, shifter & 0x4, jk0);
-        jk1 = jk_ff(colorChanged1, !(shifter & 0x4), jk1);
-        shifter <<= 1;
-        shifter |= (pixinBit ? 0x1 : 0);
-        latch = selected;
-        pixinByte >>= 1;
-        ++pixinBitCounter;
-        if (!(pixinBitCounter % 7)) {
-            ++scanlines[pixinByteCounter % 2];
-            ++pixinByteCounter;
-            pixinByte = *scanlines[pixinByteCounter % 2];
-        }
-    }
-}
-*/
-
-static void a2dhgrToABGR81x2(uint8_t *pixout0, uint8_t *pixout1, const uint8_t *scanlines[2],
-                             int scanline_byte_cnt) {
-    int pixin_byte_index = 0;
-    int clock_ctr = 0; // 1 bit per clock cycle
-    uint8_t pixin_byte = *scanlines[0];
-    unsigned shifter = 0x00;
-    unsigned barrel = 0x00;
-    unsigned latch = 0x00;
-    bool jk0 = false;
-    bool jk1 = false;
-
-    scanline_byte_cnt <<= 1; // account for both scanlines/40+40
-    while (pixin_byte_index < scanline_byte_cnt) {
-        unsigned barrel_rotate = clock_ctr % 4;
-        bool pixin_bit = (pixin_byte & 0x1);
-        bool changed_3 = pixin_bit && !(shifter & 0x8);
-        bool changed_2 = !pixin_bit && (shifter & 0x8);
-        uint8_t pixout;
-        uint8_t next_latch;
-        //  barrel rotate in an attempt to retain the original nibble for comparison
-        //  with the incoming shift register pattern
-        barrel = shifter >> barrel_rotate;
-        barrel |= (shifter << (4 - barrel_rotate));
-        barrel &= 0xf;
-
-        //  select the latch input which will be applied to the latch on the next tick
-        next_latch = (jk0 || jk1) ? latch : barrel;
-        //  output indexed RGB color
-        // scales the 4-bit color to 8-bit.  this works well with color maps define 16-pixels per
-        // color horizontal so UVs can be scaled appropriately from 0 to 1 without rounding or
-        // worries abound text bleed.  The + 8 makes this resolution 5-bit (xxxx1000) where xxxx is
-        // the latch
-        pixout = (next_latch << 4) + 8;
-        *(pixout0++) = pixout;
-        *(pixout1++) = pixout;
-
-        //  next clock
-        clock_ctr++;
-
-        jk0 = jk_ff(changed_3, shifter & 0x4, jk0);
-        jk1 = jk_ff(changed_2, !(shifter & 0x4), jk1);
-
-        //  apply bit to shift register
-        shifter <<= 1;
-        shifter |= (pixin_bit ? 1 : 0);
-        shifter &= 0xf;
-
-        //  load latch with output from barrel vs prior latch selection
-        latch = next_latch;
-
-        //  advance to next byte in the video stream
-        pixin_byte >>= 1;
-        if ((clock_ctr % 7) == 0) {
-            ++scanlines[pixin_byte_index % 2];
-            ++pixin_byte_index;
-            pixin_byte = *scanlines[pixin_byte_index % 2];
-        }
-    }
-}
 
 //  scanlines[2] = {aux_memory,main_memory} interleaved for the scanline.
 //
@@ -467,24 +356,11 @@ static void a2dhgrToIndexedRGB1x2(uint8_t *pixout0, uint8_t *pixout1, const uint
             }
         }
 
-        /*
-        if (latch_counter == 0) {
-            if (changed) {
-                latch_counter = 3 - barrel_rotate;
-            }
-        } else {
-            latch_counter--;
-        }
-        */
-
         //  next clock
         clock_ctr++;
         if (tail_counter > 0) {
             tail_counter--;
         }
-
-        //  load latch with output from barrel vs prior latch selection
-        // latch = next_latch;
 
         //  apply bit to shift register
         shifter <<= 1;
@@ -522,33 +398,7 @@ static void _render_double_hires(const ClemensVideo *video, const uint8_t *main,
         const uint8_t *pixsources[2] = {aux + video->scanlines[row].offset,
                                         main + video->scanlines[row].offset};
         uint8_t *pixout = texture + y * 2 * stride;
-        // a2dhgrToABGR81x2(pixout, pixout + stride, pixsources, video->scanline_byte_cnt);
         a2dhgrToIndexedRGB1x2(pixout, pixout + stride, pixsources, video->scanline_byte_cnt);
-        /*
-        const uint8_t* pixin = pixsources[0];
-        unsigned color = 0;
-        unsigned x = 0, xi = 0;
-        uint8_t data = pixin[0];
-        while (x < 560) {
-          color <<= 1;
-          if (data & 0x1) color |= 0x1;
-          data >>= 1;
-          ++x;
-          if ((x % 4) == 0) {
-            unsigned xo = x - 4;
-            for (unsigned xo = x - 4; xo < x; ++xo) {
-              unsigned pixel = ((color & 0xf) << 4) + 8;
-              pixout[xo] = pixel;
-              (pixout + kGraphicsTextureWidth)[xo] = pixel;
-            }
-          }
-          if ((x % 7) == 0) {
-            ++xi;
-            pixin = pixsources[xi % 2];
-            data = pixin[xi >> 1];
-          }
-        }
-        */
     }
 }
 


### PR DESCRIPTION
Changes include a reexamination of the original DHGR implementation which was a literal translation of the [US Patent](https://patents.google.com/patent/US4786893A/en)

The changes revolve around the selection criteria for color when repeated bit patterns representing color transition from one color to another.    There were a couple issues with this implementation related to fringing and white/black bit strings that the new implementation resolves. 

Also the new implementation opts for the 'alternative' method described in the patent (figure 6) versus a literal JK flip-flip counter implementation.   This new implementation should clarify what exactly the selection criteria are (it is not clear from the patent from what I could tell.)  

Compared this to GSPlus and it's *slightly* different (I think this implementation is an improvement at least for the MM2 screenshot.)    When compared to AppleWin RGB (which I think emulates older RGB conversion algorithms from earlier RGB cards), it looks like a good blend between the RGB and Idealized Composite (which is close to the GSPlus look as well.)

Finally I resolve the 4 pixel offset of the final rendered image.  Screenshots below.


### Before
![dhgr-mm2-bad](https://user-images.githubusercontent.com/1252669/221607152-39658fed-cd8e-4e16-a4d7-e777a3638fed.png)

### After
![dhgr-mm2-good](https://user-images.githubusercontent.com/1252669/221607266-257778c6-66b5-45f9-9a62-f7e2cd4a3ded.png)

![dhgr-mm2-text-fix](https://user-images.githubusercontent.com/1252669/221607288-bbaafa8d-1c1e-4518-ad7b-5ae9f083ff7d.png)
