### PR TITLE
Render screen to display at the end of a VGC vertical blank 

### DIFF
--- a/clem_shared.h
+++ b/clem_shared.h
@@ -76,9 +76,15 @@ struct ClemensClock {
 #define clem_calc_ns_step_from_clocks(_clocks_step_, _clocks_step_reference_)                      \
     ((uint32_t)(CLEM_MEGA2_CYCLE_NS * (uint64_t)(_clocks_step_) / (_clocks_step_reference_)))
 
-/** _ns_ is of type uint64_t */
+/** _ns_ should be a delta time */
 #define clem_calc_clocks_step_from_ns(_ns_, _clocks_step_reference_)                               \
     ((clem_clocks_duration_t)((_ns_) * (_clocks_step_reference_)) / CLEM_MEGA2_CYCLE_NS)
+
+//#define clem_calc_clocks_step_from_ns(_ns_, _clocks_step_reference_)                               \
+//   ((clem_clocks_duration_t)(((float)(_ns_) / CLEM_MEGA2_CYCLE_NS) * (_clocks_step_reference_)))
+
+#define clem_calc_clocks_remainder_from_ns(_ns_, _clocks_step_reference_)                          \
+    ((clem_clocks_duration_t)((_ns_) * (_clocks_step_reference_)) % CLEM_MEGA2_CYCLE_NS)
 
 /**
  * @brief Defines the abstract interface to slot-based card hardware

--- a/clem_shared.h
+++ b/clem_shared.h
@@ -76,9 +76,14 @@ struct ClemensClock {
 #define clem_calc_ns_step_from_clocks(_clocks_step_, _clocks_step_reference_)                      \
     ((uint32_t)(CLEM_MEGA2_CYCLE_NS * (uint64_t)(_clocks_step_) / (_clocks_step_reference_)))
 
-/** _ns_ should be a delta time */
+/** _ns_ should be a delta time - this will break for deltas > 1ms */
 #define clem_calc_clocks_step_from_ns(_ns_, _clocks_step_reference_)                               \
     ((clem_clocks_duration_t)((_ns_) * (_clocks_step_reference_)) / CLEM_MEGA2_CYCLE_NS)
+
+/** _ns_ should be a delta time < 1 second */
+#define clem_calc_clocks_step_from_ns_long(_ns_, _clocks_step_reference_)                          \
+    ((clem_clocks_duration_t)((clem_clocks_time_t)(_ns_) * (_clocks_step_reference_) /             \
+                              CLEM_MEGA2_CYCLE_NS))
 
 //#define clem_calc_clocks_step_from_ns(_ns_, _clocks_step_reference_)                               \
 //   ((clem_clocks_duration_t)(((float)(_ns_) / CLEM_MEGA2_CYCLE_NS) * (_clocks_step_reference_)))

--- a/clem_vgc.c
+++ b/clem_vgc.c
@@ -265,21 +265,20 @@ void clem_vgc_sync(struct ClemensVGC *vgc, struct ClemensClock *clock, const uin
             sks_vgc_sync_last_time = sks_vgc_sync_this_time;
             sks_vgc_frame_count++;
         }
+        if (sks_vgc_sync_this_time >= CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step) {
+            unsigned h_counter = _clem_vgc_calc_h_counter(vgc->dt_scanline, clock->ref_step);
+            fprintf(stdout, "vgc: [%.2f (%u)][%u ns, dt = %u ns] {v: %u, h: %u}, vdiff: %d\n",
+                    sks_vgc_frame_count / CLEM_VGC_NTSC_FRAMES_PER_SECOND, sks_vgc_frame_count,
+                    clem_calc_ns_step_from_clocks(sks_vgc_sync_this_time, clock->ref_step),
+                    clem_calc_ns_step_from_clocks(sks_vgc_sync_this_time - sks_vgc_sync_last_time,
+                                                  clock->ref_step),
+                    v_counter, h_counter, (int)(v_counter - sks_vgc_vcounter_last));
+            fflush(stdout);
+            sks_vgc_vcounter_last = v_counter;
+            sks_vgc_sync_last_time -= (CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step);
+            sks_vgc_sync_this_time -= (CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step);
+        }
         sks_vgc_sync_this_time += (clock->ts - vgc->ts_last_frame);
-    }
-
-    if (sks_vgc_sync_this_time >= CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step) {
-        unsigned h_counter = _clem_vgc_calc_h_counter(vgc->dt_scanline, clock->ref_step);
-        fprintf(stdout, "vgc: [%.2f (%u)][%u ns, dt = %u ns] {v: %u, h: %u}, vdiff: %d\n",
-                sks_vgc_frame_count / CLEM_VGC_NTSC_FRAMES_PER_SECOND, sks_vgc_frame_count,
-                clem_calc_ns_step_from_clocks(sks_vgc_sync_this_time, clock->ref_step),
-                clem_calc_ns_step_from_clocks(sks_vgc_sync_this_time - sks_vgc_sync_last_time,
-                                              clock->ref_step),
-                v_counter, h_counter, (int)(v_counter - sks_vgc_vcounter_last));
-        fflush(stdout);
-        sks_vgc_vcounter_last = v_counter;
-        sks_vgc_sync_last_time -= (CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step);
-        sks_vgc_sync_this_time -= (CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step);
     }
 
     vgc->ts_last_frame = clock->ts;

--- a/clem_vgc.c
+++ b/clem_vgc.c
@@ -1,8 +1,10 @@
-#include "clem_shared.h"
 #include "clem_vgc.h"
 #include "clem_debug.h"
 #include "clem_mmio_defs.h"
+#include "clem_shared.h"
 #include "clem_util.h"
+
+#include <inttypes.h>
 
 /* References:
 
@@ -13,286 +15,296 @@
    http://www.1000bit.it/support/manuali/apple/technotes/iigs/tn.iigs.040.html
 */
 
-#define CLEM_VGC_VSYNC_TIME_NS (1e9 / 60)
+static clem_clocks_duration_t sks_vgc_sync_debug_timer = 0;
+static unsigned sks_vgc_vcounter_last = 0;
 
-static inline void _clem_vgc_set_scanline_int(struct ClemensVGC *vgc,
-                                              bool enable) {
-  if (enable) {
-    vgc->irq_line |= CLEM_IRQ_VGC_SCAN_LINE;
-  } else {
-    vgc->irq_line &= ~CLEM_IRQ_VGC_SCAN_LINE;
-  }
-}
-
-static inline unsigned _clem_vgc_calc_v_counter(unsigned frame_ns) {
-  return (frame_ns / CLEM_VGC_HORIZ_SCAN_TIME_NS) & 0x1ff; /* 9 bits */
-}
-
-static inline unsigned _clem_vgc_calc_h_counter(unsigned scanline_ns) {
-  return (scanline_ns / 980) & 0x7f; /* 7 bits */
-}
-
-static bool _clem_vgc_is_scanline_int_enabled(const uint8_t *mega2_e1,
-                                              unsigned v_counter) {
-  if (v_counter >= CLEM_VGC_FIRST_VISIBLE_SCANLINE_CNTR) {
-    v_counter -= CLEM_VGC_FIRST_VISIBLE_SCANLINE_CNTR;
-    if (v_counter < CLEM_VGC_SHGR_SCANLINE_COUNT) {
-      return (mega2_e1[0x9d00 + v_counter] &
-              CLEM_VGC_SCANLINE_CONTROL_INTERRUPT) != 0;
+static inline void _clem_vgc_set_scanline_int(struct ClemensVGC *vgc, bool enable) {
+    if (enable) {
+        vgc->irq_line |= CLEM_IRQ_VGC_SCAN_LINE;
+    } else {
+        vgc->irq_line &= ~CLEM_IRQ_VGC_SCAN_LINE;
     }
-  }
-  return false;
+}
+
+static inline unsigned _clem_vgc_calc_v_counter(clem_clocks_duration_t duration,
+                                                clem_clocks_duration_t ref_step) {
+
+    unsigned v_counter =
+        (duration * CLEM_MEGA2_CYCLE_NS) / (CLEM_VGC_HORIZ_SCAN_TIME_NS * ref_step);
+
+    return v_counter & 0x1ff; /* 9 bits */
+}
+
+static inline unsigned _clem_vgc_calc_h_counter(clem_clocks_duration_t duration,
+                                                clem_clocks_duration_t ref_step) {
+    return (duration / clem_calc_clocks_step_from_ns(980, ref_step)) & 0x7f; /* 7 bits */
+}
+
+static bool _clem_vgc_is_scanline_int_enabled(const uint8_t *mega2_e1, unsigned v_counter) {
+    if (v_counter >= CLEM_VGC_FIRST_VISIBLE_SCANLINE_CNTR) {
+        v_counter -= CLEM_VGC_FIRST_VISIBLE_SCANLINE_CNTR;
+        if (v_counter < CLEM_VGC_SHGR_SCANLINE_COUNT) {
+            return (mega2_e1[0x9d00 + v_counter] & CLEM_VGC_SCANLINE_CONTROL_INTERRUPT) != 0;
+        }
+    }
+    return false;
 }
 
 void clem_vgc_reset(struct ClemensVGC *vgc) {
-  /* setup scanline maps for all of the different modes */
-  ClemensVideo *video;
-  struct ClemensScanline *line;
-  unsigned offset;
-  unsigned row, inner;
+    /* setup scanline maps for all of the different modes */
+    ClemensVideo *video;
+    struct ClemensScanline *line;
+    unsigned offset;
+    unsigned row, inner;
 
-  vgc->mode_flags = CLEM_VGC_INIT;
-  vgc->text_fg_color = CLEM_VGC_COLOR_WHITE;
-  vgc->text_bg_color = CLEM_VGC_COLOR_MEDIUM_BLUE;
-  vgc->scanline_irq_enable = false;
-  vgc->vbl_started = false;
-  vgc->vbl_counter = 0;
+    vgc->mode_flags = CLEM_VGC_INIT;
+    vgc->text_fg_color = CLEM_VGC_COLOR_WHITE;
+    vgc->text_bg_color = CLEM_VGC_COLOR_MEDIUM_BLUE;
+    vgc->scanline_irq_enable = false;
+    vgc->vbl_started = false;
+    vgc->vbl_counter = 0;
 
-  /*  text page 1 $0400-$07FF, page 2 = $0800-$0BFF
+    /*  text page 1 $0400-$07FF, page 2 = $0800-$0BFF
 
-      rows (0, 8, 16), (1, 9, 17), (2, 10, 18), etc.. increment by 40, for
-      every row in the tuple.  When advancing to next tuple of rows, account
-      for 8 byte 'hole' (so row 0 = +0, row 1 = +128, row 2 = +256)
-  */
-  line = &vgc->text_1_scanlines[0];
-  offset = 0x400;
-  for (row = 0; row < 8; ++row, ++line) {
-    line[0].offset = offset;
-    line[0].control = 0;
-    line[8].offset = offset + 40;
-    line[8].control = 0;
-    line[16].offset = offset + 80;
-    line[16].control = 0;
-    offset += 128;
-  }
-  line = &vgc->text_2_scanlines[0];
-  for (row = 0; row < 8; ++row, ++line) {
-    line[0].offset = offset;
-    line[0].control = 0;
-    line[8].offset = offset + 40;
-    line[8].control = 0;
-    line[16].offset = offset + 80;
-    line[16].control = 0;
-    offset += 128;
-  }
-  /*  hgr page 1 $2000-$3FFF, page 2 = $4000-$5FFF
-
-      line text but each "row" is 8 pixels high and offsets increment by 1024
-      of course, each byte is 7 pixels + 1 palette bit, which keeps the
-      familiar +40, +80 increments used in text scanline calculation.
-  */
-  line = &vgc->hgr_1_scanlines[0];
-  offset = 0x2000;
-  for (row = 0; row < 8; ++row) {
-    line[0 + row * 8].offset = offset + row * 128;
-    line[0 + row * 8].control = 0;
-    line[64 + row * 8].offset = (offset + 0x28) + row * 128;
-    line[64 + row * 8].control = 0;
-    line[128 + row * 8].offset = (offset + 0x50) + row * 128;
-    line[128 + row * 8].control = 0;
-  }
-  for (row = 0; row < 24; ++row) {
-    for (inner = 1; inner < 8; ++inner) {
-      line[row * 8 + inner].offset = line[row * 8 + (inner - 1)].offset + 0x400;
-      line[row * 8 + inner].control = 0;
+        rows (0, 8, 16), (1, 9, 17), (2, 10, 18), etc.. increment by 40, for
+        every row in the tuple.  When advancing to next tuple of rows, account
+        for 8 byte 'hole' (so row 0 = +0, row 1 = +128, row 2 = +256)
+    */
+    line = &vgc->text_1_scanlines[0];
+    offset = 0x400;
+    for (row = 0; row < 8; ++row, ++line) {
+        line[0].offset = offset;
+        line[0].control = 0;
+        line[8].offset = offset + 40;
+        line[8].control = 0;
+        line[16].offset = offset + 80;
+        line[16].control = 0;
+        offset += 128;
     }
-  }
-  line = &vgc->hgr_2_scanlines[0];
-  offset = 0x4000;
-  for (row = 0; row < 8; ++row) {
-    line[0 + row * 8].offset = offset + row * 128;
-    line[0 + row * 8].control = 0;
-    line[64 + row * 8].offset = (offset + 0x28) + row * 128;
-    line[64 + row * 8].control = 0;
-    line[128 + row * 8].offset = (offset + 0x50) + row * 128;
-    line[128 + row * 8].control = 0;
-  }
-  for (row = 0; row < 24; ++row) {
-    for (inner = 1; inner < 8; ++inner) {
-      line[row * 8 + inner].offset = line[row * 8 + (inner - 1)].offset + 0x400;
-      line[row * 8 + inner].control = 0;
+    line = &vgc->text_2_scanlines[0];
+    for (row = 0; row < 8; ++row, ++line) {
+        line[0].offset = offset;
+        line[0].control = 0;
+        line[8].offset = offset + 40;
+        line[8].control = 0;
+        line[16].offset = offset + 80;
+        line[16].control = 0;
+        offset += 128;
     }
-  }
-  line = &vgc->shgr_scanlines[0];
-  offset = 0x2000;
-  for (row = 0; row < 200; ++row, ++line) {
-    line->offset = offset;
-    line->control = 0;
-    offset += 160;
-  }
+    /*  hgr page 1 $2000-$3FFF, page 2 = $4000-$5FFF
+
+        line text but each "row" is 8 pixels high and offsets increment by 1024
+        of course, each byte is 7 pixels + 1 palette bit, which keeps the
+        familiar +40, +80 increments used in text scanline calculation.
+    */
+    line = &vgc->hgr_1_scanlines[0];
+    offset = 0x2000;
+    for (row = 0; row < 8; ++row) {
+        line[0 + row * 8].offset = offset + row * 128;
+        line[0 + row * 8].control = 0;
+        line[64 + row * 8].offset = (offset + 0x28) + row * 128;
+        line[64 + row * 8].control = 0;
+        line[128 + row * 8].offset = (offset + 0x50) + row * 128;
+        line[128 + row * 8].control = 0;
+    }
+    for (row = 0; row < 24; ++row) {
+        for (inner = 1; inner < 8; ++inner) {
+            line[row * 8 + inner].offset = line[row * 8 + (inner - 1)].offset + 0x400;
+            line[row * 8 + inner].control = 0;
+        }
+    }
+    line = &vgc->hgr_2_scanlines[0];
+    offset = 0x4000;
+    for (row = 0; row < 8; ++row) {
+        line[0 + row * 8].offset = offset + row * 128;
+        line[0 + row * 8].control = 0;
+        line[64 + row * 8].offset = (offset + 0x28) + row * 128;
+        line[64 + row * 8].control = 0;
+        line[128 + row * 8].offset = (offset + 0x50) + row * 128;
+        line[128 + row * 8].control = 0;
+    }
+    for (row = 0; row < 24; ++row) {
+        for (inner = 1; inner < 8; ++inner) {
+            line[row * 8 + inner].offset = line[row * 8 + (inner - 1)].offset + 0x400;
+            line[row * 8 + inner].control = 0;
+        }
+    }
+    line = &vgc->shgr_scanlines[0];
+    offset = 0x2000;
+    for (row = 0; row < 200; ++row, ++line) {
+        line->offset = offset;
+        line->control = 0;
+        offset += 160;
+    }
 }
 
 void clem_vgc_set_mode(struct ClemensVGC *vgc, unsigned mode_flags) {
-  if (mode_flags & CLEM_VGC_RESOLUTION_MASK) {
-    clem_vgc_clear_mode(vgc, CLEM_VGC_RESOLUTION_MASK);
-  }
-  vgc->mode_flags |= mode_flags;
+    if (mode_flags & CLEM_VGC_RESOLUTION_MASK) {
+        clem_vgc_clear_mode(vgc, CLEM_VGC_RESOLUTION_MASK);
+    }
+    vgc->mode_flags |= mode_flags;
 }
 
 void clem_vgc_clear_mode(struct ClemensVGC *vgc, unsigned mode_flags) {
-  vgc->mode_flags &= ~mode_flags;
-  if (mode_flags & CLEM_VGC_ENABLE_VBL_IRQ) {
-    vgc->irq_line &= ~CLEM_IRQ_VGC_BLANK;
-  }
+    vgc->mode_flags &= ~mode_flags;
+    if (mode_flags & CLEM_VGC_ENABLE_VBL_IRQ) {
+        vgc->irq_line &= ~CLEM_IRQ_VGC_BLANK;
+    }
 }
 
-void clem_vgc_set_text_colors(struct ClemensVGC *vgc, unsigned fg_color,
-                              unsigned bg_color) {
-  vgc->text_fg_color = fg_color;
-  vgc->text_bg_color = bg_color;
+void clem_vgc_set_text_colors(struct ClemensVGC *vgc, unsigned fg_color, unsigned bg_color) {
+    vgc->text_fg_color = fg_color;
+    vgc->text_bg_color = bg_color;
 }
 
 void clem_vgc_set_region(struct ClemensVGC *vgc, uint8_t c02b_value) {
-  unsigned last_mode_flags = vgc->mode_flags;
-  if (c02b_value & 0x08) {
-    clem_vgc_set_mode(vgc, CLEM_VGC_LANGUAGE);
-  } else {
-    clem_vgc_clear_mode(vgc, CLEM_VGC_LANGUAGE);
-  }
-  if (c02b_value & 0x10) {
-    clem_vgc_set_mode(vgc, CLEM_VGC_PAL);
-  } else {
-    clem_vgc_clear_mode(vgc, CLEM_VGC_PAL);
-  }
-  if ((last_mode_flags ^ vgc->mode_flags) & CLEM_VGC_PAL) {
-    //  since we use vertical blanks as a time counter vs absolute clocks, need
-    //  to reset the counter when changing the refresh rate - not the best
-    //  solution but given how infrequent this use-case might be, this
-    //  oddity shoudn't have any practical effect
-    vgc->vbl_counter = 0;
-  }
-  vgc->text_language = (c02b_value & 0xe0) >> 5;
+    unsigned last_mode_flags = vgc->mode_flags;
+    if (c02b_value & 0x08) {
+        clem_vgc_set_mode(vgc, CLEM_VGC_LANGUAGE);
+    } else {
+        clem_vgc_clear_mode(vgc, CLEM_VGC_LANGUAGE);
+    }
+    if (c02b_value & 0x10) {
+        clem_vgc_set_mode(vgc, CLEM_VGC_PAL);
+    } else {
+        clem_vgc_clear_mode(vgc, CLEM_VGC_PAL);
+    }
+    if ((last_mode_flags ^ vgc->mode_flags) & CLEM_VGC_PAL) {
+        //  since we use vertical blanks as a time counter vs absolute clocks, need
+        //  to reset the counter when changing the refresh rate - not the best
+        //  solution but given how infrequent this use-case might be, this
+        //  oddity shoudn't have any practical effect
+        vgc->vbl_counter = 0;
+    }
+    vgc->text_language = (c02b_value & 0xe0) >> 5;
 }
 
 uint8_t clem_vgc_get_region(struct ClemensVGC *vgc) {
-  uint8_t result = (vgc->mode_flags & CLEM_VGC_LANGUAGE) ? 0x08 : 0x00;
-  if (vgc->mode_flags & CLEM_VGC_PAL)
-    result |= 0x10;
-  result |= (uint8_t)((vgc->text_language << 5) & 0xe0);
-  return result;
+    uint8_t result = (vgc->mode_flags & CLEM_VGC_LANGUAGE) ? 0x08 : 0x00;
+    if (vgc->mode_flags & CLEM_VGC_PAL)
+        result |= 0x10;
+    result |= (uint8_t)((vgc->text_language << 5) & 0xe0);
+    return result;
 }
 
 void clem_vgc_scanline_enable_int(struct ClemensVGC *vgc, bool enable) {
-  vgc->scanline_irq_enable = enable;
-  if (!enable) {
-    _clem_vgc_set_scanline_int(vgc, false);
-  }
+    vgc->scanline_irq_enable = enable;
+    if (!enable) {
+        _clem_vgc_set_scanline_int(vgc, false);
+    }
 }
 
-void clem_vgc_sync(struct ClemensVGC *vgc, struct ClemensClock *clock,
-                   const uint8_t *mega2_bank0, const uint8_t *mega2_bank1) {
-  /* TODO: VBL detection depends on NTSC/PAL switch
-              @ specific time within a scan until end of scan
-           Calculate v_counter and h_counter on demand given:
-              NTSC/PAL mode
-              Timer/cycle
-           Trigger IRQ (vgc->irq_line) if inside VBL region
-           And of course, super hi-res
-  */
-  unsigned scanline_ns;
-  unsigned frame_ns;
-  unsigned v_counter;
+#define CLEM_VGC_HORIZ_SCAN_DURATION(_ref_step_)                                                   \
+    (clem_calc_clocks_step_from_ns(CLEM_VGC_HORIZ_SCAN_TIME_NS, _ref_step_))
 
-  if (vgc->mode_flags & CLEM_VGC_INIT) {
-    vgc->ts_last_frame = clock->ts;
-    vgc->ts_scanline_0 = clock->ts;
-    vgc->dt_scanline = 0;
-    vgc->mode_flags &= ~CLEM_VGC_INIT;
-  } else {
-    frame_ns = clem_calc_ns_step_from_clocks(clock->ts - vgc->ts_scanline_0,
-                                             clock->ref_step);
-    v_counter = _clem_vgc_calc_v_counter(frame_ns);
+#define CLEM_VGC_NTSC_SCAN_DURATION(_ref_step_)                                                    \
+    (clem_calc_clocks_step_from_ns(CLEM_VGC_NTSC_SCAN_TIME_NS, _ref_step_))
 
-    vgc->dt_scanline += (clock->ts - vgc->ts_last_frame);
-    scanline_ns =
-        clem_calc_ns_step_from_clocks(vgc->dt_scanline, clock->ref_step);
-    if (scanline_ns > CLEM_VGC_HORIZ_SCAN_TIME_NS) {
-      vgc->dt_scanline = clem_calc_clocks_step_from_ns(
-          scanline_ns - CLEM_VGC_HORIZ_SCAN_TIME_NS, clock->ref_step);
-      if (vgc->scanline_irq_enable &&
-          (vgc->mode_flags & CLEM_VGC_SUPER_HIRES)) {
-        if (_clem_vgc_is_scanline_int_enabled(mega2_bank1, v_counter)) {
-          _clem_vgc_set_scanline_int(vgc, true);
-        }
-      }
-    }
+void clem_vgc_sync(struct ClemensVGC *vgc, struct ClemensClock *clock, const uint8_t *mega2_bank0,
+                   const uint8_t *mega2_bank1) {
+    /* TODO: VBL detection depends on NTSC/PAL switch
+                @ specific time within a scan until end of scan
+             Calculate v_counter and h_counter on demand given:
+                NTSC/PAL mode
+                Timer/cycle
+             Trigger IRQ (vgc->irq_line) if inside VBL region
+             And of course, super hi-res
+    */
+    clem_clocks_duration_t frame_duration;
+    unsigned v_counter;
 
-    // todo: vbl only once per VBL frame
-    if (v_counter >= CLEM_VGC_VBL_NTSC_LOWER_BOUND && !vgc->vbl_started) {
-      if (vgc->mode_flags & CLEM_VGC_ENABLE_VBL_IRQ) {
-        vgc->irq_line |= CLEM_IRQ_VGC_BLANK;
-      }
-      vgc->vbl_started = true;
-    }
-    if (frame_ns >= CLEM_VGC_NTSC_SCAN_TIME_NS) {
-      vgc->ts_scanline_0 =
-          clock->ts -
-          clem_calc_clocks_step_from_ns(frame_ns - CLEM_VGC_NTSC_SCAN_TIME_NS,
-                                        clock->ref_step);
-      vgc->vbl_started = false;
-      vgc->vbl_counter++;
-    }
-  }
-
-  vgc->ts_last_frame = clock->ts;
-}
-
-uint8_t clem_vgc_read_switch(struct ClemensVGC *vgc, struct ClemensClock *clock,
-                             uint8_t ioreg, uint8_t flags) {
-  uint8_t result = 0x00;
-  unsigned scan_time_ns;
-  unsigned v_counter;
-  unsigned h_counter;
-
-  scan_time_ns = clem_calc_ns_step_from_clocks(clock->ts - vgc->ts_scanline_0,
-                                               clock->ref_step);
-  /* 65 cycles per horizontal scanline, 980 ns per horizontal count = 63.7us*/
-  v_counter = _clem_vgc_calc_v_counter(scan_time_ns);
-  h_counter = _clem_vgc_calc_h_counter(
-      clem_calc_ns_step_from_clocks(vgc->dt_scanline, clock->ref_step));
-
-  switch (ioreg) {
-  case CLEM_MMIO_REG_VBLBAR:
-    /* IIgs sets bit 7 if scanline is within vertical blank region */
-    if (v_counter >= CLEM_VGC_VBL_NTSC_LOWER_BOUND) {
-      result |= 0x80;
-    }
-    break;
-  case CLEM_MMIO_REG_VGC_VERTCNT:
-    result = (uint8_t)(((v_counter + 0xFA) >> 1) & 0xff);
-    break;
-  case CLEM_MMIO_REG_VGC_HORIZCNT:
-    if (h_counter < 1) {
-      result = 0x00;
+    if (vgc->mode_flags & CLEM_VGC_INIT) {
+        vgc->ts_last_frame = clock->ts;
+        vgc->ts_scanline_0 = clock->ts;
+        vgc->dt_scanline = 0;
+        vgc->mode_flags &= ~CLEM_VGC_INIT;
+        sks_vgc_sync_debug_timer = 0;
     } else {
-      result = 0x3F + h_counter;
+        vgc->dt_scanline += (clock->ts - vgc->ts_last_frame);
+        if (vgc->dt_scanline >= CLEM_VGC_HORIZ_SCAN_DURATION(clock->ref_step)) {
+            vgc->dt_scanline -= CLEM_VGC_HORIZ_SCAN_DURATION(clock->ref_step);
+            if (vgc->scanline_irq_enable && (vgc->mode_flags & CLEM_VGC_SUPER_HIRES)) {
+                if (_clem_vgc_is_scanline_int_enabled(mega2_bank1, v_counter)) {
+                    _clem_vgc_set_scanline_int(vgc, true);
+                }
+            }
+        }
+
+        // TODO: vbl only once per VBL frame?
+        frame_duration = clock->ts - vgc->ts_scanline_0;
+        v_counter = _clem_vgc_calc_v_counter(frame_duration, clock->ref_step);
+        if (v_counter >= CLEM_VGC_VBL_NTSC_LOWER_BOUND && !vgc->vbl_started) {
+            if (vgc->mode_flags & CLEM_VGC_ENABLE_VBL_IRQ) {
+                vgc->irq_line |= CLEM_IRQ_VGC_BLANK;
+            }
+            vgc->vbl_started = true;
+        }
+        if (frame_duration >= CLEM_VGC_NTSC_SCAN_DURATION(clock->ref_step)) {
+            vgc->ts_scanline_0 += frame_duration;
+            vgc->vbl_started = false;
+            vgc->vbl_counter++;
+
+            fprintf(stdout, "vgc: vbl counter: %u (v_counter = %u)\n", vgc->vbl_counter, v_counter);
+            fflush(stdout);
+        }
     }
-    result |= ((v_counter + 0xFA) & 1) << 7;
-    break;
-  }
-  return result;
+
+    sks_vgc_sync_debug_timer += (clock->ts - vgc->ts_last_frame);
+
+    if (sks_vgc_sync_debug_timer >= CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step) {
+        unsigned h_counter = _clem_vgc_calc_h_counter(vgc->dt_scanline, clock->ref_step);
+        fprintf(stdout, "vgc: {v: %u, h: %u}, vdiff: %d\n", v_counter, h_counter,
+                (int)(v_counter - sks_vgc_vcounter_last));
+        fflush(stdout);
+        sks_vgc_vcounter_last = v_counter;
+        sks_vgc_sync_debug_timer -= (CLEM_MEGA2_CYCLES_PER_SECOND * clock->ref_step);
+    }
+
+    vgc->ts_last_frame = clock->ts;
 }
 
-void clem_vgc_write_switch(struct ClemensVGC *vgc, struct ClemensClock *clock,
-                           uint8_t ioreg, uint8_t value) {
-  switch (ioreg) {
-  case CLEM_MMIO_REG_RTC_VGC_SCANINT:
-    if (!(value & 0x20)) {
-      _clem_vgc_set_scanline_int(vgc, false);
+uint8_t clem_vgc_read_switch(struct ClemensVGC *vgc, struct ClemensClock *clock, uint8_t ioreg,
+                             uint8_t flags) {
+    uint8_t result = 0x00;
+    unsigned v_counter;
+    unsigned h_counter;
+
+    /* 65 cycles per horizontal scanline, 978 ns per horizontal count = 63.57us*/
+    v_counter = _clem_vgc_calc_v_counter(clock->ts - vgc->ts_scanline_0, clock->ref_step);
+    h_counter = _clem_vgc_calc_h_counter(vgc->dt_scanline, clock->ref_step);
+
+    switch (ioreg) {
+    case CLEM_MMIO_REG_VBLBAR:
+        /* IIgs sets bit 7 if scanline is within vertical blank region */
+        if (v_counter >= CLEM_VGC_VBL_NTSC_LOWER_BOUND) {
+            result |= 0x80;
+        }
+        break;
+    case CLEM_MMIO_REG_VGC_VERTCNT:
+        result = (uint8_t)(((v_counter + 0xFA) >> 1) & 0xff);
+        break;
+    case CLEM_MMIO_REG_VGC_HORIZCNT:
+        if (h_counter < 1) {
+            result = 0x00;
+        } else {
+            result = 0x3F + h_counter;
+        }
+        result |= ((v_counter + 0xFA) & 1) << 7;
+        break;
     }
-    break;
-  default:
-    CLEM_UNIMPLEMENTED("vgc: write %02x : %02x ", ioreg, value);
-    break;
-  }
+    return result;
+}
+
+void clem_vgc_write_switch(struct ClemensVGC *vgc, struct ClemensClock *clock, uint8_t ioreg,
+                           uint8_t value) {
+    switch (ioreg) {
+    case CLEM_MMIO_REG_RTC_VGC_SCANINT:
+        if (!(value & 0x20)) {
+            _clem_vgc_set_scanline_int(vgc, false);
+        }
+        break;
+    default:
+        CLEM_UNIMPLEMENTED("vgc: write %02x : %02x ", ioreg, value);
+        break;
+    }
 }

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -355,6 +355,10 @@ static bool _clem_mmio_niolc(struct ClemensMemory *mem) {
     return (mmio->mmap_register & CLEM_MEM_IO_MMAP_NIOLC) != 0;
 }
 
+bool clemens_is_mmio_initialized(ClemensMMIO *mmio) {
+    return mmio->state_type == kClemensMMIOStateType_Active;
+}
+
 void clemens_emulate_mmio(ClemensMachine *clem, ClemensMMIO *mmio) {
     struct Clemens65C816 *cpu = &clem->cpu;
     struct ClemensClock clock;

--- a/emulator_mmio.h
+++ b/emulator_mmio.h
@@ -8,6 +8,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief
+ *
+ * @param mmio
+ * @return true
+ * @return false
+ */
+bool clemens_is_mmio_initialized(ClemensMMIO *mmio);
+
+/**
  * @brief Emulate the I/O portion of an Apple IIgs
  *
  * This should be paired with calls to clemens_emulate_cpu().  The calls are

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -66,6 +66,7 @@ set(PROJECT_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_audio.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_display.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_backend.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clem_command_queue.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_configuration.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_disk_library.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/clem_disk_utils.cpp"

--- a/host/cinek/circular_buffer.hpp
+++ b/host/cinek/circular_buffer.hpp
@@ -26,192 +26,162 @@
 
 /* 10-19-2014 - added to cinek namespace.
  */
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <atomic>
 
 namespace cinek {
 
-template<typename Element, size_t Size>
-class CircularBuffer
-{
-public:
-  static constexpr size_t kCapacity = Size+1;
-  static constexpr size_t kLimit = Size;
+template <typename Element, size_t Size> class CircularBuffer {
+  public:
+    static constexpr size_t kCapacity = Size + 1;
+    static constexpr size_t kLimit = Size;
 
-  using ValueType = Element;
+    using ValueType = Element;
 
-  CircularBuffer() : _tail(0), _head(0){}
+    CircularBuffer() : _tail(0), _head(0) {}
 
-  void clear() { _tail = 0; _head = 0; }
-  bool push(const Element& item);
-  bool push(Element&& item);
-  Element* acquireTail();
-  bool push();
+    void clear() {
+        _tail = 0;
+        _head = 0;
+    }
+    bool push(const Element &item);
+    bool push(Element &&item);
+    Element *acquireTail();
+    bool push();
 
-  bool pop(Element& item);
-  bool pop();
+    bool pop(Element &item);
+    bool pop();
 
-  bool isEmpty() const;
-  bool isFull() const;
-  bool isLockFree() const;
-  size_t size() const;
+    bool isEmpty() const;
+    bool isFull() const;
+    bool isLockFree() const;
+    size_t size() const;
 
-  Element& at(size_t index);
-  const Element& at(size_t index) const;
+    Element &at(size_t index);
+    const Element &at(size_t index) const;
 
-private:
-  size_t increment(size_t idx) const;
+  private:
+    size_t increment(size_t idx) const;
 
-  std::atomic<size_t>  _tail;  // tail(input) index
-  Element    _array[kCapacity];
-  std::atomic<size_t>   _head; // head(output) index
+    std::atomic<size_t> _tail; // tail(input) index
+    Element _array[kCapacity];
+    std::atomic<size_t> _head; // head(output) index
 };
-
 
 // Here with memory_order_seq_cst for every operation. This is overkill but easy to reason about
 //
-// Push on tail. TailHead is only changed by producer and can be safely loaded using memory_order_relexed
+// Push on tail. TailHead is only changed by producer and can be safely loaded using
+// memory_order_relexed
 //         head is updated by consumer and must be loaded using at least memory_order_acquire
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::push(const Element& item)
-{
-  const auto current_tail = _tail.load();
-  const auto next_tail = increment(current_tail);
-  if(next_tail != _head.load())
-  {
-    _array[current_tail] = item;
-    _tail.store(next_tail);
-    return true;
-  }
+template <typename Element, size_t Size>
+bool CircularBuffer<Element, Size>::push(const Element &item) {
+    const auto current_tail = _tail.load();
+    const auto next_tail = increment(current_tail);
+    if (next_tail != _head.load()) {
+        _array[current_tail] = item;
+        _tail.store(next_tail);
+        return true;
+    }
 
-  return false;  // full queue
+    return false; // full queue
 }
 
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::push(Element&& item)
-{
-  const auto current_tail = _tail.load();
-  const auto next_tail = increment(current_tail);
-  if(next_tail != _head.load())
-  {
-    _array[current_tail] = std::move(item);
-    _tail.store(next_tail);
-    return true;
-  }
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::push(Element &&item) {
+    const auto current_tail = _tail.load();
+    const auto next_tail = increment(current_tail);
+    if (next_tail != _head.load()) {
+        _array[current_tail] = std::move(item);
+        _tail.store(next_tail);
+        return true;
+    }
 
-  return false;  // full queue
+    return false; // full queue
 }
 
-template<typename Element, size_t Size>
-Element* CircularBuffer<Element, Size>::acquireTail()
-{
-  const auto current_tail = _tail.load();
-  const auto next_tail = increment(current_tail);
-  if (next_tail != _head.load())
-  {
-    return &_array[current_tail];
-  }
-  return nullptr;
+template <typename Element, size_t Size> Element *CircularBuffer<Element, Size>::acquireTail() {
+    const auto current_tail = _tail.load();
+    const auto next_tail = increment(current_tail);
+    if (next_tail != _head.load()) {
+        return &_array[current_tail];
+    }
+    return nullptr;
 }
 
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::push()
-{
-  const auto current_tail = _tail.load();
-  const auto next_tail = increment(current_tail);
-  if(next_tail != _head.load())
-  {
-    _tail.store(next_tail);
-    return true;
-  }
-  return false;  // full queue
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::push() {
+    const auto current_tail = _tail.load();
+    const auto next_tail = increment(current_tail);
+    if (next_tail != _head.load()) {
+        _tail.store(next_tail);
+        return true;
+    }
+    return false; // full queue
 }
-
 
 // Pop by Consumer can only update the head
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::pop(Element& item)
-{
-  const auto current_head = _head.load();
-  if(current_head == _tail.load())
-    return false;   // empty queue
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::pop(Element &item) {
+    const auto current_head = _head.load();
+    if (current_head == _tail.load())
+        return false; // empty queue
 
-  item = _array[current_head];
-  _head.store(increment(current_head));
-  return true;
+    item = _array[current_head];
+    _head.store(increment(current_head));
+    return true;
 }
 
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::pop()
-{
-  const auto current_head = _head.load();
-  if(current_head == _tail.load())
-    return false;   // empty queue
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::pop() {
+    const auto current_head = _head.load();
+    if (current_head == _tail.load())
+        return false; // empty queue
 
-  _head.store(increment(current_head));
-  return true;
+    _head.store(increment(current_head));
+    return true;
 }
-
 
 // snapshot with acceptance of that this comparison function is not atomic
 // (*) Used by clients or test, since pop() avoid double load overhead by not
 // using isEmpty()
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::isEmpty() const
-{
-  return (_head.load() == _tail.load());
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::isEmpty() const {
+    return (_head.load() == _tail.load());
 }
 
 // snapshot with acceptance that this comparison is not atomic
 // (*) Used by clients or test, since push() avoid double load overhead by not
 // using isFull()
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::isFull() const
-{
-  const auto next_tail = increment(_tail.load());
-  return (next_tail == _head.load());
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::isFull() const {
+    const auto next_tail = increment(_tail.load());
+    return (next_tail == _head.load());
 }
 
-
-template<typename Element, size_t Size>
-bool CircularBuffer<Element, Size>::isLockFree() const
-{
-  return (_tail.is_lock_free() && _head.is_lock_free());
+template <typename Element, size_t Size> bool CircularBuffer<Element, Size>::isLockFree() const {
+    return (_tail.is_lock_free() && _head.is_lock_free());
 }
 
-template<typename Element, size_t Size>
-size_t CircularBuffer<Element, Size>::increment(size_t idx) const
-{
-  return (idx + 1) % kCapacity;
+template <typename Element, size_t Size>
+size_t CircularBuffer<Element, Size>::increment(size_t idx) const {
+    return (idx + 1) % kCapacity;
 }
 
-template<typename Element, size_t Size>
-size_t CircularBuffer<Element, Size>::size() const
-{
-  const auto current_head = _head.load();
-  const auto current_tail = _tail.load();
-  if (current_tail >= current_head) {
-    return current_tail - current_head;
-  } else {
-    return (kCapacity - current_head) + current_tail;
-  }
+template <typename Element, size_t Size> size_t CircularBuffer<Element, Size>::size() const {
+    const auto current_head = _head.load();
+    const auto current_tail = _tail.load();
+    if (current_tail >= current_head) {
+        return current_tail - current_head;
+    } else {
+        return (kCapacity - current_head) + current_tail;
+    }
 }
 
-template<typename Element, size_t Size>
-Element& CircularBuffer<Element, Size>::at(size_t index)
-{
-  const auto current_head = _head.load();
-  return _array[(current_head + index) % kCapacity];
+template <typename Element, size_t Size> Element &CircularBuffer<Element, Size>::at(size_t index) {
+    const auto current_head = _head.load();
+    return _array[(current_head + index) % kCapacity];
 }
 
-template<typename Element, size_t Size>
-const Element& CircularBuffer<Element, Size>::at(size_t index) const
-{
-  const auto current_head = _head.load();
-  return _array[(current_head + index) % kCapacity];
+template <typename Element, size_t Size>
+const Element &CircularBuffer<Element, Size>::at(size_t index) const {
+    const auto current_head = _head.load();
+    return _array[(current_head + index) % kCapacity];
 }
 
-
-} // sequential_consistent
+} // namespace cinek
 #endif /* CIRCULARFIFO_SEQUENTIAL_H_ */

--- a/host/cinek/ckdefs.h
+++ b/host/cinek/ckdefs.h
@@ -42,21 +42,21 @@
 /**@{*/
 
 #ifdef _MSC_VER
-    #define CK_COMPILER_MSVC        1
+#define CK_COMPILER_MSVC 1
 #else
-    #define CK_COMPILER_MSVC        0
+#define CK_COMPILER_MSVC 0
 #endif
 
 #if __clang__
-    #define CK_COMPILER_CLANG       1
+#define CK_COMPILER_CLANG 1
 #else
-    #define CK_COMPILER_CLANG       0
+#define CK_COMPILER_CLANG 0
 #endif
 
 #if defined(__GNUC__)
-    #define CK_COMPILER_GNUC        1
+#define CK_COMPILER_GNUC 1
 #else
-    #define CK_COMPILER_GNUC        0
+#define CK_COMPILER_GNUC 0
 #endif
 
 /**
@@ -64,15 +64,15 @@
  * Set to 1 if available, else set to 0 if not available.
  */
 #ifndef CK_COMPILER_HAS_STDINT
-  #if CK_COMPILER_MSVC
-    #if _MSC_VER < 1600
-      #define CK_COMPILER_HAS_STDINT 0
-    #else
-      #define CK_COMPILER_HAS_STDINT 1
-    #endif
-  #else
-    #define CK_COMPILER_HAS_STDINT 1
-  #endif
+#if CK_COMPILER_MSVC
+#if _MSC_VER < 1600
+#define CK_COMPILER_HAS_STDINT 0
+#else
+#define CK_COMPILER_HAS_STDINT 1
+#endif
+#else
+#define CK_COMPILER_HAS_STDINT 1
+#endif
 /* CK_COMPILER_HAS_STDINT */
 #endif
 
@@ -82,32 +82,32 @@
  * Define if C++ exception handling is enabled.
  */
 #if !defined(CK_CPP_EXCEPTIONS) || !CK_CPP_EXCEPTIONS
-  #if CK_COMPILER_CLANG
-    #if __has_feature(cxx_exceptions)
-      #define CK_CPP_EXCEPTIONS 1
-    #else
-      #define CK_CPP_EXCEPTIONS 0
-    #endif
-  #elif CK_COMPILER_MSVC
-    #ifdef _CPPUNWIND
-      #define CK_CPP_EXCEPTIONS 1
-    #else
-      #undef _HAS_EXCEPTIONS
-      #define _HAS_EXCEPTIONS 0
-    #endif
-  #elif CK_COMPILER_GNUC
-    #if defined(__EXCEPTIONS) || defined(__cpp_exceptions)
-      #define CK_CPP_EXCEPTIONS 1
-    #else
-      #define CK_CPP_EXCEPTIONS 0
-    #endif
-  #endif
-  #define CK_NOEXCEPT
+#if CK_COMPILER_CLANG
+#if __has_feature(cxx_exceptions)
+#define CK_CPP_EXCEPTIONS 1
 #else
-  #define CK_NOEXCEPT noexcept
+#define CK_CPP_EXCEPTIONS 0
+#endif
+#elif CK_COMPILER_MSVC
+#ifdef _CPPUNWIND
+#define CK_CPP_EXCEPTIONS 1
+#else
+#undef _HAS_EXCEPTIONS
+#define _HAS_EXCEPTIONS 0
+#endif
+#elif CK_COMPILER_GNUC
+#if defined(__EXCEPTIONS) || defined(__cpp_exceptions)
+#define CK_CPP_EXCEPTIONS 1
+#else
+#define CK_CPP_EXCEPTIONS 0
+#endif
+#endif
+#define CK_NOEXCEPT
+#else
+#define CK_NOEXCEPT noexcept
 #endif
 
-#endif  /* __cplusplus */
+#endif /* __cplusplus */
 
 /**@}*/
 
@@ -147,48 +147,48 @@
 /**@}*/
 
 #ifdef __APPLE__
-  #include "TargetConditionals.h"
-  #if TARGET_OS_IPHONE
-    #define CK_TARGET_IOS
-  #elif TARGET_IPHONE_SIMULATOR
-    #define CK_TARGET_IOS_SIMULATOR
-  #elif TARGET_OS_MAC
-    #define CK_TARGET_OSX
-  #endif
+#include "TargetConditionals.h"
+#if TARGET_OS_IPHONE
+#define CK_TARGET_IOS
+#elif TARGET_IPHONE_SIMULATOR
+#define CK_TARGET_IOS_SIMULATOR
+#elif TARGET_OS_MAC
+#define CK_TARGET_OSX
+#endif
 #elif __linux__
-  #define CK_TARGET_LINUX
+#define CK_TARGET_LINUX
 #elif _WIN32
-  #define CK_TARGET_WINDOWS
+#define CK_TARGET_WINDOWS
 #else
-  #error "Detected an unsupported platform."
+#error "Detected an unsupported platform."
 #endif
 
 /**
  *  \def CK_ALIGN_SIZE(_val, _align_)
  *  Returns a size value based on _val_, and aligned using the specified _align_ value.
  */
-#define CK_ALIGN_SIZE(_val_, _align_) ( ((_val_)+(_align_)-1) & ~((_align_)-1) )
+#define CK_ALIGN_SIZE(_val_, _align_) (((_val_) + (_align_)-1) & ~((_align_)-1))
 /**
  * \def CK_ALIGN_PTR(_ptr_, _align_)
  * Returns an adjusted pointer based on _ptr_, aligned by _align_ bytes.
  */
-#define CK_ALIGN_PTR(_ptr_, _align_) ( ((uintptr_t)(_ptr_)+(_align_)-1) & ~((_align_)-1) )
+#define CK_ALIGN_PTR(_ptr_, _align_) (((uintptr_t)(_ptr_) + (_align_)-1) & ~((_align_)-1))
 
 /**
  * \def CK_ARCH_ALIGN_BYTES
  * The architecture specific alignment value (in bytes.)
  */
-#define CK_ARCH_ALIGN_BYTES sizeof(void*)
+#define CK_ARCH_ALIGN_BYTES sizeof(void *)
 /**
  *  \def CK_ALIGN_SIZE_TO_ARCH(_val_)
  *  Invokes CK_ALIGN_SIZE with the platform's predefined alignment value.
  */
-#define CK_ALIGN_SIZE_TO_ARCH(_val_) CK_ALIGN_SIZE( (_val_), CK_ARCH_ALIGN_BYTES )
+#define CK_ALIGN_SIZE_TO_ARCH(_val_) CK_ALIGN_SIZE((_val_), CK_ARCH_ALIGN_BYTES)
 /**
  *  \def CK_ALIGN_PTR_TO_ARCH(_ptr_)
  *  Invokes CK_ALIGN_PTR with the platform's predefined alignment value.
  */
-#define CK_ALIGN_PTR_TO_ARCH(_ptr_) CK_ALIGN_PTR( (_ptr_), CK_ARCH_ALIGN_BYTES )
+#define CK_ALIGN_PTR_TO_ARCH(_ptr_) CK_ALIGN_PTR((_ptr_), CK_ARCH_ALIGN_BYTES)
 
 /**
  * \def CK_ARCH_MALLOC_ALIGN_BYTES
@@ -196,39 +196,36 @@
  * using the GNU behavior as standard since many libraries seem to assume this
  * type of alignment.
  */
-#define CK_ARCH_MALLOC_ALIGN_BYTES (CK_ARCH_ALIGN_BYTES*2)
+#define CK_ARCH_MALLOC_ALIGN_BYTES (CK_ARCH_ALIGN_BYTES * 2)
 
 /**
  * \def DO_PRAGMA(_x_)
  * Adds a compiler pragma.
  */
-#define DO_PRAGMA(_x_) __pragma (_x_)
+#define DO_PRAGMA(_x_) __pragma(_x_)
 
 /**
  * \def CK_C_S_(_plaintext_)
  * Stringification
  */
-#define CK_C_S(__ck_s) #__ck_s
+#define CK_C_S(__ck_s)  #__ck_s
 #define CK_C_S_(__ck_s) CK_C_S(__ck_s)
 
-
 #if CK_COMPILER_CLANG
-  #define CK_FILENAME __BASE_FILE__
-#elif CK_COMPILER_GNUC
-  #define CK_FILENAME __FILE__
+#define CK_FILENAME __BASE_FILE__
+#else
+#define CK_FILENAME __FILE__
 #endif
 
 #define CK_C_LINE__ CK_C_S_(__LINE__)
-
 
 /**@{*/
 /**
  * \def TODO(_x_)
  * Adds a TODO message to the compile process.
  */
-#define CK_TODO(_x_) DO_PRAGMA( message(CK_FILENAME ":" CK_C_LINE__ " TODO: " #_x_ ) )
+#define CK_TODO(_x_) DO_PRAGMA(message(CK_FILENAME ":" CK_C_LINE__ " TODO: " #_x_))
 /**@}*/
-
 
 #ifdef __cplusplus
 /**
@@ -241,33 +238,28 @@
  * Prevents copy operations for the specified class.  This must be placed
  * the C++ class definition.
  */
-#define CK_CLASS_NON_COPYABLE(__class_name_) \
-  __class_name_(const __class_name_&) = delete; \
-  __class_name_& operator=(const __class_name_&) = delete;
+#define CK_CLASS_NON_COPYABLE(__class_name_)                                                       \
+    __class_name_(const __class_name_ &) = delete;                                                 \
+    __class_name_ &operator=(const __class_name_ &) = delete;
 
+template <typename... Ts> struct ck_sizeof_max;
 
-template<typename... Ts>
-struct ck_sizeof_max;
-
-template<>
-struct ck_sizeof_max<>
-{
+template <> struct ck_sizeof_max<> {
     enum { size = 0 };
 };
 
-template<typename T0, typename... Ts>
-struct ck_sizeof_max<T0, Ts...>
-{
-    enum { size = sizeof(T0) < ck_sizeof_max<Ts...>::size ?
-                  ck_sizeof_max<Ts...>::size : sizeof(T0) };
+template <typename T0, typename... Ts> struct ck_sizeof_max<T0, Ts...> {
+    enum {
+        size = sizeof(T0) < ck_sizeof_max<Ts...>::size ? ck_sizeof_max<Ts...>::size : sizeof(T0)
+    };
 };
 
 /**@}*/
 #endif
 
 #if defined(_MSC_VER)
-  #define strncasecmp _strnicmp
-  #define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#define strcasecmp  _stricmp
 #endif
 
 typedef double CKTime;

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -18,7 +18,6 @@
 #include <optional>
 #include <vector>
 
-#include "cinek/circular_buffer.hpp"
 #include "fmt/format.h"
 
 static constexpr unsigned kSlabMemorySize = 32 * 1024 * 1024;
@@ -26,108 +25,66 @@ static constexpr unsigned kInterpreterMemorySize = 1 * 1024 * 1024;
 static constexpr unsigned kLogOutputLineLimit = 1024;
 static constexpr unsigned kSmartPortDiskBlockCount = 32 * 1024 * 2; // 32 MB blocks
 
-struct ClemensRunSampler {
-    std::chrono::microseconds referenceFrameTimer;
-    std::chrono::microseconds actualFrameTimer;
-    std::chrono::microseconds sampledFrameTime;
+ClemensRunSampler::ClemensRunSampler() { reset(); }
 
-    double sampledFramesPerSecond;
+void ClemensRunSampler::reset() {
+    referenceFrameTimer = std::chrono::microseconds::zero();
+    actualFrameTimer = std::chrono::microseconds::zero();
+    sampledFrameTime = std::chrono::microseconds::zero();
+    sampledClocksSpent = 0;
+    sampledCyclesSpent = 0;
+    sampledFramesPerSecond = 0.0f;
+    sampledEmulatorSpeedMhz = 0.0f;
+    actualEmulatorSpeedMhz = 0.0f;
+    frameTimeBuffer.clear();
+    clocksBuffer.clear();
+    cyclesBuffer.clear();
+}
 
-    cinek::CircularBuffer<std::chrono::microseconds, 120> frameTimeBuffer;
+void ClemensRunSampler::update(std::chrono::microseconds actualFrameInterval,
+                               clem_clocks_duration_t clocksSpent, unsigned cyclesSpent) {
 
-    clem_clocks_time_t sampledClocksSpent;
-    uint64_t sampledCyclesSpent;
-    cinek::CircularBuffer<clem_clocks_duration_t, 120> clocksBuffer;
-    cinek::CircularBuffer<clem_clocks_duration_t, 120> cyclesBuffer;
+    actualFrameTimer += actualFrameInterval;
 
-    double sampledEmulatorSpeedMhz;
-    double actualEmulatorSpeedMhz;
+    if (frameTimeBuffer.isFull()) {
+        decltype(frameTimeBuffer)::ValueType lruFrametime;
+        if (frameTimeBuffer.pop(lruFrametime)) {
+            sampledFrameTime -= lruFrametime;
+        }
+    }
+    frameTimeBuffer.push(actualFrameInterval);
+    sampledFrameTime += actualFrameInterval;
 
-    ClemensRunSampler() { reset(); }
-
-    void reset() {
-        referenceFrameTimer = std::chrono::microseconds::zero();
-        actualFrameTimer = std::chrono::microseconds::zero();
-        sampledFrameTime = std::chrono::microseconds::zero();
-        sampledClocksSpent = 0;
-        sampledCyclesSpent = 0;
-        sampledFramesPerSecond = 0.0f;
-        sampledEmulatorSpeedMhz = 0.0f;
-        actualEmulatorSpeedMhz = 0.0f;
-        frameTimeBuffer.clear();
-        clocksBuffer.clear();
-        cyclesBuffer.clear();
+    if (sampledFrameTime >= std::chrono::microseconds(100000)) {
+        sampledFramesPerSecond = frameTimeBuffer.size() * 1e6 / sampledFrameTime.count();
     }
 
-    void update(std::chrono::microseconds fixedFrameInterval,
-                std::chrono::microseconds actualFrameInterval, clem_clocks_duration_t clocksSpent,
-                unsigned cyclesSpent) {
-
-        // Our goal is to keep the actualFrameTimer roughly in sync with the referenceFrameTimer.
-        // Given how thread scheduling differs between platforms and machines, it's expected the
-        // "actual" timer will overshoot and undershoot the reference timer during a run.
-        // This method will attempt to keep up using a timer delay.
-
-        referenceFrameTimer += fixedFrameInterval;
-        actualFrameTimer += actualFrameInterval;
-
-        if (actualFrameTimer >= referenceFrameTimer) {
-            //  Our runner is taking too long, so try to catch up.
-            //
-            std::this_thread::yield();
-            if (actualFrameTimer - referenceFrameTimer > std::chrono::microseconds(500000)) {
-                //  TODO: Check whether this value increases over time - means we have a slow
-                //  machine.  This hack below will reset the timers to cap the delay
-                actualFrameTimer = referenceFrameTimer = std::chrono::microseconds::zero();
-            }
-        } else {
-            // Our runner is faster than the machine speed.  Keep our runner at the desired
-            // framerate.
-            std::this_thread::sleep_for(referenceFrameTimer - actualFrameTimer);
-            referenceFrameTimer -= actualFrameTimer;
-            actualFrameTimer = std::chrono::microseconds::zero();
-        }
-
-        if (frameTimeBuffer.isFull()) {
-            decltype(frameTimeBuffer)::ValueType lruFrametime;
-            if (frameTimeBuffer.pop(lruFrametime)) {
-                sampledFrameTime -= lruFrametime;
-            }
-        }
-        frameTimeBuffer.push(actualFrameInterval);
-        sampledFrameTime += actualFrameInterval;
-
-        if (sampledFrameTime >= std::chrono::microseconds(100000)) {
-            sampledFramesPerSecond = frameTimeBuffer.size() * 1e6 / sampledFrameTime.count();
-        }
-
-        //  calculate emulator speed by using cycles_spent * CLEM_CLOCKS_MEGA2_CYCLE
-        //  as a reference for 1.023mhz where
-        //    reference_clocks = cycles_spent * CLEM_CLOCKS_MEGA2_CYCLE
-        //    acutal_clocks = sampledClocksSpent
-        //    (reference / actual) * 1.023mhz is the emulator speed
-        if (clocksBuffer.isFull()) {
-            decltype(clocksBuffer)::ValueType lruClocksSpent = 0;
-            clocksBuffer.pop(lruClocksSpent);
-            sampledClocksSpent -= lruClocksSpent;
-        }
-        clocksBuffer.push(clocksSpent);
-        sampledClocksSpent += clocksSpent;
-
-        if (cyclesBuffer.isFull()) {
-            decltype(cyclesBuffer)::ValueType lruCycles = 0;
-            cyclesBuffer.pop(lruCycles);
-            sampledCyclesSpent -= lruCycles;
-        }
-        cyclesBuffer.push(cyclesSpent);
-        sampledCyclesSpent += cyclesSpent;
-        if (sampledClocksSpent > (CLEM_CLOCKS_MEGA2_CYCLE * CLEM_MEGA2_CYCLES_PER_SECOND / 10)) {
-            sampledEmulatorSpeedMhz =
-                1.023 * double(CLEM_CLOCKS_MEGA2_CYCLE * sampledCyclesSpent) / sampledClocksSpent;
-        }
-        // TODO: calculate # cycles per second = actual mhz (for fast emulation mode)
+    //  calculate emulator speed by using cycles_spent * CLEM_CLOCKS_MEGA2_CYCLE
+    //  as a reference for 1.023mhz where
+    //    reference_clocks = cycles_spent * CLEM_CLOCKS_MEGA2_CYCLE
+    //    acutal_clocks = sampledClocksSpent
+    //    (reference / actual) * 1.023mhz is the emulator speed
+    if (clocksBuffer.isFull()) {
+        decltype(clocksBuffer)::ValueType lruClocksSpent = 0;
+        clocksBuffer.pop(lruClocksSpent);
+        sampledClocksSpent -= lruClocksSpent;
     }
-};
+    clocksBuffer.push(clocksSpent);
+    sampledClocksSpent += clocksSpent;
+
+    if (cyclesBuffer.isFull()) {
+        decltype(cyclesBuffer)::ValueType lruCycles = 0;
+        cyclesBuffer.pop(lruCycles);
+        sampledCyclesSpent -= lruCycles;
+    }
+    cyclesBuffer.push(cyclesSpent);
+    sampledCyclesSpent += cyclesSpent;
+    if (sampledClocksSpent > (CLEM_CLOCKS_MEGA2_CYCLE * CLEM_MEGA2_CYCLES_PER_SECOND / 10)) {
+        sampledEmulatorSpeedMhz =
+            1.023 * double(CLEM_CLOCKS_MEGA2_CYCLE * sampledCyclesSpent) / sampledClocksSpent;
+    }
+    // TODO: calculate # cycles per second = actual mhz (for fast emulation mode)
+}
 
 template <typename... Args>
 void ClemensBackend::localLog(int log_level, const char *msg, Args... args) {
@@ -140,9 +97,9 @@ void ClemensBackend::localLog(int log_level, const char *msg, Args... args) {
     logOutput_.emplace_back(logLine);
 }
 
-ClemensBackend::ClemensBackend(std::string romPathname, const Config &config,
-                               PublishStateDelegate publishDelegate)
+ClemensBackend::ClemensBackend(std::string romPathname, const Config &config)
     : config_(config), slabMemory_(kSlabMemorySize, malloc(kSlabMemorySize)),
+      mockingboard_(nullptr),
       interpreter_(cinek::FixedStack(kInterpreterMemorySize, malloc(kInterpreterMemorySize))),
       breakpoints_(std::move(config_.breakpoints)), logLevel_(CLEM_DEBUG_LOG_INFO),
       debugMemoryPage_(0x00), areInstructionsLogged_(false) {
@@ -199,228 +156,23 @@ ClemensBackend::ClemensBackend(std::string romPathname, const Config &config,
                    smartPortDrives_[driveIndex].imagePath, driveIndex);
     }
 
-    //  Everything is ready for the main thread
-    runner_ = std::thread(&ClemensBackend::main, this, std::move(publishDelegate));
+    clocksRemainingInTimeslice_ = 0;
+    publishSeqNo_ = 0;
 }
 
 ClemensBackend::~ClemensBackend() {
-    terminate();
-    runner_.join();
+    saveBRAM();
+
+    //  TODO: clemens_mmio_card_eject() will clear the slot but it still needs
+    //        to be destroyed by the app
+    for (int i = 0; i < CLEM_CARD_SLOT_COUNT; ++i) {
+        destroyCard(mmio_.card_slot[i]);
+        mmio_.card_slot[i] = NULL;
+    }
 
     free(slabMemory_.getHead());
 }
 
-void ClemensBackend::terminate() { queueToFront(Command{Command::Terminate}); }
-
-void ClemensBackend::reset() { queue(Command{Command::ResetMachine}); }
-
-void ClemensBackend::resetMachine() {
-    machine_.cpu.pins.resbIn = false;
-    machine_.resb_counter = 3;
-}
-
-void ClemensBackend::setRefreshFrequency(unsigned hz) {
-    queue(Command{Command::SetHostUpdateFrequency, fmt::format("{}", hz)});
-}
-
-void ClemensBackend::run() { queue(Command{Command::RunMachine}); }
-
-void ClemensBackend::step(unsigned count) {
-    queue(Command{Command::StepMachine, fmt::format("{}", count)});
-}
-
-unsigned ClemensBackend::stepMachine(const std::string_view &inputParam) {
-    unsigned count;
-    if (std::from_chars(inputParam.data(), inputParam.data() + inputParam.size(), count).ec !=
-        std::errc{}) {
-        return 0;
-    }
-    return count;
-}
-
-void ClemensBackend::publish() { queue(Command{Command::Publish}); }
-
-void ClemensBackend::insertDisk(ClemensDriveType driveType, std::string diskPath) {
-    queue(Command{Command::InsertDisk,
-                  fmt::format("{}={}", ClemensDiskUtilities::getDriveName(driveType), diskPath)});
-}
-
-bool ClemensBackend::insertDisk(const std::string_view &inputParam, bool allowBlank) {
-    auto sepPos = inputParam.find('=');
-    if (sepPos == std::string_view::npos)
-        return false;
-    auto driveName = inputParam.substr(0, sepPos);
-    auto imagePath = inputParam.substr(sepPos + 1);
-    auto driveType = ClemensDiskUtilities::getDriveType(driveName);
-    if (driveType == kClemensDrive_Invalid)
-        return false;
-
-    diskDrives_[driveType].imagePath = imagePath;
-    return loadDisk(driveType, allowBlank);
-}
-
-void ClemensBackend::insertBlankDisk(ClemensDriveType driveType, std::string diskPath) {
-    queue(Command{Command::InsertBlankDisk,
-                  fmt::format("{}={}", ClemensDiskUtilities::getDriveName(driveType), diskPath)});
-}
-
-void ClemensBackend::ejectDisk(ClemensDriveType driveType) {
-    queue(Command{Command::EjectDisk, std::string(ClemensDiskUtilities::getDriveName(driveType))});
-}
-
-void ClemensBackend::ejectDisk(const std::string_view &inputParam) {
-    auto driveType = ClemensDiskUtilities::getDriveType(inputParam);
-    diskDrives_[driveType].isEjecting = true;
-}
-
-void ClemensBackend::writeProtectDisk(ClemensDriveType driveType, bool wp) {
-    queue(Command{Command::WriteProtectDisk,
-                  fmt::format("{},{}", ClemensDiskUtilities::getDriveName(driveType), wp ? 1 : 0)});
-}
-
-bool ClemensBackend::writeProtectDisk(const std::string_view &inputParam) {
-    auto sepPos = inputParam.find(',');
-    if (sepPos == std::string_view::npos)
-        return false;
-    auto driveParam = inputParam.substr(0, sepPos);
-    auto driveType = ClemensDiskUtilities::getDriveType(driveParam);
-    auto *drive = clemens_drive_get(&mmio_, driveType);
-    if (!drive || !drive->has_disk)
-        return false;
-
-    auto enableParam = inputParam.substr(sepPos + 1);
-    drive->disk.is_write_protected = enableParam == "1";
-
-    return true;
-}
-
-void ClemensBackend::debugMemoryPage(uint8_t page) {
-    queue(Command{Command::DebugMemoryPage, std::to_string(page)});
-}
-
-void ClemensBackend::debugMemoryWrite(uint16_t addr, uint8_t value) {
-    queue(Command{Command::WriteMemory, fmt::format("{}={}", addr, value)});
-}
-
-void ClemensBackend::writeMemory(const std::string_view &inputParam) {
-    auto sepPos = inputParam.find('=');
-    if (sepPos == std::string_view::npos) {
-        return;
-    }
-    uint16_t addr;
-    if (std::from_chars(inputParam.data(), inputParam.data() + sepPos, addr).ec != std::errc{})
-        return;
-    auto valStr = inputParam.substr(sepPos + 1);
-    uint8_t value;
-    if (std::from_chars(valStr.data(), valStr.data() + valStr.size(), value).ec != std::errc{})
-        return;
-
-    clem_write(&machine_, value, addr, debugMemoryPage_, CLEM_MEM_FLAG_NULL);
-}
-
-void ClemensBackend::debugLogLevel(int logLevel) {
-    queue(Command{Command::DebugLogLevel, fmt::format("{}", logLevel)});
-}
-
-void ClemensBackend::debugMessage(std::string msg) {
-    queue(Command{Command::DebugMessage, std::move(msg)});
-}
-
-void ClemensBackend::debugProgramTrace(std::string op, std::string path) {
-    queue(Command{Command::DebugProgramTrace,
-                  fmt::format("{},{}", op, path.empty() ? "#" : path.c_str())});
-}
-
-bool ClemensBackend::programTrace(const std::string_view &inputParam) {
-    auto sepPos = inputParam.find(',');
-    auto op = inputParam.substr(0, sepPos);
-    std::string_view param;
-    if (sepPos != std::string_view::npos) {
-        param = inputParam.substr(sepPos + 1);
-        if (param == "#")
-            param = std::string_view();
-    } else {
-        param = std::string_view();
-    }
-    auto path = param;
-    if (programTrace_ == nullptr && op == "on") {
-        nextTraceSeq_ = 0;
-        programTrace_ = std::make_unique<ClemensProgramTrace>();
-        programTrace_->enableToolboxLogging(true);
-        fmt::print("Program trace enabled\n");
-        return true;
-    }
-    bool ok = true;
-    if (programTrace_ != nullptr && !path.empty()) {
-        //  save if a path was supplied
-        auto exportPath = std::filesystem::path(config_.traceRootPath) / path;
-        ok = programTrace_->exportTrace(exportPath.string().c_str());
-        if (ok) {
-            programTrace_->reset();
-            fmt::print("Exported program trace to '{}'.\n", exportPath.string());
-        } else {
-            fmt::print("ERROR: failed to export program trace to '{}'.  Trace not cleared.\n",
-                       exportPath.string());
-        }
-    }
-    if (programTrace_ != nullptr && op == "off") {
-        fmt::print("Program trace disabled\n");
-        programTrace_ = nullptr;
-    }
-    if (programTrace_) {
-        if (op == "iwm") {
-            programTrace_->enableIWMLogging(!programTrace_->isIWMLoggingEnabled());
-            fmt::print("{} tracing = {}\n", op, programTrace_->isIWMLoggingEnabled());
-        } else {
-            fmt::print("{} tracing is not recognized.\n", op);
-        }
-    }
-    return ok;
-}
-
-void ClemensBackend::saveMachine(std::string path) {
-    queue(Command{Command::SaveMachine, std::move(path)});
-}
-
-bool ClemensBackend::saveSnapshot(const std::string_view &inputParam) {
-    auto outputPath = std::filesystem::path(config_.snapshotRootPath) / inputParam;
-    return ClemensSerializer::save(outputPath.string(), &machine_, &mmio_, diskContainers_.size(),
-                                   diskContainers_.data(), diskDrives_.data(),
-                                   CLEM_SMARTPORT_DRIVE_LIMIT, smartPortDisks_.data(),
-                                   smartPortDrives_.data(), breakpoints_);
-}
-
-void ClemensBackend::loadMachine(std::string path) {
-    queue(Command{Command::LoadMachine, std::move(path)});
-}
-
-bool ClemensBackend::loadSnapshot(const std::string_view &inputParam) {
-    auto outputPath = std::filesystem::path(config_.snapshotRootPath) / inputParam;
-    bool res = ClemensSerializer::load(
-        outputPath.string(), &machine_, &mmio_, diskContainers_.size(), diskContainers_.data(),
-        diskDrives_.data(), CLEM_SMARTPORT_DRIVE_LIMIT, smartPortDisks_.data(),
-        smartPortDrives_.data(), breakpoints_, &ClemensBackend::unserializeAllocate, this);
-    saveBRAM();
-    return res;
-}
-
-void ClemensBackend::runScript(std::string command) {
-    queue(Command{Command::RunScript, std::move(command)});
-}
-
-bool ClemensBackend::runScriptCommand(const std::string_view &command) {
-    auto result = interpreter_.parse(command);
-    if (result.type == ClemensInterpreter::Result::Ok) {
-        interpreter_.execute(this);
-    } else if (result.type == ClemensInterpreter::Result::SyntaxError) {
-        // CLEM_TERM_COUT.print(TerminalLine::Error, "Syntax Error");
-        return false;
-    } else {
-        //        CLEM_TERM_COUT.print(TerminalLine::Error, "Unrecognized command!");
-        return false;
-    }
-    return true;
-}
 //  TODO: Move into Clemens API clemens_mmio_find_card_name()
 static ClemensCard *findMockingboardCard(ClemensMMIO *mmio) {
     for (int cardIdx = 0; cardIdx < CLEM_CARD_SLOT_COUNT; ++cardIdx) {
@@ -534,160 +286,15 @@ bool ClemensBackend::saveSmartPortDisk(unsigned driveIndex) {
     return true;
 }
 
-static const char *sInputKeys[] = {"",      "keyD", "keyU",   "mouseD", "mouseU",
-                                   "mouse", "padl", "nopadl", NULL};
-
-void ClemensBackend::inputEvent(const ClemensInputEvent &input) {
-    CK_ASSERT_RETURN(*sInputKeys[input.type] != '\0');
-    Command cmd{Command::Input};
-    if (input.type == kClemensInputType_Paddle ||
-        input.type == kClemensInputType_PaddleDisconnected) {
-        cmd.operand = fmt::format("{}={},{},{}", sInputKeys[input.type], input.value_a,
-                                  input.value_b, input.gameport_button_mask);
-    } else {
-        cmd.operand = fmt::format("{}={},{},{}", sInputKeys[input.type], input.value_a,
-                                  input.value_b, input.adb_key_toggle_mask);
-    }
-    queue(cmd);
-}
-
-#if defined(__GNUC__)
-#if !defined(__clang__)
-//  NOTE GCC warning seems spurious for *some* std::string_view::find() cases
-//       have added plenty of guards around the line below to no avail.
-//            commaPos = !inputValueB.empty() ? inputValueB.find(',') : std::string_view::npos;
-//  ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91397
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-#endif
-void ClemensBackend::inputMachine(const std::string_view &inputParam) {
-    if (!clemens_is_initialized_simple(&machine_)) {
-        return;
-    }
-    auto equalsTokenPos = inputParam.find('=');
-    auto name = inputParam.substr(0, equalsTokenPos);
-    auto value = inputParam.substr(equalsTokenPos + 1);
-    for (const char **keyName = &sInputKeys[0]; *keyName != NULL; ++keyName) {
-        if (name == *keyName) {
-            ClemensInputEvent inputEvent{};
-            inputEvent.type = (ClemensInputType)((int)(keyName - &sInputKeys[0]));
-            //  oh why, oh why no straightforward C++ conversion from std::string_view
-            //  to number
-            auto commaPos = value.find(',');
-            auto inputValueA = value.substr(0, commaPos);
-            inputEvent.value_a = (int16_t)std::stol(std::string(inputValueA));
-            if (commaPos != std::string_view::npos) {
-                std::string_view inputModifiers;
-                auto inputValueB = value.substr(commaPos + 1);
-                commaPos = !inputValueB.empty() ? inputValueB.find(',') : std::string_view::npos;
-                if (commaPos != std::string_view::npos) {
-                    inputModifiers = inputValueB.substr(commaPos + 1);
-                    inputValueB = inputValueB.substr(0, commaPos);
-                }
-                inputEvent.value_b = (int16_t)std::stol(std::string(inputValueB));
-                if (inputEvent.type == kClemensInputType_Paddle ||
-                    inputEvent.type == kClemensInputType_PaddleDisconnected) {
-                    inputEvent.gameport_button_mask = std::stoul(std::string(inputModifiers));
-                } else {
-                    inputEvent.adb_key_toggle_mask = std::stoul(std::string(inputModifiers));
-                }
-            }
-            clemens_input(&mmio_, &inputEvent);
-        }
-    }
-}
-#if defined(__GNUC__)
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#endif
-
-void ClemensBackend::breakExecution() { queue(Command{Command::Break}); }
-
-void ClemensBackend::addBreakpoint(const ClemensBackendBreakpoint &breakpoint) {
-    Command cmd;
-    cmd.operand = fmt::format("{:s}:{:06X}",
-                              breakpoint.type == ClemensBackendBreakpoint::DataRead ? "r"
-                              : breakpoint.type == ClemensBackendBreakpoint::Write  ? "w"
-                              : breakpoint.type == ClemensBackendBreakpoint::IRQ    ? "i"
-                                                                                    : "",
-                              breakpoint.address);
-    cmd.type = Command::AddBreakpoint;
-    queue(std::move(cmd));
-}
-
-bool ClemensBackend::addBreakpoint(const std::string_view &inputParam) {
-    auto sepPos = inputParam.find(':');
-    assert(sepPos != std::string_view::npos);
-    auto type = inputParam.substr(0, sepPos);
-    auto address = inputParam.substr(sepPos + 1);
-    ClemensBackendBreakpoint bp;
-    if (type == "r") {
-        bp.type = ClemensBackendBreakpoint::DataRead;
-    } else if (type == "w") {
-        bp.type = ClemensBackendBreakpoint::Write;
-    } else if (type == "i") {
-        bp.type = ClemensBackendBreakpoint::IRQ;
-    } else {
-        bp.type = ClemensBackendBreakpoint::Execute;
-    }
-    bp.address = (uint32_t)std::stoul(std::string(address), nullptr, 16);
-    auto range = std::equal_range(
-        breakpoints_.begin(), breakpoints_.end(), bp,
-        [](const ClemensBackendBreakpoint &bp, const ClemensBackendBreakpoint &newBp) {
-            return bp.address < newBp.address;
-        });
-    while (range.first != range.second) {
-        if (range.first->type == bp.type) {
-            break;
-        }
-        range.first++;
-    }
-    if (range.first == range.second) {
-        breakpoints_.emplace(range.second, bp);
-    }
-    return true;
-}
-
-void ClemensBackend::removeBreakpoint(unsigned index) {
-    queue(Command{Command::DelBreakpoint, std::to_string(index)});
-}
-
-bool ClemensBackend::delBreakpoint(const std::string_view &inputParam) {
-    if (inputParam.empty()) {
-        breakpoints_.clear();
-        return true;
-    }
-    unsigned index = (unsigned)std::stoul(std::string(inputParam));
-    if (index >= breakpoints_.size()) {
-        return false;
-    }
-    breakpoints_.erase(breakpoints_.begin() + index);
-    return true;
-}
-
-void ClemensBackend::queue(const Command &cmd) {
-    {
-        std::lock_guard<std::mutex> queuelock(commandQueueMutex_);
-        commandQueue_.emplace_back(cmd);
-    }
-    commandQueueCondition_.notify_one();
-}
-
-void ClemensBackend::queueToFront(const Command &cmd) {
-    {
-        std::lock_guard<std::mutex> queuelock(commandQueueMutex_);
-        commandQueue_.emplace_front(cmd);
-    }
-    commandQueueCondition_.notify_one();
-}
-
 //  from the emulator, obtain the number of clocks per second desired
 //
 static int64_t calculateClocksPerTimeslice(ClemensMMIO *mmio, unsigned hz) {
     bool is_machine_slow;
     return int64_t(clemens_clocks_per_second(mmio, &is_machine_slow) / hz);
+}
+
+bool ClemensBackend::isRunning() const {
+    return !stepsRemaining_.has_value() || *stepsRemaining_ > 0;
 }
 
 #if defined(__GNUC__)
@@ -702,410 +309,234 @@ static int64_t calculateClocksPerTimeslice(ClemensMMIO *mmio, unsigned hz) {
 #endif
 #endif
 
-void ClemensBackend::main(PublishStateDelegate publishDelegate) {
-    int64_t clocksRemainingInTimeslice = 0;
-    std::optional<int> stepsRemaining = 0;
-    bool isTerminated = false;
-    bool isMachineReady = false;
+ClemensCommandQueue::DispatchResult ClemensBackend::main(ClemensCommandQueue &commandQueue,
+                                                         ClemensBackendState &backendState) {
 
-    ClemensRunSampler runSampler;
-
-    //  TODO: clemens API clemens_mmio_card_insert()
-    for (size_t cardIdx = 0; cardIdx < config_.cardNames.size(); ++cardIdx) {
-        auto &cardName = config_.cardNames[cardIdx];
-        if (!cardName.empty()) {
-            mmio_.card_slot[cardIdx] = createCard(cardName.c_str());
-        } else {
-            mmio_.card_slot[cardIdx] = NULL;
-        }
-    }
-
-    fmt::print("Starting backend thread.\n");
-
-    ClemensCard *mockingboard = findMockingboardCard(&mmio_);
-    uint64_t publishSeqNo = 0;
     unsigned emulatorRefreshFrequency = 60;
-    auto fixedFrameInterval =
-        std::chrono::microseconds((long)std::floor(1e6 / emulatorRefreshFrequency));
     auto lastFrameTimePoint = std::chrono::high_resolution_clock::now();
     std::optional<unsigned> hitBreakpoint;
-    std::optional<std::string> debugMessage;
-    std::vector<ClemensBackendResult> commandResults;
-
-    ClemensBackendState publishedState{};
-    publishedState.results.reserve(8);
 
     double emulatorTimeScalar = 1.0; //  used for fast emulation
 
-    while (!isTerminated) {
-        bool isRunning = !stepsRemaining.has_value() || *stepsRemaining > 0;
-        bool publishState = false;
-        bool updateSeqNo = false;
+    bool wasMachineRunning = isRunning();
+    bool updateSeqNo = false;
 
-        std::unique_lock<std::mutex> queuelock(commandQueueMutex_);
-        if (!isRunning) {
-            //  waiting for commands
-            commandQueueCondition_.wait(queuelock, [this] { return !commandQueue_.empty(); });
+    ClemensCommandQueue::DispatchResult commandResults = commandQueue.dispatchAll(*this);
+    bool isTerminated = commandResults.second;
+    bool isMachineRunning = isRunning();
+    if (wasMachineRunning != isMachineRunning) {
+        if (isMachineRunning) {
+            runSampler_.reset();
         }
-
-        //  TODO: we may just be able to use a vector for the command queue and
-        //        create a local copy of the queue to minimize time spent executing
-        //        commands.   the mutex seems to be used just for adds to the
-        //        command queue.
-        while (!commandQueue_.empty() && !isTerminated) {
-            auto command = commandQueue_.front();
-            commandQueue_.pop_front();
-            bool commandFailed = false;
-
-            switch (command.type) {
-            case Command::Terminate:
-                isTerminated = true;
-                break;
-            case Command::ResetMachine:
-                resetMachine();
-                isMachineReady = true;
-                mockingboard = findMockingboardCard(&mmio_);
-                break;
-            case Command::SetHostUpdateFrequency:
-                emulatorRefreshFrequency = std::stoul(command.operand);
-                if (emulatorRefreshFrequency) {
-                    fixedFrameInterval =
-                        std::chrono::microseconds((long)std::floor(1e6 / emulatorRefreshFrequency));
-                } else {
-                    fixedFrameInterval = std::chrono::microseconds::zero();
-                }
-                break;
-            case Command::RunMachine:
-                stepsRemaining = std::nullopt;
-                isRunning = true;
-                runSampler.reset();
-                break;
-            case Command::StepMachine:
-                *stepsRemaining = stepMachine(command.operand);
-                isRunning = true;
-                runSampler.reset();
-                break;
-            case Command::Publish:
-                publishState = true;
-                break;
-            case Command::InsertDisk:
-                if (!insertDisk(command.operand, false))
-                    commandFailed = true;
-                break;
-            case Command::InsertBlankDisk:
-                if (!insertDisk(command.operand, true))
-                    commandFailed = true;
-                break;
-            case Command::EjectDisk:
-                ejectDisk(command.operand);
-                break;
-            case Command::WriteProtectDisk:
-                writeProtectDisk(command.operand);
-                break;
-            case Command::Input:
-                inputMachine(command.operand);
-                break;
-            case Command::Break:
-                stepsRemaining = 0;
-                break;
-            case Command::AddBreakpoint:
-                if (!addBreakpoint(command.operand))
-                    commandFailed = true;
-                break;
-            case Command::DelBreakpoint:
-                if (!delBreakpoint(command.operand))
-                    commandFailed = true;
-                break;
-            case Command::DebugMemoryPage:
-                debugMemoryPage_ = (uint8_t)(std::stoul(command.operand));
-                break;
-            case Command::WriteMemory:
-                writeMemory(command.operand);
-                break;
-            case Command::DebugLogLevel:
-                logLevel_ = (int)(std::stol(command.operand));
-                break;
-            case Command::DebugMessage:
-                debugMessage = std::move(command.operand);
-                break;
-            case Command::DebugProgramTrace:
-                if (!programTrace(command.operand))
-                    commandFailed = true;
-                break;
-            case Command::SaveMachine:
-                if (!saveSnapshot(command.operand))
-                    commandFailed = true;
-                break;
-            case Command::LoadMachine:
-                if (loadSnapshot(command.operand)) {
-                    mockingboard = findMockingboardCard(&mmio_);
-                } else {
-                    //  TODO: this should force a restart - hopefully the
-                    //        frontend will save the current state prior to loading
-                    //        a new one to avoid data loss.
-                    commandFailed = true;
-                }
-                break;
-            case Command::RunScript:
-                if (!runScriptCommand(command.operand)) {
-                    commandFailed = true;
-                }
-                break;
-            case Command::Undefined:
-                break;
-            }
-
-            if (command.type != Command::Publish && command.type != Command::Input) {
-                //   queue command result
-                ClemensBackendResult commandResult;
-                commandResult.cmd = std::move(command);
-                commandResult.type =
-                    commandFailed ? ClemensBackendResult::Failed : ClemensBackendResult::Succeeded;
-                commandResults.emplace_back(commandResult);
-            }
-        }
-        queuelock.unlock();
-
-        //  TODO: these edge cases seem sloppy - but we'll need to prevent the
-        //        thread from spinning if the machine will not run
-        if (!isMachineReady || emulatorRefreshFrequency == 0) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(15));
-            continue;
-        }
-        //  if isRunning is false, we use a condition var/wait to hold the thread
-        if (isRunning && !isTerminated) {
-            //  Run the emulator in either 'step' or 'run' mode.
-            //
-            //  RUN MODE executes several instructions in time slices to maximize
-            //  performance while providing feedback to the frontend.
-            //
-            //  STEP MODE executes a single instruction and decrements a 'step' counter
-            //
-            //  If neither mode is applicable, the emulator holds and this loop will
-            //  wait for commands from the frontend
-            //
-            areInstructionsLogged_ = stepsRemaining.has_value() && (*stepsRemaining > 0);
-
-            const time_t kEpoch1904To1970Seconds = 2082844800;
-            auto epoch_time_1904 =
-                (std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) +
-                 kEpoch1904To1970Seconds);
-
-            clemens_rtc_set(&mmio_, (unsigned)epoch_time_1904);
-
-            // TODO: this should be an adaptive scalar to support a variety of devices.
-            // Though if the emulator runs hot (cannot execute the desired cycles in enough time),
-            // that shouldn't matter too much given that this 'speed boost' is meant to be
-            // temporary, and the emulator should catch up once the IWM is inactive.
-            if (clemens_is_drive_io_active(&mmio_)) {
-                emulatorTimeScalar = 8.0;
-            } else {
-                emulatorTimeScalar = 1.0;
-            }
-            auto lastClocksSpent = machine_.tspec.clocks_spent;
-            int64_t clocksPerTimeslice =
-                calculateClocksPerTimeslice(&mmio_, emulatorRefreshFrequency) * emulatorTimeScalar;
-
-            clocksRemainingInTimeslice += clocksPerTimeslice;
-
-            machine_.cpu.cycles_spent = 0;
-            while (clocksRemainingInTimeslice > 0 &&
-                   (!stepsRemaining.has_value() || *stepsRemaining > 0)) {
-                clem_clocks_time_t pre_emulate_time = machine_.tspec.clocks_spent;
-                clemens_emulate_cpu(&machine_);
-                clemens_emulate_mmio(&machine_, &mmio_);
-                clem_clocks_duration_t emulate_step_clocks =
-                    machine_.tspec.clocks_spent - pre_emulate_time;
-                clocksRemainingInTimeslice -= emulate_step_clocks;
-                if (stepsRemaining.has_value()) {
-                    stepsRemaining = *stepsRemaining - 1;
-                }
-                //  TODO: MMIO bypass
-                if (!breakpoints_.empty()) {
-                    if ((hitBreakpoint = checkHitBreakpoint()).has_value()) {
-                        stepsRemaining = 0;
-                        break;
-                    }
-                }
-            } // clocksRemainingInTimeslice
-
-            if (stepsRemaining.has_value() && *stepsRemaining == 0) {
-                //  if we've finished stepping through code, we are also done with our
-                //  timeslice and will wait for a new step/run request
-                clocksRemainingInTimeslice = 0;
-                isRunning = false;
-                areInstructionsLogged_ = false;
-            }
-
-            auto currentFrameTimePoint = std::chrono::high_resolution_clock::now();
-            auto actualFrameInterval = std::chrono::duration_cast<std::chrono::microseconds>(
-                currentFrameTimePoint - lastFrameTimePoint);
-            lastFrameTimePoint = currentFrameTimePoint;
-
-            runSampler.update(
-                fixedFrameInterval, actualFrameInterval,
-                (clem_clocks_duration_t)(machine_.tspec.clocks_spent - lastClocksSpent),
-                machine_.cpu.cycles_spent);
-
-            for (auto diskDriveIt = diskDrives_.begin(); diskDriveIt != diskDrives_.end();
-                 ++diskDriveIt) {
-                auto &diskDrive = *diskDriveIt;
-                auto driveIndex = unsigned(diskDriveIt - diskDrives_.begin());
-                auto driveType = static_cast<ClemensDriveType>(driveIndex);
-                auto *clemensDrive = clemens_drive_get(&mmio_, driveType);
-                diskDrive.isSpinning = clemensDrive->is_spindle_on;
-                diskDrive.isWriteProtected = clemensDrive->disk.is_write_protected;
-                diskDrive.saveFailed = false;
-                if (diskDrive.isEjecting) {
-                    if (clemens_eject_disk_async(&mmio_, driveType, &disks_[driveIndex])) {
-                        diskDrive.isEjecting = false;
-                        if (!saveDisk(driveType))
-                            diskDrive.saveFailed = true;
-                        diskDrive.imagePath.clear();
-                        ClemensDiskUtilities::createEmptyDisk(driveType, disks_[driveType]);
-                    }
-                }
-            }
-            for (auto diskDriveIt = smartPortDrives_.begin(); diskDriveIt != smartPortDrives_.end();
-                 ++diskDriveIt) {
-                auto &diskDrive = *diskDriveIt;
-                // auto driveIndex = unsigned(diskDriveIt - smartPortDrives_.begin());
-                //  auto *clemensUnit = clemens_smartport_unit_get(&mmio_, driveIndex);
-                //   TODO: detect SmartPort drive status - enable2 only detects if the
-                //         whole bus is active - which may be fine for now since we just support
-                //         one SmartPort drive!
-                diskDrive.isSpinning = mmio_.dev_iwm.enable2;
-                diskDrive.isWriteProtected = false;
-                diskDrive.saveFailed = false;
-                if (diskDrive.isEjecting) {
-                    //  TODO: SmartPort drive ejection
-                }
-            }
-            updateSeqNo = true;
-        }
-
-        if (isTerminated) {
-            //  eject and save all disks
-            for (auto diskDriveIt = diskDrives_.begin(); diskDriveIt != diskDrives_.end();
-                 ++diskDriveIt) {
-                auto &diskDrive = *diskDriveIt;
-                if (diskDrive.imagePath.empty())
-                    continue;
-
-                auto driveIndex = unsigned(diskDriveIt - diskDrives_.begin());
-                auto driveType = static_cast<ClemensDriveType>(driveIndex);
-                if (clemens_eject_disk_async(&mmio_, driveType, &disks_[driveIndex])) {
-                    saveDisk(driveType);
-                    localLog(CLEM_DEBUG_LOG_INFO, "Saved {}", diskDrive.imagePath);
-                }
-            }
-            for (auto hardDriveIt = smartPortDrives_.begin(); hardDriveIt != smartPortDrives_.end();
-                 ++hardDriveIt) {
-                auto &drive = *hardDriveIt;
-                if (drive.imagePath.empty())
-                    continue;
-                auto driveIndex = unsigned(hardDriveIt - smartPortDrives_.begin());
-                ClemensSmartPortDevice device;
-                clemens_remove_smartport_disk(&mmio_, driveIndex, &device);
-                smartPortDisks_[driveIndex].destroySmartPortDevice(&device);
-                saveSmartPortDisk(driveIndex);
-                localLog(CLEM_DEBUG_LOG_INFO, "Saved {}", drive.imagePath);
-            }
-            publishState = true;
-            updateSeqNo = true;
-        }
-
-        updateSeqNo = updateSeqNo || !commandResults.empty();
-
-        if (updateSeqNo) {
-            publishSeqNo++;
-        }
-
-        //  TODO: publish emulator state using a callback
-        //        the recipient will synchronize with UI accordingly with the
-        //        assumption that once the callback returns, we can alter the state
-        //        again as needed next timeslice.
-        if (publishState) {
-            std::swap(publishedState.results, commandResults);
-            publishedState.machine = &machine_;
-            publishedState.mmio = &mmio_;
-            publishedState.fps = runSampler.sampledFramesPerSecond;
-            publishedState.seqno = publishSeqNo;
-            publishedState.isTerminated = isTerminated;
-            publishedState.isRunning = isRunning;
-            if (programTrace_ != nullptr) {
-                publishedState.isTracing = true;
-                publishedState.isIWMTracing = programTrace_->isIWMLoggingEnabled();
-            } else {
-                publishedState.isTracing = false;
-                publishedState.isIWMTracing = false;
-            }
-            publishedState.mmioWasInitialized = clemens_is_initialized_simple(&machine_);
-            if (publishedState.mmioWasInitialized) {
-                clemens_get_monitor(&publishedState.monitor, &mmio_);
-                clemens_get_text_video(&publishedState.text, &mmio_);
-                clemens_get_graphics_video(&publishedState.graphics, &machine_, &mmio_);
-                if (clemens_get_audio(&publishedState.audio, &mmio_)) {
-                    if (mockingboard) {
-                        auto &audio = publishedState.audio;
-                        float *audio_frame_head = reinterpret_cast<float *>(
-                            audio.data + audio.frame_start * audio.frame_stride);
-                        clem_card_ay3_render(mockingboard, audio_frame_head, audio.frame_count,
-                                             audio.frame_stride / sizeof(float),
-                                             config_.audioSamplesPerSecond);
-                    }
-                }
-            }
-            publishedState.hostCPUID = clem_host_get_processor_number();
-            publishedState.logLevel = logLevel_;
-            publishedState.logBufferStart = logOutput_.data();
-            publishedState.logBufferEnd = logOutput_.data() + logOutput_.size();
-            publishedState.bpBufferStart = breakpoints_.data();
-            publishedState.bpBufferEnd = breakpoints_.data() + breakpoints_.size();
-            if (hitBreakpoint.has_value()) {
-                publishedState.bpHitIndex = *hitBreakpoint;
-            }
-
-            publishedState.diskDrives = diskDrives_.data();
-            publishedState.smartDrives = smartPortDrives_.data();
-            publishedState.logInstructionStart = loggedInstructions_.data();
-            publishedState.logInstructionEnd =
-                loggedInstructions_.data() + loggedInstructions_.size();
-
-            //  read IO memory from bank 0xe0 which ignores memory shadow settings
-            for (uint16_t ioAddr = 0xc000; ioAddr < 0xc0ff; ++ioAddr) {
-                clem_read(&machine_, &publishedState.ioPageValues[ioAddr - 0xc000], ioAddr, 0xe0,
-                          CLEM_MEM_FLAG_NULL);
-            }
-            publishedState.debugMemoryPage = debugMemoryPage_;
-            publishedState.emulatorSpeedMhz = runSampler.sampledEmulatorSpeedMhz;
-            publishedState.fastEmulationOn = emulatorTimeScalar > 1.0f;
-            publishedState.message = std::move(debugMessage);
-
-            // send the published state to our listener
-            publishDelegate(publishedState);
-
-            if (publishedState.mmioWasInitialized) {
-                clemens_audio_next_frame(&mmio_, publishedState.audio.frame_count);
-            }
-            logOutput_.clear();
-            loggedInstructions_.clear();
-            commandResults.clear();
-            hitBreakpoint = std::nullopt;
-            debugMessage = std::nullopt;
-        }
-    } // !isTerminated
-
-    saveBRAM();
-
-    //  TODO: clemens_mmio_card_eject() will clear the slot but it still needs
-    //        to be destroyed by the app
-    for (int i = 0; i < CLEM_CARD_SLOT_COUNT; ++i) {
-        destroyCard(mmio_.card_slot[i]);
-        mmio_.card_slot[i] = NULL;
     }
 
-    fmt::print("Terminated backend refresh thread.\n");
+    if (isMachineRunning && !isTerminated) {
+        //  Run the emulator in either 'step' or 'run' mode.
+        //
+        //  RUN MODE executes several instructions in time slices to maximize
+        //  performance while providing feedback to the frontend.
+        //
+        //  STEP MODE executes a single instruction and decrements a 'step' counter
+        //
+        //  If neither mode is applicable, the emulator holds and this loop will
+        //  wait for commands from the frontend
+        //
+        areInstructionsLogged_ = stepsRemaining_.has_value() && (*stepsRemaining_ > 0);
+
+        const time_t kEpoch1904To1970Seconds = 2082844800;
+        auto epoch_time_1904 =
+            (std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) +
+             kEpoch1904To1970Seconds);
+
+        clemens_rtc_set(&mmio_, (unsigned)epoch_time_1904);
+
+        // TODO: this should be an adaptive scalar to support a variety of devices.
+        // Though if the emulator runs hot (cannot execute the desired cycles in enough time),
+        // that shouldn't matter too much given that this 'speed boost' is meant to be
+        // temporary, and the emulator should catch up once the IWM is inactive.
+        if (clemens_is_drive_io_active(&mmio_)) {
+            emulatorTimeScalar = 8.0;
+        } else {
+            emulatorTimeScalar = 1.0;
+        }
+        auto lastClocksSpent = machine_.tspec.clocks_spent;
+        int64_t clocksPerTimeslice =
+            calculateClocksPerTimeslice(&mmio_, emulatorRefreshFrequency) * emulatorTimeScalar;
+
+        clocksRemainingInTimeslice_ += clocksPerTimeslice;
+
+        machine_.cpu.cycles_spent = 0;
+        while (clocksRemainingInTimeslice_ > 0 && isRunning()) {
+            clem_clocks_time_t pre_emulate_time = machine_.tspec.clocks_spent;
+            clemens_emulate_cpu(&machine_);
+            clemens_emulate_mmio(&machine_, &mmio_);
+            clem_clocks_duration_t emulate_step_clocks =
+                machine_.tspec.clocks_spent - pre_emulate_time;
+            clocksRemainingInTimeslice_ -= emulate_step_clocks;
+            if (stepsRemaining_.has_value()) {
+                stepsRemaining_ = *stepsRemaining_ - 1;
+            }
+            //  TODO: MMIO bypass
+            if (!breakpoints_.empty()) {
+                if ((hitBreakpoint = checkHitBreakpoint()).has_value()) {
+                    stepsRemaining_ = 0;
+                    break;
+                }
+            }
+        } // clocksRemainingInTimeslice
+
+        if (stepsRemaining_.has_value() && *stepsRemaining_ == 0) {
+            //  if we've finished stepping through code, we are also done with our
+            //  timeslice and will wait for a new step/run request
+            clocksRemainingInTimeslice_ = 0;
+            isMachineRunning = false;
+            areInstructionsLogged_ = false;
+        }
+
+        auto currentFrameTimePoint = std::chrono::high_resolution_clock::now();
+        auto actualFrameInterval = std::chrono::duration_cast<std::chrono::microseconds>(
+            currentFrameTimePoint - lastFrameTimePoint);
+        lastFrameTimePoint = currentFrameTimePoint;
+
+        runSampler_.update(actualFrameInterval,
+                           (clem_clocks_duration_t)(machine_.tspec.clocks_spent - lastClocksSpent),
+                           machine_.cpu.cycles_spent);
+
+        for (auto diskDriveIt = diskDrives_.begin(); diskDriveIt != diskDrives_.end();
+             ++diskDriveIt) {
+            auto &diskDrive = *diskDriveIt;
+            auto driveIndex = unsigned(diskDriveIt - diskDrives_.begin());
+            auto driveType = static_cast<ClemensDriveType>(driveIndex);
+            auto *clemensDrive = clemens_drive_get(&mmio_, driveType);
+            diskDrive.isSpinning = clemensDrive->is_spindle_on;
+            diskDrive.isWriteProtected = clemensDrive->disk.is_write_protected;
+            diskDrive.saveFailed = false;
+            if (diskDrive.isEjecting) {
+                if (clemens_eject_disk_async(&mmio_, driveType, &disks_[driveIndex])) {
+                    diskDrive.isEjecting = false;
+                    if (!saveDisk(driveType))
+                        diskDrive.saveFailed = true;
+                    diskDrive.imagePath.clear();
+                    ClemensDiskUtilities::createEmptyDisk(driveType, disks_[driveType]);
+                }
+            }
+        }
+        for (auto diskDriveIt = smartPortDrives_.begin(); diskDriveIt != smartPortDrives_.end();
+             ++diskDriveIt) {
+            auto &diskDrive = *diskDriveIt;
+            // auto driveIndex = unsigned(diskDriveIt - smartPortDrives_.begin());
+            //  auto *clemensUnit = clemens_smartport_unit_get(&mmio_, driveIndex);
+            //   TODO: detect SmartPort drive status - enable2 only detects if the
+            //         whole bus is active - which may be fine for now since we just support
+            //         one SmartPort drive!
+            diskDrive.isSpinning = mmio_.dev_iwm.enable2;
+            diskDrive.isWriteProtected = false;
+            diskDrive.saveFailed = false;
+            if (diskDrive.isEjecting) {
+                //  TODO: SmartPort drive ejection
+            }
+        }
+        updateSeqNo = true;
+    }
+
+    if (isTerminated) {
+        //  eject and save all disks
+        for (auto diskDriveIt = diskDrives_.begin(); diskDriveIt != diskDrives_.end();
+             ++diskDriveIt) {
+            auto &diskDrive = *diskDriveIt;
+            if (diskDrive.imagePath.empty())
+                continue;
+
+            auto driveIndex = unsigned(diskDriveIt - diskDrives_.begin());
+            auto driveType = static_cast<ClemensDriveType>(driveIndex);
+            if (clemens_eject_disk_async(&mmio_, driveType, &disks_[driveIndex])) {
+                saveDisk(driveType);
+                localLog(CLEM_DEBUG_LOG_INFO, "Saved {}", diskDrive.imagePath);
+            }
+        }
+        for (auto hardDriveIt = smartPortDrives_.begin(); hardDriveIt != smartPortDrives_.end();
+             ++hardDriveIt) {
+            auto &drive = *hardDriveIt;
+            if (drive.imagePath.empty())
+                continue;
+            auto driveIndex = unsigned(hardDriveIt - smartPortDrives_.begin());
+            ClemensSmartPortDevice device;
+            clemens_remove_smartport_disk(&mmio_, driveIndex, &device);
+            smartPortDisks_[driveIndex].destroySmartPortDevice(&device);
+            saveSmartPortDisk(driveIndex);
+            localLog(CLEM_DEBUG_LOG_INFO, "Saved {}", drive.imagePath);
+        }
+        updateSeqNo = true;
+    }
+
+    updateSeqNo = updateSeqNo || !commandResults.first.empty();
+
+    if (updateSeqNo) {
+        publishSeqNo_++;
+    }
+
+    backendState.machine = &machine_;
+    backendState.mmio = &mmio_;
+    backendState.fps = runSampler_.sampledFramesPerSecond;
+    backendState.seqno = publishSeqNo_;
+    backendState.isTerminated = isTerminated;
+    backendState.isRunning = isMachineRunning;
+    if (programTrace_ != nullptr) {
+        backendState.isTracing = true;
+        backendState.isIWMTracing = programTrace_->isIWMLoggingEnabled();
+    } else {
+        backendState.isTracing = false;
+        backendState.isIWMTracing = false;
+    }
+    backendState.mmioWasInitialized = clemens_is_initialized_simple(&machine_);
+    if (backendState.mmioWasInitialized) {
+        clemens_get_monitor(&backendState.monitor, &mmio_);
+        clemens_get_text_video(&backendState.text, &mmio_);
+        clemens_get_graphics_video(&backendState.graphics, &machine_, &mmio_);
+        if (clemens_get_audio(&backendState.audio, &mmio_)) {
+            if (mockingboard_) {
+                auto &audio = backendState.audio;
+                float *audio_frame_head =
+                    reinterpret_cast<float *>(audio.data + audio.frame_start * audio.frame_stride);
+                clem_card_ay3_render(mockingboard_, audio_frame_head, audio.frame_count,
+                                     audio.frame_stride / sizeof(float),
+                                     config_.audioSamplesPerSecond);
+            }
+        }
+    }
+    backendState.hostCPUID = clem_host_get_processor_number();
+    backendState.logLevel = logLevel_;
+    backendState.logBufferStart = logOutput_.data();
+    backendState.logBufferEnd = logOutput_.data() + logOutput_.size();
+    backendState.bpBufferStart = breakpoints_.data();
+    backendState.bpBufferEnd = breakpoints_.data() + breakpoints_.size();
+    if (hitBreakpoint.has_value()) {
+        backendState.bpHitIndex = *hitBreakpoint;
+    }
+
+    backendState.diskDrives = diskDrives_.data();
+    backendState.smartDrives = smartPortDrives_.data();
+    backendState.logInstructionStart = loggedInstructions_.data();
+    backendState.logInstructionEnd = loggedInstructions_.data() + loggedInstructions_.size();
+
+    //  read IO memory from bank 0xe0 which ignores memory shadow settings
+    for (uint16_t ioAddr = 0xc000; ioAddr < 0xc0ff; ++ioAddr) {
+        clem_read(&machine_, &backendState.ioPageValues[ioAddr - 0xc000], ioAddr, 0xe0,
+                  CLEM_MEM_FLAG_NULL);
+    }
+    backendState.debugMemoryPage = debugMemoryPage_;
+    backendState.emulatorSpeedMhz = runSampler_.sampledEmulatorSpeedMhz;
+    backendState.fastEmulationOn = emulatorTimeScalar > 1.0f;
+
+    return commandResults;
+}
+
+void ClemensBackend::post(ClemensBackendState &backendState) {
+    if (backendState.mmioWasInitialized) {
+        clemens_audio_next_frame(&mmio_, backendState.audio.frame_count);
+    }
+    logOutput_.clear();
+    loggedInstructions_.clear();
 }
 
 #if defined(__GNUC__)
@@ -1236,6 +667,18 @@ void ClemensBackend::initApple2GS() {
     audioMixBuffer.data =
         (uint8_t *)(slabMemory_.allocate(audioMixBuffer.frame_count * audioMixBuffer.stride));
     clemens_assign_audio_mix_buffer(&mmio_, &audioMixBuffer);
+
+    //  TODO: clemens API clemens_mmio_card_insert()
+    for (size_t cardIdx = 0; cardIdx < config_.cardNames.size(); ++cardIdx) {
+        auto &cardName = config_.cardNames[cardIdx];
+        if (!cardName.empty()) {
+            mmio_.card_slot[cardIdx] = createCard(cardName.c_str());
+        } else {
+            mmio_.card_slot[cardIdx] = NULL;
+        }
+    }
+
+    mockingboard_ = findMockingboardCard(&mmio_);
 }
 
 void ClemensBackend::saveBRAM() {
@@ -1353,4 +796,152 @@ void ClemensBackend::assignPropertyToU32(MachineProperty property, uint32_t valu
         machine_.cpu.regs.PC = (uint16_t)(value & 0xff);
         break;
     };
+}
+
+void ClemensBackend::onCommandReset() {
+    machine_.cpu.pins.resbIn = false;
+    machine_.resb_counter = 3;
+    mockingboard_ = findMockingboardCard(&mmio_);
+}
+
+void ClemensBackend::onCommandRun() { stepsRemaining_ = std::nullopt; }
+
+void ClemensBackend::onCommandBreakExecution() { *stepsRemaining_ = 0; }
+
+void ClemensBackend::onCommandStep(unsigned count) { *stepsRemaining_ = count; }
+
+void ClemensBackend::onCommandAddBreakpoint(const ClemensBackendBreakpoint &breakpoint) {
+    auto range = std::equal_range(
+        breakpoints_.begin(), breakpoints_.end(), breakpoint,
+        [](const ClemensBackendBreakpoint &breakpoint, const ClemensBackendBreakpoint &newBp) {
+            return breakpoint.address < newBp.address;
+        });
+    while (range.first != range.second) {
+        if (range.first->type == breakpoint.type) {
+            break;
+        }
+        range.first++;
+    }
+    if (range.first == range.second) {
+        breakpoints_.emplace(range.second, breakpoint);
+    }
+}
+
+bool ClemensBackend::onCommandRemoveBreakpoint(int index) {
+    if (index < 0) {
+        breakpoints_.clear();
+        return true;
+    }
+    if (index >= (int)breakpoints_.size()) {
+        return false;
+    }
+    breakpoints_.erase(breakpoints_.begin() + index);
+    return true;
+}
+
+void ClemensBackend::onCommandInputEvent(const ClemensInputEvent &inputEvent) {
+    if (!clemens_is_initialized_simple(&machine_)) {
+        return;
+    }
+    clemens_input(&mmio_, &inputEvent);
+}
+
+bool ClemensBackend::onCommandInsertDisk(ClemensDriveType driveType, std::string diskPath) {
+    diskDrives_[driveType].imagePath = diskPath;
+    return loadDisk(driveType, false);
+}
+
+bool ClemensBackend::onCommandInsertBlankDisk(ClemensDriveType driveType, std::string diskPath) {
+    diskDrives_[driveType].imagePath = diskPath;
+    return loadDisk(driveType, true);
+}
+
+void ClemensBackend::onCommandEjectDisk(ClemensDriveType driveType) {
+    diskDrives_[driveType].isEjecting = true;
+}
+
+bool ClemensBackend::onCommandWriteProtectDisk(ClemensDriveType driveType, bool wp) {
+    auto *drive = clemens_drive_get(&mmio_, driveType);
+    if (!drive || !drive->has_disk)
+        return false;
+    drive->disk.is_write_protected = wp;
+    return true;
+}
+
+void ClemensBackend::onCommandDebugMemoryPage(uint8_t pageIndex) { debugMemoryPage_ = pageIndex; }
+
+void ClemensBackend::onCommandDebugMemoryWrite(uint16_t addr, uint8_t value) {
+    clem_write(&machine_, value, addr, debugMemoryPage_, CLEM_MEM_FLAG_NULL);
+}
+
+void ClemensBackend::onCommandDebugLogLevel(int logLevel) { logLevel_ = logLevel; }
+
+bool ClemensBackend::onCommandDebugProgramTrace(std::string_view op, std::string_view path) {
+    if (programTrace_ == nullptr && op == "on") {
+        nextTraceSeq_ = 0;
+        programTrace_ = std::make_unique<ClemensProgramTrace>();
+        programTrace_->enableToolboxLogging(true);
+        fmt::print("Program trace enabled\n");
+        return true;
+    }
+    bool ok = true;
+    if (programTrace_ != nullptr && !path.empty()) {
+        //  save if a path was supplied
+        auto exportPath = std::filesystem::path(config_.traceRootPath) / path;
+        ok = programTrace_->exportTrace(exportPath.string().c_str());
+        if (ok) {
+            programTrace_->reset();
+            fmt::print("Exported program trace to '{}'.\n", exportPath.string());
+        } else {
+            fmt::print("ERROR: failed to export program trace to '{}'.  Trace not cleared.\n",
+                       exportPath.string());
+        }
+    }
+    if (programTrace_ != nullptr && op == "off") {
+        fmt::print("Program trace disabled\n");
+        programTrace_ = nullptr;
+    }
+    if (programTrace_) {
+        if (op == "iwm") {
+            programTrace_->enableIWMLogging(!programTrace_->isIWMLoggingEnabled());
+            fmt::print("{} tracing = {}\n", op, programTrace_->isIWMLoggingEnabled());
+        } else {
+            fmt::print("{} tracing is not recognized.\n", op);
+        }
+    }
+    return ok;
+}
+
+bool ClemensBackend::onCommandSaveMachine(std::string path) {
+    auto outputPath = std::filesystem::path(config_.snapshotRootPath) / path;
+    saveBRAM();
+    return ClemensSerializer::save(outputPath.string(), &machine_, &mmio_, diskContainers_.size(),
+                                   diskContainers_.data(), diskDrives_.data(),
+                                   CLEM_SMARTPORT_DRIVE_LIMIT, smartPortDisks_.data(),
+                                   smartPortDrives_.data(), breakpoints_);
+}
+
+bool ClemensBackend::onCommandLoadMachine(std::string path) {
+    auto outputPath = std::filesystem::path(config_.snapshotRootPath) / path;
+    bool res = ClemensSerializer::load(
+        outputPath.string(), &machine_, &mmio_, diskContainers_.size(), diskContainers_.data(),
+        diskDrives_.data(), CLEM_SMARTPORT_DRIVE_LIMIT, smartPortDisks_.data(),
+        smartPortDrives_.data(), breakpoints_, &ClemensBackend::unserializeAllocate, this);
+    mockingboard_ = findMockingboardCard(&mmio_);
+    saveBRAM();
+    return res;
+}
+
+bool ClemensBackend::onCommandRunScript(std::string command) {
+    auto result = interpreter_.parse(command);
+    if (result.type == ClemensInterpreter::Result::Ok) {
+        interpreter_.execute(this);
+    } else if (result.type == ClemensInterpreter::Result::SyntaxError) {
+        // CLEM_TERM_COUT.print(TerminalLine::Error, "Syntax Error");
+        return false;
+    } else {
+        //        CLEM_TERM_COUT.print(TerminalLine::Error, "Unrecognized command!");
+        return false;
+    }
+    return true;
 }

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -1,6 +1,7 @@
 #ifndef CLEM_HOST_BACKEND_HPP
 #define CLEM_HOST_BACKEND_HPP
 
+#include "clem_command_queue.hpp"
 #include "clem_host_shared.hpp"
 #include "clem_interpreter.hpp"
 #include "clem_smartport_disk.hpp"
@@ -10,19 +11,42 @@
 #include "clem_woz.h"
 
 #include <array>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <vector>
 
 class ClemensProgramTrace;
 
+struct ClemensRunSampler {
+    std::chrono::microseconds referenceFrameTimer;
+    std::chrono::microseconds actualFrameTimer;
+    std::chrono::microseconds sampledFrameTime;
+
+    double sampledFramesPerSecond;
+
+    cinek::CircularBuffer<std::chrono::microseconds, 120> frameTimeBuffer;
+
+    clem_clocks_time_t sampledClocksSpent;
+    uint64_t sampledCyclesSpent;
+    cinek::CircularBuffer<clem_clocks_duration_t, 120> clocksBuffer;
+    cinek::CircularBuffer<clem_clocks_duration_t, 120> cyclesBuffer;
+
+    double sampledEmulatorSpeedMhz;
+    double actualEmulatorSpeedMhz;
+
+    ClemensRunSampler();
+
+    void reset();
+    void update(std::chrono::microseconds actualFrameInterval, clem_clocks_duration_t clocksSpent,
+                unsigned cyclesSpent);
+};
+
 //  TODO: Machine type logic could be subclassed into an Apple2GS backend, etc.
-class ClemensBackend {
+class ClemensBackend : public ClemensCommandQueueListener {
   public:
     using Config = ClemensBackendConfig;
 
@@ -31,60 +55,15 @@ class ClemensBackend {
     //    scope.  The front-end should copy what it needs for its display during
     //    the delegate's scope. Once the delegate has finished, the data in
     //    ClemensBackendState should be considered invalid/undefined.
-    using PublishStateDelegate = std::function<void(const ClemensBackendState &)>;
-    ClemensBackend(std::string romPathname, const Config &config,
-                   PublishStateDelegate publishDelegate);
+    using PublishStateDelegate = std::function<ClemensCommandQueue(
+        const ClemensCommandQueue::ResultBuffer &, const ClemensBackendState &)>;
+    ClemensBackend(std::string romPathname, const Config &config);
     ~ClemensBackend();
 
-    //  Queues a command to the backend.   Most commands are processed on the next
-    //  execution frame.  Certain commands may hold the queue (i.e. like wait())
-    //  Priority commands like Cancel or Terminate are pushed to the front,
-    //  overriding commands like Wait.
-    void terminate();
-    //  Issues a soft reset to the machine.   This is roughly equivalent to pressing
-    //  the power button.
-    void reset();
-    //  The host should expect emulator state refreshes at this frequency if in
-    //  run mode
-    void setRefreshFrequency(unsigned hz);
-    //  Clears step mode and enter run mode
-    void run();
-    //  Steps the emulator
-    void step(unsigned count);
-    //  Will issue the publish delegate on the next machine iteration
-    void publish();
-    //  Send host input to the emulator
-    void inputEvent(const ClemensInputEvent &inputEvent);
-    //  Insert disk
-    void insertDisk(ClemensDriveType driveType, std::string diskPath);
-    //  Insert blank disk
-    void insertBlankDisk(ClemensDriveType driveType, std::string diskPath);
-    //  Eject disk
-    void ejectDisk(ClemensDriveType driveType);
-    //  Break
-    void breakExecution();
-    //  Add a breakpoint
-    void addBreakpoint(const ClemensBackendBreakpoint &breakpoint);
-    //  Remove a breakpoint
-    void removeBreakpoint(unsigned index);
-    //  Sets the write protect status on a disk in a drive
-    void writeProtectDisk(ClemensDriveType driveType, bool wp);
-    //  Sets the active debug memory page that can be read from or written to by
-    //  the front end (this value is communicated on publish)
-    void debugMemoryPage(uint8_t pageIndex);
-    //  Write a single byte to machine memory at the current debugMemoryPage
-    void debugMemoryWrite(uint16_t addr, uint8_t value);
-    //  Set logging level
-    void debugLogLevel(int logLevel);
-    //  Send a message to the publish delegate from the frontend
-    void debugMessage(std::string msg);
-    //  Enable a program trace
-    void debugProgramTrace(std::string op, std::string path);
-    //  Save and load the machine
-    void saveMachine(std::string path);
-    void loadMachine(std::string path);
+    ClemensCommandQueue::DispatchResult main(ClemensCommandQueue &commandQueue,
+                                             ClemensBackendState &backendState);
 
-    void runScript(std::string command);
+    void post(ClemensBackendState &backendState);
 
     //  these methods do not queue instructions to execute on the runner
     //  and must be executed instead on the runner thread.  They are made public
@@ -95,27 +74,27 @@ class ClemensBackend {
     void assignPropertyToU32(MachineProperty property, uint32_t value);
 
   private:
-    using Command = ClemensBackendCommand;
-
-    void queue(const Command &cmd);
-    void queueToFront(const Command &cmd);
-
-    void main(PublishStateDelegate publishDelegate);
-    void resetMachine();
-    unsigned stepMachine(const std::string_view &inputParam);
-    bool insertDisk(const std::string_view &inputParam, bool allowBlank);
-    void ejectDisk(const std::string_view &inputParam);
-    bool writeProtectDisk(const std::string_view &inputParam);
-    void writeMemory(const std::string_view &inputParam);
-    void inputMachine(const std::string_view &inputParam);
-    bool addBreakpoint(const std::string_view &inputParam);
-    bool delBreakpoint(const std::string_view &inputParam);
-    bool programTrace(const std::string_view &inputParam);
-    bool saveSnapshot(const std::string_view &inputParam);
-    bool loadSnapshot(const std::string_view &inputParam);
-    bool runScriptCommand(const std::string_view &command);
+    void onCommandReset() final;
+    void onCommandRun() final;
+    void onCommandBreakExecution() final;
+    void onCommandStep(unsigned count) final;
+    void onCommandAddBreakpoint(const ClemensBackendBreakpoint &breakpoint) final;
+    bool onCommandRemoveBreakpoint(int index) final;
+    void onCommandInputEvent(const ClemensInputEvent &inputEvent) final;
+    bool onCommandInsertDisk(ClemensDriveType driveType, std::string diskPath) final;
+    bool onCommandInsertBlankDisk(ClemensDriveType driveType, std::string diskPath) final;
+    void onCommandEjectDisk(ClemensDriveType driveType) final;
+    bool onCommandWriteProtectDisk(ClemensDriveType driveType, bool wp) final;
+    void onCommandDebugMemoryPage(uint8_t pageIndex) final;
+    void onCommandDebugMemoryWrite(uint16_t addr, uint8_t value) final;
+    void onCommandDebugLogLevel(int logLevel) final;
+    bool onCommandDebugProgramTrace(std::string_view op, std::string_view path) final;
+    bool onCommandSaveMachine(std::string path) final;
+    bool onCommandLoadMachine(std::string path) final;
+    bool onCommandRunScript(std::string command) final;
 
     std::optional<unsigned> checkHitBreakpoint();
+    bool isRunning() const;
 
     void initEmulatedDiskLocalStorage();
     bool loadDisk(ClemensDriveType driveType, bool allowBlank);
@@ -142,11 +121,6 @@ class ClemensBackend {
   private:
     Config config_;
 
-    std::thread runner_;
-    std::deque<Command> commandQueue_;
-    std::mutex commandQueueMutex_;
-    std::condition_variable commandQueueCondition_;
-
     //  memory allocated once for the machine
     cinek::FixedStack slabMemory_;
     //  the actual machine object
@@ -154,6 +128,7 @@ class ClemensBackend {
     cinek::ByteBuffer diskBuffer_;
     ClemensMachine machine_;
     ClemensMMIO mmio_;
+    ClemensCard *mockingboard_;
 
     ClemensInterpreter interpreter_;
 
@@ -172,6 +147,12 @@ class ClemensBackend {
     int logLevel_;
     uint8_t debugMemoryPage_;
     bool areInstructionsLogged_;
+
+    ClemensRunSampler runSampler_;
+
+    std::optional<int> stepsRemaining_;
+    int64_t clocksRemainingInTimeslice_;
+    uint64_t publishSeqNo_;
 };
 
 #endif

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -5,6 +5,7 @@
 
 #include "fmt/core.h"
 
+#include <cassert>
 #include <charconv>
 
 //  State affected to translate from the old main() to the new main()
@@ -12,6 +13,14 @@
 //      - dispatchAll can alter this equation - so just set isRunning again after dispatchAll()
 //      - if this isRunning has changed to ON from OFF after the call to dispatchAll, reset the run
 //      sampler.
+
+void ClemensCommandQueue::queue(ClemensCommandQueue &other) {
+    while (!queue_.isFull() && !other.queue_.isEmpty()) {
+        Command cmd;
+        other.queue_.pop(cmd);
+        queue_.push(cmd);
+    }
+}
 
 auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> DispatchResult {
     DispatchResult result;
@@ -110,9 +119,8 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
                 commandFailed ? ClemensBackendResult::Failed : ClemensBackendResult::Succeeded;
             result.first.emplace_back(commandResult);
         }
-
-        queue_.clear();
     }
+    queue_.clear();
 
     return result;
 }

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -1,0 +1,362 @@
+#include "clem_command_queue.hpp"
+#include "clem_disk_utils.hpp"
+
+#include "cinek/ckdebug.h"
+
+#include "fmt/core.h"
+
+#include <charconv>
+
+//  State affected to translate from the old main() to the new main()
+//  bool isRunning = !stepsRemaining.has_value() || *stepsRemaining > 0;
+//      - dispatchAll can alter this equation - so just set isRunning again after dispatchAll()
+//      - if this isRunning has changed to ON from OFF after the call to dispatchAll, reset the run
+//      sampler.
+
+auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> DispatchResult {
+    DispatchResult result;
+    result.second = false;
+
+    bool commandFailed = false;
+    while (!queue_.isEmpty() && !result.second) {
+        Command cmd;
+        queue_.pop(cmd);
+
+        switch (cmd.type) {
+        case Command::Terminate:
+            result.second = true;
+            break;
+        case Command::ResetMachine:
+            listener.onCommandReset();
+            break;
+        case Command::RunMachine:
+            listener.onCommandRun();
+            break;
+        case Command::StepMachine: {
+            unsigned count;
+            if (std::from_chars(cmd.operand.data(), cmd.operand.data() + cmd.operand.size(), count)
+                    .ec != std::errc{}) {
+                count = 0;
+            }
+            listener.onCommandStep(count);
+        } break;
+        case Command::InsertDisk:
+            if (!insertDisk(listener, cmd.operand, false))
+                commandFailed = true;
+            break;
+        case Command::InsertBlankDisk:
+            if (!insertDisk(listener, cmd.operand, true))
+                commandFailed = true;
+            break;
+        case Command::EjectDisk:
+            ejectDisk(listener, cmd.operand);
+            break;
+        case Command::WriteProtectDisk:
+            writeProtectDisk(listener, cmd.operand);
+            break;
+        case Command::Input:
+            inputMachine(listener, cmd.operand);
+            break;
+        case Command::Break:
+            listener.onCommandBreakExecution();
+            break;
+        case Command::AddBreakpoint:
+            if (!addBreakpoint(listener, cmd.operand))
+                commandFailed = true;
+            break;
+        case Command::DelBreakpoint:
+            if (!delBreakpoint(listener, cmd.operand))
+                commandFailed = true;
+            break;
+        case Command::DebugMemoryPage:
+            listener.onCommandDebugMemoryPage((uint8_t)(std::stoul(cmd.operand)));
+            break;
+        case Command::WriteMemory:
+            writeMemory(listener, cmd.operand);
+            break;
+        case Command::DebugLogLevel:
+            listener.onCommandDebugLogLevel((int)(std::stol(cmd.operand)));
+            break;
+        case Command::DebugProgramTrace:
+            if (!programTrace(listener, cmd.operand))
+                commandFailed = true;
+            break;
+        case Command::SaveMachine:
+            if (!listener.onCommandSaveMachine(cmd.operand))
+                commandFailed = true;
+            break;
+        case Command::LoadMachine:
+            if (!listener.onCommandLoadMachine(cmd.operand)) {
+                //  TODO: this should force a restart - hopefully the
+                //        frontend will save the current state prior to loading
+                //        a new one to avoid data loss.
+                commandFailed = true;
+            }
+            break;
+        case Command::RunScript:
+            if (!listener.onCommandRunScript(cmd.operand)) {
+                commandFailed = true;
+            }
+            break;
+        case Command::Undefined:
+            break;
+        }
+
+        if (cmd.type != Command::Input) {
+            //   queue command result
+            ClemensBackendResult commandResult;
+            commandResult.cmd = std::move(cmd);
+            commandResult.type =
+                commandFailed ? ClemensBackendResult::Failed : ClemensBackendResult::Succeeded;
+            result.first.emplace_back(commandResult);
+        }
+
+        queue_.clear();
+    }
+
+    return result;
+}
+
+void ClemensCommandQueue::terminate() { queue(Command{Command::Terminate}); }
+
+void ClemensCommandQueue::reset() { queue(Command{Command::ResetMachine}); }
+
+void ClemensCommandQueue::run() { queue(Command{Command::RunMachine}); }
+
+void ClemensCommandQueue::step(unsigned count) {
+    queue(Command{Command::StepMachine, fmt::format("{}", count)});
+}
+
+void ClemensCommandQueue::insertDisk(ClemensDriveType driveType, std::string diskPath) {
+    queue(Command{Command::InsertDisk,
+                  fmt::format("{}={}", ClemensDiskUtilities::getDriveName(driveType), diskPath)});
+}
+
+void ClemensCommandQueue::insertBlankDisk(ClemensDriveType driveType, std::string diskPath) {
+    queue(Command{Command::InsertBlankDisk,
+                  fmt::format("{}={}", ClemensDiskUtilities::getDriveName(driveType), diskPath)});
+}
+
+bool ClemensCommandQueue::insertDisk(ClemensCommandQueueListener &listener,
+                                     const std::string_view &inputParam, bool allowBlank) {
+    auto sepPos = inputParam.find('=');
+    if (sepPos == std::string_view::npos)
+        return false;
+    auto driveName = inputParam.substr(0, sepPos);
+    auto imagePath = inputParam.substr(sepPos + 1);
+    auto driveType = ClemensDiskUtilities::getDriveType(driveName);
+    if (driveType == kClemensDrive_Invalid)
+        return false;
+
+    return allowBlank ? listener.onCommandInsertBlankDisk(driveType, std::string(imagePath))
+                      : listener.onCommandInsertDisk(driveType, std::string(imagePath));
+}
+
+void ClemensCommandQueue::ejectDisk(ClemensDriveType driveType) {
+    queue(Command{Command::EjectDisk, std::string(ClemensDiskUtilities::getDriveName(driveType))});
+}
+
+void ClemensCommandQueue::ejectDisk(ClemensCommandQueueListener &listener,
+                                    const std::string_view &inputParam) {
+    auto driveType = ClemensDiskUtilities::getDriveType(inputParam);
+    listener.onCommandEjectDisk(driveType);
+}
+
+void ClemensCommandQueue::writeProtectDisk(ClemensDriveType driveType, bool wp) {
+    queue(Command{Command::WriteProtectDisk,
+                  fmt::format("{},{}", ClemensDiskUtilities::getDriveName(driveType), wp ? 1 : 0)});
+}
+
+bool ClemensCommandQueue::writeProtectDisk(ClemensCommandQueueListener &listener,
+                                           const std::string_view &inputParam) {
+    auto sepPos = inputParam.find(',');
+    if (sepPos == std::string_view::npos)
+        return false;
+    auto driveParam = inputParam.substr(0, sepPos);
+    auto driveType = ClemensDiskUtilities::getDriveType(driveParam);
+    auto enableParam = inputParam.substr(sepPos + 1);
+
+    return listener.onCommandWriteProtectDisk(driveType, enableParam == "1");
+}
+
+void ClemensCommandQueue::debugMemoryPage(uint8_t page) {
+    queue(Command{Command::DebugMemoryPage, std::to_string(page)});
+}
+
+void ClemensCommandQueue::debugMemoryWrite(uint16_t addr, uint8_t value) {
+    queue(Command{Command::WriteMemory, fmt::format("{}={}", addr, value)});
+}
+
+void ClemensCommandQueue::writeMemory(ClemensCommandQueueListener &listener,
+                                      const std::string_view &inputParam) {
+    auto sepPos = inputParam.find('=');
+    if (sepPos == std::string_view::npos) {
+        return;
+    }
+    uint16_t addr;
+    if (std::from_chars(inputParam.data(), inputParam.data() + sepPos, addr).ec != std::errc{})
+        return;
+    auto valStr = inputParam.substr(sepPos + 1);
+    uint8_t value;
+    if (std::from_chars(valStr.data(), valStr.data() + valStr.size(), value).ec != std::errc{})
+        return;
+
+    listener.onCommandDebugMemoryWrite(addr, value);
+}
+
+void ClemensCommandQueue::debugLogLevel(int logLevel) {
+    queue(Command{Command::DebugLogLevel, fmt::format("{}", logLevel)});
+}
+
+void ClemensCommandQueue::debugProgramTrace(std::string op, std::string path) {
+    queue(Command{Command::DebugProgramTrace,
+                  fmt::format("{},{}", op, path.empty() ? "#" : path.c_str())});
+}
+
+bool ClemensCommandQueue::programTrace(ClemensCommandQueueListener &listener,
+                                       const std::string_view &inputParam) {
+    auto sepPos = inputParam.find(',');
+    auto op = inputParam.substr(0, sepPos);
+    std::string_view param;
+    if (sepPos != std::string_view::npos) {
+        param = inputParam.substr(sepPos + 1);
+        if (param == "#")
+            param = std::string_view();
+    } else {
+        param = std::string_view();
+    }
+    auto path = param;
+    return listener.onCommandDebugProgramTrace(op, path);
+}
+
+void ClemensCommandQueue::saveMachine(std::string path) {
+    queue(Command{Command::SaveMachine, std::move(path)});
+}
+
+void ClemensCommandQueue::loadMachine(std::string path) {
+    queue(Command{Command::LoadMachine, std::move(path)});
+}
+
+void ClemensCommandQueue::runScript(std::string command) {
+    queue(Command{Command::RunScript, std::move(command)});
+}
+
+void ClemensCommandQueue::breakExecution() { queue(Command{Command::Break}); }
+
+void ClemensCommandQueue::addBreakpoint(const ClemensBackendBreakpoint &breakpoint) {
+    Command cmd;
+    cmd.operand = fmt::format("{:s}:{:06X}",
+                              breakpoint.type == ClemensBackendBreakpoint::DataRead ? "r"
+                              : breakpoint.type == ClemensBackendBreakpoint::Write  ? "w"
+                              : breakpoint.type == ClemensBackendBreakpoint::IRQ    ? "i"
+                                                                                    : "",
+                              breakpoint.address);
+    cmd.type = Command::AddBreakpoint;
+    queue(std::move(cmd));
+}
+
+bool ClemensCommandQueue::addBreakpoint(ClemensCommandQueueListener &listener,
+                                        const std::string_view &inputParam) {
+    auto sepPos = inputParam.find(':');
+    assert(sepPos != std::string_view::npos);
+    auto type = inputParam.substr(0, sepPos);
+    auto address = inputParam.substr(sepPos + 1);
+    ClemensBackendBreakpoint bp;
+    if (type == "r") {
+        bp.type = ClemensBackendBreakpoint::DataRead;
+    } else if (type == "w") {
+        bp.type = ClemensBackendBreakpoint::Write;
+    } else if (type == "i") {
+        bp.type = ClemensBackendBreakpoint::IRQ;
+    } else {
+        bp.type = ClemensBackendBreakpoint::Execute;
+    }
+    bp.address = (uint32_t)std::stoul(std::string(address), nullptr, 16);
+
+    listener.onCommandAddBreakpoint(bp);
+
+    return true;
+}
+
+void ClemensCommandQueue::removeBreakpoint(unsigned index) {
+    queue(Command{Command::DelBreakpoint, std::to_string(index)});
+}
+
+bool ClemensCommandQueue::delBreakpoint(ClemensCommandQueueListener &listener,
+                                        const std::string_view &inputParam) {
+    if (inputParam.empty()) {
+        return listener.onCommandRemoveBreakpoint(-1);
+    }
+
+    unsigned index = (unsigned)std::stoul(std::string(inputParam));
+    return listener.onCommandRemoveBreakpoint(index);
+}
+
+#if defined(__GNUC__)
+#if !defined(__clang__)
+//  NOTE GCC warning seems spurious for *some* std::string_view::find() cases
+//       have added plenty of guards around the line below to no avail.
+//            commaPos = !inputValueB.empty() ? inputValueB.find(',') : std::string_view::npos;
+//  ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91397
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+#endif
+static const char *sInputKeys[] = {"",      "keyD", "keyU",   "mouseD", "mouseU",
+                                   "mouse", "padl", "nopadl", NULL};
+
+void ClemensCommandQueue::inputEvent(const ClemensInputEvent &input) {
+    CK_ASSERT_RETURN(*sInputKeys[input.type] != '\0');
+    Command cmd{Command::Input};
+    if (input.type == kClemensInputType_Paddle ||
+        input.type == kClemensInputType_PaddleDisconnected) {
+        cmd.operand = fmt::format("{}={},{},{}", sInputKeys[input.type], input.value_a,
+                                  input.value_b, input.gameport_button_mask);
+    } else {
+        cmd.operand = fmt::format("{}={},{},{}", sInputKeys[input.type], input.value_a,
+                                  input.value_b, input.adb_key_toggle_mask);
+    }
+    queue(cmd);
+}
+
+void ClemensCommandQueue::inputMachine(ClemensCommandQueueListener &listener,
+                                       const std::string_view &inputParam) {
+    auto equalsTokenPos = inputParam.find('=');
+    auto name = inputParam.substr(0, equalsTokenPos);
+    auto value = inputParam.substr(equalsTokenPos + 1);
+    for (const char **keyName = &sInputKeys[0]; *keyName != NULL; ++keyName) {
+        if (name == *keyName) {
+            ClemensInputEvent inputEvent{};
+            inputEvent.type = (ClemensInputType)((int)(keyName - &sInputKeys[0]));
+            //  oh why, oh why no straightforward C++ conversion from std::string_view
+            //  to number
+            auto commaPos = value.find(',');
+            auto inputValueA = value.substr(0, commaPos);
+            inputEvent.value_a = (int16_t)std::stol(std::string(inputValueA));
+            if (commaPos != std::string_view::npos) {
+                std::string_view inputModifiers;
+                auto inputValueB = value.substr(commaPos + 1);
+                commaPos = !inputValueB.empty() ? inputValueB.find(',') : std::string_view::npos;
+                if (commaPos != std::string_view::npos) {
+                    inputModifiers = inputValueB.substr(commaPos + 1);
+                    inputValueB = inputValueB.substr(0, commaPos);
+                }
+                inputEvent.value_b = (int16_t)std::stol(std::string(inputValueB));
+                if (inputEvent.type == kClemensInputType_Paddle ||
+                    inputEvent.type == kClemensInputType_PaddleDisconnected) {
+                    inputEvent.gameport_button_mask = std::stoul(std::string(inputModifiers));
+                } else {
+                    inputEvent.adb_key_toggle_mask = std::stoul(std::string(inputModifiers));
+                }
+            }
+            listener.onCommandInputEvent(inputEvent);
+        }
+    }
+}
+#if defined(__GNUC__)
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#endif
+
+void ClemensCommandQueue::queue(const Command &cmd) { queue_.push(cmd); }

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -37,6 +37,9 @@ class ClemensCommandQueue {
     using ResultBuffer = std::vector<ClemensBackendResult>;
     using DispatchResult = std::pair<ResultBuffer, bool>;
 
+    void queue(ClemensCommandQueue &other);
+    bool isEmpty() const { return queue_.isEmpty(); }
+
     //  execute all commands
     DispatchResult dispatchAll(ClemensCommandQueueListener &listener);
 

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -1,0 +1,106 @@
+#ifndef CLEM_HOST_COMMAND_QUEUE_HPP
+#define CLEM_HOST_COMMAND_QUEUE_HPP
+
+#include "clem_host_shared.hpp"
+
+#include "cinek/circular_buffer.hpp"
+
+#include <optional>
+#include <string>
+
+class ClemensCommandQueueListener {
+  public:
+    virtual ~ClemensCommandQueueListener() {}
+
+    virtual void onCommandReset() = 0;
+    virtual void onCommandRun() = 0;
+    virtual void onCommandBreakExecution() = 0;
+    virtual void onCommandStep(unsigned count) = 0;
+    virtual void onCommandAddBreakpoint(const ClemensBackendBreakpoint &breakpoint) = 0;
+    virtual bool onCommandRemoveBreakpoint(int index) = 0;
+    virtual void onCommandInputEvent(const ClemensInputEvent &inputEvent) = 0;
+    virtual bool onCommandInsertDisk(ClemensDriveType driveType, std::string diskPath) = 0;
+    virtual bool onCommandInsertBlankDisk(ClemensDriveType driveType, std::string diskPath) = 0;
+    virtual void onCommandEjectDisk(ClemensDriveType driveType) = 0;
+    virtual bool onCommandWriteProtectDisk(ClemensDriveType driveType, bool wp) = 0;
+    virtual void onCommandDebugMemoryPage(uint8_t pageIndex) = 0;
+    virtual void onCommandDebugMemoryWrite(uint16_t addr, uint8_t value) = 0;
+    virtual void onCommandDebugLogLevel(int logLevel) = 0;
+    virtual bool onCommandDebugProgramTrace(std::string_view op, std::string_view path) = 0;
+    virtual bool onCommandSaveMachine(std::string path) = 0;
+    virtual bool onCommandLoadMachine(std::string path) = 0;
+    virtual bool onCommandRunScript(std::string command) = 0;
+};
+
+class ClemensCommandQueue {
+  public:
+    using ResultBuffer = std::vector<ClemensBackendResult>;
+    using DispatchResult = std::pair<ResultBuffer, bool>;
+
+    //  execute all commands
+    DispatchResult dispatchAll(ClemensCommandQueueListener &listener);
+
+    //  Queues a command to the backend.   Most commands are processed on the next
+    //  execution frame.  Certain commands may hold the queue (i.e. like wait())
+    //  Priority commands like Cancel or Terminate are pushed to the front,
+    //  overriding commands like Wait.
+    void terminate();
+    //  Issues a soft reset to the machine.   This is roughly equivalent to pressing
+    //  the power button.
+    void reset();
+    //  Clears step mode and enter run mode
+    void run();
+    //  Steps the emulator
+    void step(unsigned count);
+    //  Send host input to the emulator
+    void inputEvent(const ClemensInputEvent &inputEvent);
+    //  Insert disk
+    void insertDisk(ClemensDriveType driveType, std::string diskPath);
+    //  Insert blank disk
+    void insertBlankDisk(ClemensDriveType driveType, std::string diskPath);
+    //  Eject disk
+    void ejectDisk(ClemensDriveType driveType);
+    //  Break
+    void breakExecution();
+    //  Add a breakpoint
+    void addBreakpoint(const ClemensBackendBreakpoint &breakpoint);
+    //  Remove a breakpoint
+    void removeBreakpoint(unsigned index);
+    //  Sets the write protect status on a disk in a drive
+    void writeProtectDisk(ClemensDriveType driveType, bool wp);
+    //  Sets the active debug memory page that can be read from or written to by
+    //  the front end (this value is communicated on publish)
+    void debugMemoryPage(uint8_t pageIndex);
+    //  Write a single byte to machine memory at the current debugMemoryPage
+    void debugMemoryWrite(uint16_t addr, uint8_t value);
+    //  Set logging level
+    void debugLogLevel(int logLevel);
+    //  Enable a program trace
+    void debugProgramTrace(std::string op, std::string path);
+    //  Save and load the machine
+    void saveMachine(std::string path);
+    void loadMachine(std::string path);
+
+    void runScript(std::string command);
+
+  private:
+    bool insertDisk(ClemensCommandQueueListener &listener, const std::string_view &inputParam,
+                    bool allowBlank);
+    void ejectDisk(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    bool writeProtectDisk(ClemensCommandQueueListener &listener,
+                          const std::string_view &inputParam);
+    void writeMemory(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    void inputMachine(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    bool addBreakpoint(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    bool delBreakpoint(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    bool programTrace(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
+    bool runScriptCommand(ClemensCommandQueueListener &listener, const std::string_view &command);
+
+    using Command = ClemensBackendCommand;
+    cinek::CircularBuffer<Command, 16> queue_;
+
+    void queue(const Command &cmd);
+    void queueToFront(const Command &cmd);
+};
+
+#endif

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -582,8 +582,6 @@ static std::string getCommandTypeName(ClemensBackendCommand::Type type) {
         return "ResetMachine";
     case ClemensBackendCommand::RunMachine:
         return "RunMachine";
-    case ClemensBackendCommand::SetHostUpdateFrequency:
-        return "SetHostUpdateFrequency";
     case ClemensBackendCommand::Terminate:
         return "Terminate";
     default:
@@ -605,7 +603,7 @@ ClemensFrontend::ClemensFrontend(ClemensConfiguration config,
                                  const cinek::ByteBuffer &systemFontLoBuffer,
                                  const cinek::ByteBuffer &systemFontHiBuffer)
     : config_(config), displayProvider_(systemFontLoBuffer, systemFontHiBuffer),
-      display_(displayProvider_), audio_(), frameSeqNo_(kFrameSeqNoInvalid),
+      display_(displayProvider_), audio_(), uiFrameTimeDelta_(0.0), frameSeqNo_(kFrameSeqNoInvalid),
       frameLastSeqNo_(kFrameSeqNoInvalid),
       frameWriteMemory_(kFrameMemorySize, malloc(kFrameMemorySize)),
       frameReadMemory_(kFrameMemorySize, malloc(kFrameMemorySize)),
@@ -654,7 +652,7 @@ ClemensFrontend::ClemensFrontend(ClemensConfiguration config,
 }
 
 ClemensFrontend::~ClemensFrontend() {
-    backend_ = nullptr;
+    stopBackend();
     audio_.stop();
     clem_joystick_close_devices();
     delete[] thisFrameAudioBuffer_.getHead();
@@ -679,7 +677,7 @@ void ClemensFrontend::input(ClemensInputEvent input) {
             input.value_b =
                 std::clamp(int16_t(input.value_b * kMouseScalar), (int16_t)(-63), (int16_t)(63));
         }
-        backend_->inputEvent(input);
+        backendQueue_.inputEvent(input);
     }
 }
 
@@ -688,29 +686,73 @@ void ClemensFrontend::lostFocus() {
     emulatorHasKeyboardFocus_ = false;
 }
 
-std::unique_ptr<ClemensBackend> ClemensFrontend::createBackend() {
-    constexpr unsigned refreshFrequency_ = 60;
+void ClemensFrontend::createBackend() {
     auto romPath = std::filesystem::path(config_.dataDirectory) / config_.romFilename;
-    auto backend = std::make_unique<ClemensBackend>(
-        romPath.string(), backendConfig_,
-        std::bind(&ClemensFrontend::backendStateDelegate, this, std::placeholders::_1));
-    backend->setRefreshFrequency(refreshFrequency_);
-    backend->reset();
-    backend->run();
-    fmt::print("Creating new backend emulator refreshing @ {} Hz.\n", refreshFrequency_);
-    return backend;
+    auto backend = std::make_unique<ClemensBackend>(romPath.string(), backendConfig_);
+
+    uiFrameTimeDelta_ = 0.0;
+    backendQueue_.reset();
+    backendQueue_.run();
+
+    fmt::print("Creating new backend emulator.\n");
+
+    backendThread_ = std::thread(&ClemensFrontend::runBackend, this, std::move(backend));
 }
 
-void ClemensFrontend::backendStateDelegate(const ClemensBackendState &state) {
+void ClemensFrontend::runBackend(std::unique_ptr<ClemensBackend> backend) {
+    ClemensBackendState state;
+
+    ClemensCommandQueue::DispatchResult results{};
+    double frameTimeLag = 0.0f;
+
+    // results = backend->main(commands, state)).second
+    while (!results.second) {
+        //  TODO: need to account for lag!!!
+
+        results = backend->main(state, results.first,
+                                [this](ClemensCommandQueue &commands,
+                                       const ClemensCommandQueue::ResultBuffer &lastFrameResults,
+                                       const ClemensBackendState &state) {
+                                    std::unique_lock<std::mutex> lk(frameMutex_);
+                                    readyForFrame_.wait(lk, [this]() {
+                                        return (uiFrameTimeDelta_ > 0.0) ||
+                                               !stagedBackendQueue_.isEmpty();
+                                    });
+                                    CK_TODO("Need to account for lag!!!")
+                                    frameSeqNo_++;
+                                    backendStateDelegate(state, lastFrameResults);
+                                    commands.queue(stagedBackendQueue_);
+                                    // frameTimeLag += uiFrameTimeDelta_;
+                                    uiFrameTimeDelta_ = 0.0;
+                                });
+    }
+}
+
+void ClemensFrontend::stopBackend() {
+    if (backendThread_.joinable()) {
+        backendQueue_.terminate();
+        {
+            std::lock_guard<std::mutex> lk(frameMutex_);
+            stagedBackendQueue_.queue(backendQueue_);
+        }
+        readyForFrame_.notify_one();
+        backendThread_.join();
+    }
+    backendThread_ = std::thread();
+}
+
+bool ClemensFrontend::isBackendRunning() const { return backendThread_.joinable(); }
+
+void ClemensFrontend::backendStateDelegate(const ClemensBackendState &state,
+                                           const ClemensCommandQueue::ResultBuffer &results) {
+
+    //  prevent reallocation of the results vector
+    std::copy(results.begin(), results.end(), std::back_inserter(lastCommandState_.results));
+
     copyState(state);
-    framePublished_.notify_all();
 }
 
 void ClemensFrontend::copyState(const ClemensBackendState &state) {
-    std::lock_guard<std::mutex> frameLock(frameMutex_);
-
-    frameSeqNo_ = state.seqno;
-
     frameWriteMemory_.reset();
 
     frameWriteState_.mark = 0xdeadbeef;
@@ -834,7 +876,7 @@ void ClemensFrontend::copyState(const ClemensBackendState &state) {
     memcpy(frameWriteState_.bram, state.mmio->dev_rtc.bram, CLEM_RTC_BRAM_SIZE);
 
     frameWriteState_.memoryViewBank = state.debugMemoryPage;
-    if (!state.isRunning) {
+    if (!state.isRunning && state.mmioWasInitialized) {
         frameWriteState_.memoryView = (uint8_t *)frameWriteMemory_.allocate(CLEM_IIGS_BANK_SIZE);
         //  read every byte from the memory controller - which can be 'slow' enough
         //  to effect framerate on some systems.   so we only update memory state
@@ -888,20 +930,17 @@ void ClemensFrontend::copyState(const ClemensBackendState &state) {
         }
     }
 
-    //  prevent reallocation of the results vector
-    std::copy(state.results.begin(), state.results.end(),
-              std::back_inserter(lastCommandState_.results));
     if (!lastCommandState_.message.has_value() && state.message.has_value()) {
         lastCommandState_.message = cmdMessageFromBackend(*state.message, state.machine);
     }
-    if (!lastCommandState_.terminated.has_value()) {
-        lastCommandState_.terminated = state.isTerminated;
+
+    if (state.audio.data) {
+        auto audioBufferSize = int32_t(state.audio.frame_count * state.audio.frame_stride);
+        auto audioBufferRange = lastCommandState_.audioBuffer.forwardSize(audioBufferSize);
+        memcpy(audioBufferRange.first, state.audio.data, cinek::length(audioBufferRange));
+    } else {
+        lastCommandState_.audioBuffer.reset();
     }
-
-    auto audioBufferSize = int32_t(state.audio.frame_count * state.audio.frame_stride);
-    auto audioBufferRange = lastCommandState_.audioBuffer.forwardSize(audioBufferSize);
-    memcpy(audioBufferRange.first, state.audio.data, cinek::length(audioBufferRange));
-
     frameWriteState_.logLevel = state.logLevel;
     for (auto *logItem = state.logBufferStart; logItem != state.logBufferEnd; ++logItem) {
         LogOutputNode *logMemory = reinterpret_cast<LogOutputNode *>(frameMemory_.allocate(
@@ -951,7 +990,7 @@ void ClemensFrontend::pollJoystickDevices() {
     constexpr int32_t kHostAxisMagnitude = CLEM_HOST_JOYSTICK_AXIS_DELTA * 2;
     unsigned index;
 
-    if (!backend_) {
+    if (!isBackendRunning()) {
         return;
     }
 
@@ -1000,10 +1039,10 @@ void ClemensFrontend::pollJoystickDevices() {
     joystickSlotCount_ = std::max(joystickSlotCount_, joystickCount);
     if (joystickCount < 1)
         return;
-    backend_->inputEvent(inputs[0]);
+    backendQueue_.inputEvent(inputs[0]);
     if (joystickCount < 2)
         return;
-    backend_->inputEvent(inputs[1]);
+    backendQueue_.inputEvent(inputs[1]);
 }
 
 auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInterop &interop)
@@ -1018,113 +1057,109 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
 
     bool isNewFrame = false;
     bool isBackendTerminated = false;
-
-    std::unique_lock<std::mutex> frameLock(frameMutex_);
-    framePublished_.wait_for(frameLock, std::chrono::milliseconds::zero(),
-                             [this]() { return frameSeqNo_ != frameLastSeqNo_; });
-
-    isNewFrame = frameLastSeqNo_ != frameSeqNo_;
-    if (isNewFrame) {
-        lastFrameCPURegs_ = frameReadState_.cpu.regs;
-        lastFrameCPUPins_ = frameReadState_.cpu.pins;
-        lastFrameIRQs_ = frameReadState_.irqs;
-        lastFrameNMIs_ = frameReadState_.nmis;
-        lastFrameIWM_ = frameReadState_.iwm;
-        if (frameReadState_.ioPage) {
-            memcpy(lastFrameIORegs_, frameReadState_.ioPage, 256);
-        }
-        std::swap(frameWriteMemory_, frameReadMemory_);
-        std::swap(frameWriteState_, frameReadState_);
-        //  display log lines
-        LogOutputNode *logNode = lastCommandState_.logNode;
-        while (logNode) {
-            if (consoleLines_.isFull()) {
-                consoleLines_.pop();
+    {
+        std::lock_guard<std::mutex> frameLock(frameMutex_);
+        isNewFrame = frameLastSeqNo_ != frameSeqNo_;
+        if (isNewFrame) {
+            lastFrameCPURegs_ = frameReadState_.cpu.regs;
+            lastFrameCPUPins_ = frameReadState_.cpu.pins;
+            lastFrameIRQs_ = frameReadState_.irqs;
+            lastFrameNMIs_ = frameReadState_.nmis;
+            lastFrameIWM_ = frameReadState_.iwm;
+            if (frameReadState_.ioPage) {
+                memcpy(lastFrameIORegs_, frameReadState_.ioPage, 256);
             }
-            TerminalLine logLine;
-            logLine.text.assign((char *)logNode + sizeof(LogOutputNode), logNode->sz);
-            switch (logNode->logLevel) {
-            case CLEM_DEBUG_LOG_DEBUG:
-                logLine.type = TerminalLine::Debug;
-                break;
-            case CLEM_DEBUG_LOG_INFO:
-                logLine.type = TerminalLine::Info;
-                break;
-            case CLEM_DEBUG_LOG_WARN:
-                logLine.type = TerminalLine::Warn;
-                break;
-            case CLEM_DEBUG_LOG_FATAL:
-            case CLEM_DEBUG_LOG_UNIMPL:
-                logLine.type = TerminalLine::Error;
-                break;
-            default:
-                logLine.type = TerminalLine::Info;
-                break;
+            std::swap(frameWriteMemory_, frameReadMemory_);
+            std::swap(frameWriteState_, frameReadState_);
+            //  display log lines
+            LogOutputNode *logNode = lastCommandState_.logNode;
+            while (logNode) {
+                if (consoleLines_.isFull()) {
+                    consoleLines_.pop();
+                }
+                TerminalLine logLine;
+                logLine.text.assign((char *)logNode + sizeof(LogOutputNode), logNode->sz);
+                switch (logNode->logLevel) {
+                case CLEM_DEBUG_LOG_DEBUG:
+                    logLine.type = TerminalLine::Debug;
+                    break;
+                case CLEM_DEBUG_LOG_INFO:
+                    logLine.type = TerminalLine::Info;
+                    break;
+                case CLEM_DEBUG_LOG_WARN:
+                    logLine.type = TerminalLine::Warn;
+                    break;
+                case CLEM_DEBUG_LOG_FATAL:
+                case CLEM_DEBUG_LOG_UNIMPL:
+                    logLine.type = TerminalLine::Error;
+                    break;
+                default:
+                    logLine.type = TerminalLine::Info;
+                    break;
+                }
+                consoleLines_.push(std::move(logLine));
+                logNode = logNode->next;
+                consoleChanged_ = true;
             }
-            consoleLines_.push(std::move(logLine));
-            logNode = logNode->next;
-            consoleChanged_ = true;
-        }
-        lastCommandState_.logNode = lastCommandState_.logNodeTail = nullptr;
-        //  display last few log instructions
-        LogInstructionNode *logInstructionNode = lastCommandState_.logInstructionNode;
+            lastCommandState_.logNode = lastCommandState_.logNodeTail = nullptr;
+            //  display last few log instructions
+            LogInstructionNode *logInstructionNode = lastCommandState_.logInstructionNode;
 
-        while (logInstructionNode) {
-            ClemensBackendExecutedInstruction *execInstruction = logInstructionNode->begin;
-            ClemensTraceExecutedInstruction instruction;
-            while (execInstruction != logInstructionNode->end) {
-                instruction.fromInstruction(execInstruction->data, execInstruction->operand);
-                CLEM_TERM_COUT.format(TerminalLine::Opcode, "({}) {:02X}/{:04X} {} {}",
-                                      instruction.cycles_spent, instruction.pc >> 16,
-                                      instruction.pc & 0xffff, instruction.opcode,
-                                      instruction.operand);
-                ++execInstruction;
+            while (logInstructionNode) {
+                ClemensBackendExecutedInstruction *execInstruction = logInstructionNode->begin;
+                ClemensTraceExecutedInstruction instruction;
+                while (execInstruction != logInstructionNode->end) {
+                    instruction.fromInstruction(execInstruction->data, execInstruction->operand);
+                    CLEM_TERM_COUT.format(TerminalLine::Opcode, "({}) {:02X}/{:04X} {} {}",
+                                          instruction.cycles_spent, instruction.pc >> 16,
+                                          instruction.pc & 0xffff, instruction.opcode,
+                                          instruction.operand);
+                    ++execInstruction;
+                }
+                logInstructionNode = logInstructionNode->next;
             }
-            logInstructionNode = logInstructionNode->next;
-        }
-        lastCommandState_.logInstructionNode = lastCommandState_.logInstructionNodeTail = nullptr;
+            lastCommandState_.logInstructionNode = lastCommandState_.logInstructionNodeTail =
+                nullptr;
 
-        breakpoints_.clear();
-        for (unsigned bpIndex = 0; bpIndex < frameReadState_.breakpointCount; ++bpIndex) {
-            breakpoints_.emplace_back(frameReadState_.breakpoints[bpIndex]);
-            backendConfig_.breakpoints.push_back(breakpoints_.back());
-        }
-        backendConfig_.breakpoints = breakpoints_;
-
-        if (!lastCommandState_.results.empty()) {
-            for (auto &result : lastCommandState_.results) {
-                processBackendResult(result);
+            breakpoints_.clear();
+            for (unsigned bpIndex = 0; bpIndex < frameReadState_.breakpointCount; ++bpIndex) {
+                breakpoints_.emplace_back(frameReadState_.breakpoints[bpIndex]);
+                backendConfig_.breakpoints.push_back(breakpoints_.back());
             }
-            lastCommandState_.results.clear();
-        }
-        if (lastCommandState_.hitBreakpoint.has_value()) {
-            unsigned bpIndex = *lastCommandState_.hitBreakpoint;
-            CLEM_TERM_COUT.format(TerminalLine::Info, "Breakpoint {} hit {:02X}/{:04X}.", bpIndex,
-                                  (breakpoints_[bpIndex].address >> 16) & 0xff,
-                                  breakpoints_[bpIndex].address & 0xffff);
-            emulatorHasMouseFocus_ = false;
-            lastCommandState_.hitBreakpoint = std::nullopt;
-        }
-        if (lastCommandState_.message.has_value()) {
-            cmdMessageLocal(*lastCommandState_.message);
-            lastCommandState_.message = std::nullopt;
-        }
-        if (lastCommandState_.terminated.has_value()) {
-            isBackendTerminated = *lastCommandState_.terminated;
-            lastCommandState_.terminated = std::nullopt;
-        }
+            backendConfig_.breakpoints = breakpoints_;
 
-        for (size_t driveIndex = 0; driveIndex < frameReadState_.diskDrives.size(); ++driveIndex) {
-            backendConfig_.diskDriveStates[driveIndex] = frameReadState_.diskDrives[driveIndex];
+            if (!lastCommandState_.results.empty()) {
+                for (auto &result : lastCommandState_.results) {
+                    processBackendResult(result);
+                }
+                lastCommandState_.results.clear();
+            }
+            if (lastCommandState_.hitBreakpoint.has_value()) {
+                unsigned bpIndex = *lastCommandState_.hitBreakpoint;
+                CLEM_TERM_COUT.format(TerminalLine::Info, "Breakpoint {} hit {:02X}/{:04X}.",
+                                      bpIndex, (breakpoints_[bpIndex].address >> 16) & 0xff,
+                                      breakpoints_[bpIndex].address & 0xffff);
+                emulatorHasMouseFocus_ = false;
+                lastCommandState_.hitBreakpoint = std::nullopt;
+            }
+            if (lastCommandState_.message.has_value()) {
+                cmdMessageLocal(*lastCommandState_.message);
+                lastCommandState_.message = std::nullopt;
+            }
+
+            for (size_t driveIndex = 0; driveIndex < frameReadState_.diskDrives.size();
+                 ++driveIndex) {
+                backendConfig_.diskDriveStates[driveIndex] = frameReadState_.diskDrives[driveIndex];
+            }
+
+            frameMemory_.reset();
+
+            std::swap(lastCommandState_.audioBuffer, thisFrameAudioBuffer_);
         }
-
-        frameMemory_.reset();
-
-        std::swap(lastCommandState_.audioBuffer, thisFrameAudioBuffer_);
-
-        frameLastSeqNo_ = frameSeqNo_;
+        uiFrameTimeDelta_ = deltaTime;
+        stagedBackendQueue_.queue(backendQueue_);
     }
-    frameLock.unlock();
+    readyForFrame_.notify_one();
 
     //  render video
     //  video is rendered to a texture and the UVs of the display on the virtual
@@ -1168,7 +1203,6 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
 
     if (isBackendTerminated) {
         fflush(stdout);
-        backend_ = nullptr;
     }
 
     switch (guiMode_) {
@@ -1196,26 +1230,26 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
         break;
     case GUIMode::SaveSnapshot:
         if (!saveSnapshotMode_.isStarted()) {
-            saveSnapshotMode_.start(backend_.get(), frameReadState_.isRunning);
+            saveSnapshotMode_.start(backendQueue_, frameReadState_.isRunning);
         }
-        if (saveSnapshotMode_.frame(width, height, backend_.get())) {
-            saveSnapshotMode_.stop(backend_.get());
+        if (saveSnapshotMode_.frame(width, height, backendQueue_)) {
+            saveSnapshotMode_.stop(backendQueue_);
             guiMode_ = GUIMode::Emulator;
         }
         break;
     case GUIMode::LoadSnapshot:
         if (!loadSnapshotMode_.isStarted()) {
-            loadSnapshotMode_.start(backend_.get(), backendConfig_.snapshotRootPath,
+            loadSnapshotMode_.start(backendQueue_, backendConfig_.snapshotRootPath,
                                     frameReadState_.isRunning);
         }
-        if (loadSnapshotMode_.frame(width, height, backend_.get())) {
-            loadSnapshotMode_.stop(backend_.get());
+        if (loadSnapshotMode_.frame(width, height, backendQueue_)) {
+            loadSnapshotMode_.stop(backendQueue_);
             guiMode_ = GUIMode::Emulator;
         }
         break;
     case GUIMode::RebootEmulator:
-        if (!backend_) {
-            backend_ = createBackend();
+        if (!isBackendRunning()) {
+            createBackend();
             setGUIMode(GUIMode::StartingEmulator);
         }
         break;
@@ -1239,9 +1273,6 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
         }
     }
 
-    if (backend_) {
-        backend_->publish();
-    }
     if (ImGui::IsKeyDown(ImGuiKey_LeftAlt)) {
         if (ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) {
             if (ImGui::IsKeyDown(ImGuiKey_RightAlt) || ImGui::IsKeyDown(ImGuiKey_LeftSuper)) {
@@ -1380,7 +1411,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     ImGui::Spacing();
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
                         ImVec2(style.ItemSpacing.x * 1.5f, style.ItemSpacing.y));
-    if (backend_) {
+    if (isBackendRunning()) {
         ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 255, 0, 192));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(128, 255, 128, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(255, 255, 255, 255));
@@ -1393,7 +1424,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     if (ClemensHostImGui::IconButton(
             "Power", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kPowerButton),
             kIconSize)) {
-        if (backend_) {
+        if (isBackendRunning()) {
             cmdPower("off");
         } else {
             cmdPower("on");
@@ -1404,7 +1435,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     }
     ImGui::PopStyleColor(3);
 
-    if (backend_ && !delayRebootTimer_.has_value()) {
+    if (isBackendRunning() && !delayRebootTimer_.has_value()) {
         ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 255, 0, 192));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(128, 255, 128, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(255, 255, 255, 255));
@@ -1417,7 +1448,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     if (ClemensHostImGui::IconButton(
             "Settings", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kSettings),
             kIconSize)) {
-        if (backend_ && !isEmulatorStarting()) {
+        if (isBackendRunning() && !isEmulatorStarting()) {
             if (!delayRebootTimer_.has_value()) {
                 rebootInternal();
             }
@@ -1433,7 +1464,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     if (ClemensHostImGui::IconButton(
             "Load Snapshot", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kLoad),
             kIconSize)) {
-        if (backend_ && !isEmulatorStarting()) {
+        if (isBackendRunning() && !isEmulatorStarting()) {
             setGUIMode(GUIMode::LoadSnapshot);
         }
     }
@@ -1444,7 +1475,7 @@ void ClemensFrontend::doUserMenuDisplay(float /* width */) {
     if (ClemensHostImGui::IconButton(
             "Save Snapshot", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kSave),
             kIconSize)) {
-        if (backend_ && !isEmulatorStarting()) {
+        if (isBackendRunning() && !isEmulatorStarting()) {
             setGUIMode(GUIMode::SaveSnapshot);
         }
     }
@@ -1597,7 +1628,7 @@ void ClemensFrontend::doInfoStatusLayout(ImVec2 anchor, ImVec2 dimensions, float
 
     ImGui::SameLine();
     ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-    if (backend_) {
+    if (isBackendRunning()) {
         ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 255, 0, 192));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(128, 255, 128, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(255, 255, 255, 255));
@@ -1620,7 +1651,7 @@ void ClemensFrontend::doInfoStatusLayout(ImVec2 anchor, ImVec2 dimensions, float
                     "Continue",
                     ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kStopMachine),
                     kIconSize)) {
-                backend_->breakExecution();
+                backendQueue_.breakExecution();
             }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
                 ImGui::SetTooltip("Stop execution");
@@ -1630,7 +1661,7 @@ void ClemensFrontend::doInfoStatusLayout(ImVec2 anchor, ImVec2 dimensions, float
                     "Continue",
                     ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kRunMachine),
                     kIconSize)) {
-                backend_->run();
+                backendQueue_.run();
             }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
                 ImGui::SetTooltip("Continue execution");
@@ -1859,7 +1890,7 @@ void ClemensFrontend::doMachineDiskStatus(ClemensDriveType driveType, float widt
         if (ImGui::Button("WP")) {
             if (isDiskInDrive) {
                 wp = !wp;
-                backend_->writeProtectDisk(driveType, wp);
+                backendQueue_.writeProtectDisk(driveType, wp);
             }
         }
         ImGui::PopStyleColor(3);
@@ -1933,7 +1964,7 @@ void ClemensFrontend::doMachineDiskSelection(ClemensDriveType driveType, float w
             diskLibrary_.update();
         }
         if (!drive.imagePath.empty() && !drive.isEjecting && ImGui::Selectable("<eject>")) {
-            backend_->ejectDisk(driveType);
+            backendQueue_.ejectDisk(driveType);
         }
         if (drive.imagePath.empty()) {
             if (ImGui::Selectable("<insert blank disk>")) {
@@ -1954,7 +1985,7 @@ void ClemensFrontend::doMachineDiskSelection(ClemensDriveType driveType, float w
                 }
             });
             if (!selectedPath.empty()) {
-                backend_->insertDisk(driveType, selectedPath.string());
+                backendQueue_.insertDisk(driveType, selectedPath.string());
             }
             ImGui::Separator();
         }
@@ -2156,7 +2187,7 @@ void ClemensFrontend::doMachineDebugMemoryDisplay() {
     uint8_t bank = frameReadState_.memoryViewBank;
     if (ImGui::InputScalar("Bank", ImGuiDataType_U8, &bank, NULL, NULL, "%02X",
                            ImGuiInputTextFlags_CharsHexadecimal)) {
-        backend_->debugMemoryPage((uint8_t)(bank & 0xff));
+        backendQueue_.debugMemoryPage((uint8_t)(bank & 0xff));
     }
     debugMemoryEditor_.OptAddrDigitsCount = 4;
     debugMemoryEditor_.Cols = 8;
@@ -2164,7 +2195,6 @@ void ClemensFrontend::doMachineDebugMemoryDisplay() {
 }
 
 void ClemensFrontend::doMachineDebugDOCDisplay() {
-
     auto &doc = frameReadState_.doc;
 
     ImGui::BeginTable("MMIO_Ensoniq_Global", 3);
@@ -2247,7 +2277,7 @@ ImU8 ClemensFrontend::imguiMemoryEditorRead(const ImU8 *mem_ptr, size_t off) {
 
 void ClemensFrontend::imguiMemoryEditorWrite(ImU8 *mem_ptr, size_t off, ImU8 value) {
     auto *self = reinterpret_cast<ClemensFrontend *>(mem_ptr);
-    self->backend_->debugMemoryWrite((uint16_t)(off & 0xffff), value);
+    self->backendQueue_.debugMemoryWrite((uint16_t)(off & 0xffff), value);
 }
 
 void ClemensFrontend::doMachineDebugIORegister(uint8_t *ioregsold, uint8_t *ioregs, uint8_t reg) {
@@ -3268,7 +3298,7 @@ void ClemensFrontend::doNewBlankDisk(int /*width */, int /*height*/) {
     }
     auto diskPath = diskDirectory / importDiskSetName_;
     diskPath.replace_extension("woz");
-    backend_->insertBlankDisk(importDriveType_, diskPath.string());
+    backendQueue_.insertBlankDisk(importDriveType_, diskPath.string());
     setGUIMode(GUIMode::Emulator);
 }
 
@@ -3500,7 +3530,7 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
                 CLEM_TERM_COUT.format(TerminalLine::Error, "Breakpoint {} doesn't exist", index);
                 return;
             }
-            backend_->removeBreakpoint(index);
+            backendQueue_.removeBreakpoint(index);
         }
         return;
     }
@@ -3547,7 +3577,7 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
     } else if (operand == "irq") {
         breakpoint.type = ClemensBackendBreakpoint::IRQ;
         breakpoint.address = 0x0;
-        backend_->addBreakpoint(breakpoint);
+        backendQueue_.addBreakpoint(breakpoint);
         return;
     } else {
         breakpoint.type = ClemensBackendBreakpoint::Execute;
@@ -3571,7 +3601,7 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
         return;
     }
     if (operand.empty()) {
-        backend_->breakExecution();
+        backendQueue_.breakExecution();
     } else {
         address[6] = '\0';
         char *addressEnd = NULL;
@@ -3581,11 +3611,11 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
                                   operand);
             return;
         }
-        backend_->addBreakpoint(breakpoint);
+        backendQueue_.addBreakpoint(breakpoint);
     }
 }
 
-void ClemensFrontend::cmdRun(std::string_view /*operand*/) { backend_->run(); }
+void ClemensFrontend::cmdRun(std::string_view /*operand*/) { backendQueue_.run(); }
 
 void ClemensFrontend::cmdStep(std::string_view operand) {
     unsigned count = 1;
@@ -3597,14 +3627,14 @@ void ClemensFrontend::cmdStep(std::string_view operand) {
             return;
         }
     }
-    backend_->step(count);
+    backendQueue_.step(count);
 }
 
 void ClemensFrontend::rebootInternal() {
     setGUIMode(GUIMode::RebootEmulator);
     delayRebootTimer_ = 0.0f;
-    if (backend_) {
-        backend_->terminate();
+    if (isBackendRunning()) {
+        stopBackend();
         CLEM_TERM_COUT.print(TerminalLine::Info, "Rebooting machine...");
     } else {
         CLEM_TERM_COUT.print(TerminalLine::Info, "Powering machine...");
@@ -3615,8 +3645,8 @@ void ClemensFrontend::cmdReboot(std::string_view /*operand*/) { rebootInternal()
 
 void ClemensFrontend::cmdPower(std::string_view operand) {
     if (operand == "off") {
-        if (backend_) {
-            backend_->terminate();
+        if (isBackendRunning()) {
+            stopBackend();
             setGUIMode(GUIMode::NoEmulator);
             audio_.stop();
             CLEM_TERM_COUT.print(TerminalLine::Info, "Shutting down machine...");
@@ -3624,14 +3654,14 @@ void ClemensFrontend::cmdPower(std::string_view operand) {
             CLEM_TERM_COUT.print(TerminalLine::Error, "Not powered on.");
         }
     } else if (operand == "on") {
-        if (!backend_) {
+        if (!isBackendRunning()) {
             rebootInternal();
             audio_.start();
         } else {
             CLEM_TERM_COUT.print(TerminalLine::Error, "Already on.");
         }
     } else if (operand.empty()) {
-        if (backend_) {
+        if (isBackendRunning()) {
             CLEM_TERM_COUT.print(TerminalLine::Error, "Powered on.");
         } else {
             CLEM_TERM_COUT.print(TerminalLine::Error, "Powered off.");
@@ -3639,7 +3669,7 @@ void ClemensFrontend::cmdPower(std::string_view operand) {
     }
 }
 
-void ClemensFrontend::cmdReset(std::string_view /*operand*/) { backend_->reset(); }
+void ClemensFrontend::cmdReset(std::string_view /*operand*/) { backendQueue_.reset(); }
 
 void ClemensFrontend::cmdDisk(std::string_view operand) {
     // disk
@@ -3680,18 +3710,18 @@ void ClemensFrontend::cmdDisk(std::string_view operand) {
     std::string_view diskOpValue;
     if (sepPos == std::string_view::npos) {
         if (diskOpType == "eject") {
-            backend_->ejectDisk(driveType);
+            backendQueue_.ejectDisk(driveType);
         } else {
             validOp = false;
         }
     } else {
         diskOpValue = trimToken(diskOpExpr, sepPos + 1);
         if (diskOpType == "file") {
-            backend_->insertDisk(driveType, std::string(diskOpValue));
+            backendQueue_.insertDisk(driveType, std::string(diskOpValue));
         } else if (diskOpType == "wprot") {
             bool wprot;
             if (parseBool(diskOpValue, wprot)) {
-                backend_->writeProtectDisk(driveType, wprot);
+                backendQueue_.writeProtectDisk(driveType, wprot);
             } else {
                 validValue = false;
             }
@@ -3725,7 +3755,7 @@ void ClemensFrontend::cmdLog(std::string_view operand) {
                               operand);
         return;
     }
-    backend_->debugLogLevel(int(levelName - logLevelNames.begin()));
+    backendQueue_.debugLogLevel(int(levelName - logLevelNames.begin()));
 }
 
 static std::tuple<std::array<std::string_view, 8>, std::string_view, size_t>
@@ -3788,7 +3818,8 @@ void ClemensFrontend::cmdDump(std::string_view operand) {
         message += ",";
     }
     message.pop_back();
-    backend_->debugMessage(std::move(message));
+    CK_TODO(DebugMessage : Send Message to thread so it can fill in the data)
+    // backendQueue_.debugMessage(std::move(message));
 }
 
 void ClemensFrontend::cmdTrace(std::string_view operand) {
@@ -3847,7 +3878,7 @@ void ClemensFrontend::cmdTrace(std::string_view operand) {
         CLEM_TERM_COUT.print(TerminalLine::Error,
                              "Operation only allowed while tracing is active.");
     }
-    backend_->debugProgramTrace(std::string(params[0]), path);
+    backendQueue_.debugProgramTrace(std::string(params[0]), path);
 }
 
 std::string ClemensFrontend::cmdMessageFromBackend(std::string_view message,
@@ -3954,7 +3985,7 @@ void ClemensFrontend::cmdSave(std::string_view operand) {
         CLEM_TERM_COUT.print(TerminalLine::Error, "Save requires a filename.");
         return;
     }
-    backend_->saveMachine(std::string(params[0]));
+    backendQueue_.saveMachine(std::string(params[0]));
 }
 
 void ClemensFrontend::cmdLoad(std::string_view operand) {
@@ -3963,7 +3994,7 @@ void ClemensFrontend::cmdLoad(std::string_view operand) {
         CLEM_TERM_COUT.print(TerminalLine::Error, "Load requires a filename.");
         return;
     }
-    backend_->loadMachine(std::string(params[0]));
+    backendQueue_.loadMachine(std::string(params[0]));
 }
 
 void ClemensFrontend::cmdGet(std::string_view operand) {
@@ -4010,7 +4041,7 @@ void ClemensFrontend::cmdADBMouse(std::string_view operand) {
         CLEM_TERM_COUT.print(TerminalLine::Error, "ADBMouse invalid parameters.");
         return;
     }
-    backend_->inputEvent(input);
+    backendQueue_.inputEvent(input);
     CLEM_TERM_COUT.print(TerminalLine::Info, "Input sent.");
 }
 
@@ -4025,5 +4056,5 @@ void ClemensFrontend::cmdMinimode(std::string_view operand) {
 }
 
 void ClemensFrontend::cmdScript(std::string_view command) {
-    backend_->runScript(std::string(command));
+    backendQueue_.runScript(std::string(command));
 }

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -703,7 +703,7 @@ void ClemensFrontend::runBackend(std::unique_ptr<ClemensBackend> backend) {
     ClemensBackendState state;
 
     ClemensCommandQueue::DispatchResult results{};
-    double frameTimeLag = 0.0f;
+    // double frameTimeLag = 0.0f;
 
     // results = backend->main(commands, state)).second
     while (!results.second) {
@@ -718,7 +718,7 @@ void ClemensFrontend::runBackend(std::unique_ptr<ClemensBackend> backend) {
                                         return (uiFrameTimeDelta_ > 0.0) ||
                                                !stagedBackendQueue_.isEmpty();
                                     });
-                                    CK_TODO("Need to account for lag!!!")
+                                    // CK_TODO("Need to account for lag!!!")
                                     frameSeqNo_++;
                                     backendStateDelegate(state, lastFrameResults);
                                     commands.queue(stagedBackendQueue_);
@@ -3818,8 +3818,8 @@ void ClemensFrontend::cmdDump(std::string_view operand) {
         message += ",";
     }
     message.pop_back();
-    CK_TODO(DebugMessage : Send Message to thread so it can fill in the data)
-    // backendQueue_.debugMessage(std::move(message));
+    // CK_TODO(DebugMessage : Send Message to thread so it can fill in the data)
+    //  backendQueue_.debugMessage(std::move(message));
 }
 
 void ClemensFrontend::cmdTrace(std::string_view operand) {

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -1,6 +1,7 @@
 #ifndef CLEM_HOST_FRONT_HPP
 #define CLEM_HOST_FRONT_HPP
 
+#include "clem_command_queue.hpp"
 #include "clem_host_platform.h"
 #include "clem_host_view.hpp"
 
@@ -42,11 +43,15 @@ class ClemensFrontend : public ClemensHostView {
   private:
     template <typename TBufferType> friend struct FormatView;
 
-    std::unique_ptr<ClemensBackend> createBackend();
+    void createBackend();
+    void runBackend(std::unique_ptr<ClemensBackend> backend);
+    void stopBackend();
+    bool isBackendRunning() const;
 
     //  the backend state delegate is run on a separate thread and notifies
     //  when a frame has been published
-    void backendStateDelegate(const ClemensBackendState &state);
+    void backendStateDelegate(const ClemensBackendState &state,
+                              const ClemensCommandQueue::ResultBuffer &results);
     void copyState(const ClemensBackendState &state);
     void processBackendResult(const ClemensBackendResult &result);
 
@@ -107,14 +112,35 @@ class ClemensFrontend : public ClemensHostView {
 
     ClemensDisplay display_;
     ClemensAudioDevice audio_;
+
     std::unique_ptr<ClemensBackend> backend_;
 
-    //  These buffers are populated when the backend publishes the current
-    //  emulator state.   Their contents are refreshed for every publish
-    std::condition_variable framePublished_;
-    std::mutex frameMutex_;
+    //  Handles synchronization between the emulator and the UI(main) thread
+    //  The backendQueue is filled by the UI.  It will "stage" these commands
+    //  every UI frame and report its timestamp.
+    //
+    //  The worker will handle commands as long as the frameTimestamp changes.
+    //  It uses this timestamp to make sure it doesn't emulate frames beyond
+    //  those that are needed to keep in sync with the UI.  This should more or
+    //  less work with fast emulation enabled, since frames are reported back to
+    //  the frontend based on the UI's framerate using this counter.
+    std::thread backendThread_;
+    ClemensCommandQueue backendQueue_;
+    ClemensCommandQueue stagedBackendQueue_;
+    double uiFrameTimeDelta_;
+
+    // These counters are used to identify unique frames between the two threads
+    // frameSeqNo is updated per executed emulator frame.  The UI thread will
+    // check frameSeqNo against frameLastSeqNo during the synchronization phase
+    // and if they differ, then the UI has data for a new emulator state.
     uint64_t frameSeqNo_, frameLastSeqNo_;
     static const uint64_t kFrameSeqNoInvalid;
+
+    // Synchronization - UI thread will notify the emulator of new commands and
+    // timestamp.  The worker will wait until the timestamp changes and
+    // execute frames to maintain sync with the UI thread.
+    std::condition_variable readyForFrame_;
+    std::mutex frameMutex_;
 
     //  Toggle between frame memory buffers so that backendStateDelegate and frame
     //  write to and read from separate buffers, to minimize the time we need to
@@ -211,7 +237,6 @@ class ClemensFrontend : public ClemensHostView {
     //  when an event happened (command failed, termination, breakpoint hit, etc)
     struct LastCommandState {
         std::vector<ClemensBackendResult> results;
-        std::optional<bool> terminated;
         std::optional<unsigned> hitBreakpoint;
         std::optional<std::string> message;
         LogOutputNode *logNode = nullptr;

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <vector>
 
 struct ImFont;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -131,8 +131,6 @@ struct ClemensBackendState {
     ClemensMachine *machine;
     ClemensMMIO *mmio;
     double fps;
-    uint64_t seqno;
-    bool isTerminated;
     bool isRunning;
     bool isTracing;
     bool isIWMTracing;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -25,18 +25,18 @@ struct ClemensBackendExecutedInstruction {
     char operand[32];
 };
 
-struct ClemensBackendBreakpoint {
-    enum Type { Undefined, Execute, DataRead, Write, IRQ };
-    Type type;
-    uint32_t address;
-};
-
 struct ClemensBackendDiskDriveState {
     std::string imagePath;
     bool isWriteProtected;
     bool isSpinning;
     bool isEjecting;
     bool saveFailed;
+};
+
+struct ClemensBackendBreakpoint {
+    enum Type { Undefined, Execute, DataRead, Write, IRQ };
+    Type type;
+    uint32_t address;
 };
 
 struct ClemensBackendConfig {
@@ -51,36 +51,6 @@ struct ClemensBackendConfig {
     std::vector<ClemensBackendBreakpoint> breakpoints;
     unsigned audioSamplesPerSecond;
     Type type;
-};
-
-struct ClemensBackendCommand {
-    enum Type {
-        Undefined,
-        Terminate,
-        SetHostUpdateFrequency,
-        ResetMachine,
-        RunMachine,
-        StepMachine,
-        Publish,
-        InsertDisk,
-        InsertBlankDisk,
-        EjectDisk,
-        Input,
-        Break,
-        AddBreakpoint,
-        DelBreakpoint,
-        WriteProtectDisk,
-        DebugMemoryPage,
-        WriteMemory,
-        DebugLogLevel,
-        DebugMessage,
-        DebugProgramTrace,
-        SaveMachine,
-        LoadMachine,
-        RunScript
-    };
-    Type type = Undefined;
-    std::string operand;
 };
 
 enum class ClemensBackendMachineProperty {
@@ -123,6 +93,34 @@ template <typename Stats> struct ClemensEmulatorDiagnostics {
         return std::make_pair(0.0, false);
     }
 };
+
+struct ClemensBackendCommand {
+    enum Type {
+        Undefined,
+        Terminate,
+        ResetMachine,
+        RunMachine,
+        StepMachine,
+        InsertDisk,
+        InsertBlankDisk,
+        EjectDisk,
+        Input,
+        Break,
+        AddBreakpoint,
+        DelBreakpoint,
+        WriteProtectDisk,
+        DebugMemoryPage,
+        WriteMemory,
+        DebugLogLevel,
+        DebugProgramTrace,
+        SaveMachine,
+        LoadMachine,
+        RunScript
+    };
+    Type type = Undefined;
+    std::string operand;
+};
+
 struct ClemensBackendResult {
     ClemensBackendCommand cmd;
     enum Type { Succeeded, Failed };
@@ -130,7 +128,6 @@ struct ClemensBackendResult {
 };
 
 struct ClemensBackendState {
-    std::vector<ClemensBackendResult> results;
     ClemensMachine *machine;
     ClemensMMIO *mmio;
     double fps;

--- a/host/clem_ui_load_snapshot.cpp
+++ b/host/clem_ui_load_snapshot.cpp
@@ -1,4 +1,5 @@
 #include "clem_ui_load_snapshot.hpp"
+#include "clem_command_queue.hpp"
 
 #include "clem_backend.hpp"
 #include "clem_imgui.hpp"
@@ -9,16 +10,16 @@
 
 bool ClemensLoadSnapshotUI::isStarted() const { return mode_ != Mode::None; }
 
-void ClemensLoadSnapshotUI::start(ClemensBackend *backend, const std::string &snapshotDir,
+void ClemensLoadSnapshotUI::start(ClemensCommandQueue &backend, const std::string &snapshotDir,
                                   bool isEmulatorRunning) {
     mode_ = Mode::Browser;
     interruptedExecution_ = isEmulatorRunning;
     snapshotDir_ = snapshotDir;
     snapshotName_[0] = '\0';
-    backend->breakExecution();
+    backend.breakExecution();
 }
 
-bool ClemensLoadSnapshotUI::frame(float width, float height, ClemensBackend *backend) {
+bool ClemensLoadSnapshotUI::frame(float width, float height, ClemensCommandQueue &backend) {
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     switch (mode_) {
     case Mode::None:
@@ -69,7 +70,7 @@ bool ClemensLoadSnapshotUI::frame(float width, float height, ClemensBackend *bac
             if (isOk && snapshotName_[0] != '\0') {
                 ImGui::CloseCurrentPopup();
 
-                backend->loadMachine(snapshotName_);
+                backend.loadMachine(snapshotName_);
                 fmt::print("LoadSnapshotMode: loading...\n");
                 mode_ = Mode::WaitForResponse;
             }
@@ -118,9 +119,9 @@ bool ClemensLoadSnapshotUI::frame(float width, float height, ClemensBackend *bac
     return false;
 }
 
-void ClemensLoadSnapshotUI::stop(ClemensBackend *backend) {
+void ClemensLoadSnapshotUI::stop(ClemensCommandQueue &backend) {
     if (interruptedExecution_) {
-        backend->run();
+        backend.run();
     }
     mode_ = Mode::None;
 }

--- a/host/clem_ui_load_snapshot.hpp
+++ b/host/clem_ui_load_snapshot.hpp
@@ -3,14 +3,15 @@
 
 #include <string>
 
-class ClemensBackend;
+class ClemensCommandQueue;
 
 class ClemensLoadSnapshotUI {
   public:
     bool isStarted() const;
-    void start(ClemensBackend *backend, const std::string &snapshotDir, bool isEmulatorRunning);
-    bool frame(float width, float height, ClemensBackend *backend);
-    void stop(ClemensBackend *backend);
+    void start(ClemensCommandQueue &backend, const std::string &snapshotDir,
+               bool isEmulatorRunning);
+    bool frame(float width, float height, ClemensCommandQueue &backend);
+    void stop(ClemensCommandQueue &backend);
     void succeeded();
     void fail();
 

--- a/host/clem_ui_save_snapshot.cpp
+++ b/host/clem_ui_save_snapshot.cpp
@@ -1,4 +1,5 @@
 #include "clem_ui_save_snapshot.hpp"
+#include "clem_command_queue.hpp"
 
 #include "clem_backend.hpp"
 #include "clem_imgui.hpp"
@@ -9,14 +10,14 @@
 
 bool ClemensSaveSnapshotUI::isStarted() const { return mode_ != Mode::None; }
 
-void ClemensSaveSnapshotUI::start(ClemensBackend *backend, bool isEmulatorRunning) {
+void ClemensSaveSnapshotUI::start(ClemensCommandQueue &backend, bool isEmulatorRunning) {
     mode_ = Mode::PromptForName;
     interruptedExecution_ = isEmulatorRunning;
     snapshotName_[0] = '\0';
-    backend->breakExecution();
+    backend.breakExecution();
 }
 
-bool ClemensSaveSnapshotUI::frame(float width, float /* height */, ClemensBackend *backend) {
+bool ClemensSaveSnapshotUI::frame(float width, float /* height */, ClemensCommandQueue &backend) {
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     switch (mode_) {
     case Mode::None:
@@ -54,7 +55,7 @@ bool ClemensSaveSnapshotUI::frame(float width, float /* height */, ClemensBacken
                 if (!selectedPath.has_extension()) {
                     selectedPath.replace_extension(".clemens-sav");
                 }
-                backend->saveMachine(selectedPath.string());
+                backend.saveMachine(selectedPath.string());
                 fmt::print("SaveSnapshotMode: saving...\n");
                 mode_ = Mode::WaitForResponse;
             }
@@ -103,9 +104,9 @@ bool ClemensSaveSnapshotUI::frame(float width, float /* height */, ClemensBacken
     return false;
 }
 
-void ClemensSaveSnapshotUI::stop(ClemensBackend *backend) {
+void ClemensSaveSnapshotUI::stop(ClemensCommandQueue &backend) {
     if (interruptedExecution_) {
-        backend->run();
+        backend.run();
     }
     mode_ = Mode::None;
 }

--- a/host/clem_ui_save_snapshot.hpp
+++ b/host/clem_ui_save_snapshot.hpp
@@ -1,14 +1,14 @@
 #ifndef CLEM_HOST_SAVE_SNAPSHOT_UI_HPP
 #define CLEM_HOST_SAVE_SNAPSHOT_UI_HPP
 
-class ClemensBackend;
+class ClemensCommandQueue;
 
 class ClemensSaveSnapshotUI {
   public:
     bool isStarted() const;
-    void start(ClemensBackend *backend, bool isEmulatorRunning);
-    bool frame(float width, float height, ClemensBackend *backend);
-    void stop(ClemensBackend *backend);
+    void start(ClemensCommandQueue &backend, bool isEmulatorRunning);
+    bool frame(float width, float height, ClemensCommandQueue &backend);
+    void stop(ClemensCommandQueue &backend);
     void succeeded();
     void fail();
 


### PR DESCRIPTION
Fixes the mouse tearing issue seen when the cursor is displayed.   Also likely fixes some other yet undiscovered bugs.

Related to this fix are some significant changes:
- More accurate clock timings in the VGC component; fewer back and forth conversions between nanoseconds and `clem_clocks_duration_t` which were lossy (note this change could benefit other systems - will evaluate)
- Cleaned up the host emulator communication between the UI and the emulator worker thread so that there are fewer mutexes, and all synchronization is better isolated.

Side effects:
- A small chance of a lockup on shutdown (the worker isn't terminating in this case for some reason - will investigate)
- There may be other side effects on usability given the scope of this change

Given the scope of this code change, I felt it's better to get this into mainline and deal with the repercussions in the following week (bugfixing, dogfooding) before the next release.