### PR TITLE
Disable writing to DOC E0/E2 registers

### DIFF
--- a/clem_audio.c
+++ b/clem_audio.c
@@ -33,10 +33,10 @@
  *  a square wave.
  */
 
-#define CLEM_AUDIO_CTL_BUSY 0x80
-#define CLEM_AUDIO_CTL_ACCESS_RAM 0x40
+#define CLEM_AUDIO_CTL_BUSY         0x80
+#define CLEM_AUDIO_CTL_ACCESS_RAM   0x40
 #define CLEM_AUDIO_CTL_AUTO_ADDRESS 0x20
-#define CLEM_AUDIO_CTL_VOLUME_MASK 0x07
+#define CLEM_AUDIO_CTL_VOLUME_MASK  0x07
 
 /* integer only multiply by the ratio of 102300/89489 (1023khz/894.886khz) */
 #define CLEM_ENSONIQ_CLOCKS_PER_CYCLE (CLEM_CLOCKS_MEGA2_CYCLE * 102300 / 89489)
@@ -100,476 +100,481 @@
   https://ia600407.us.archive.org/8/items/cortland_manual_set/v4_13_EnsoniqDOC.pdf
 */
 
-#define CLEM_ENSONIQ_OSC_LIMIT      32
+#define CLEM_ENSONIQ_OSC_LIMIT        32
+#define CLEM_ENSONIQ_REG_OSC_OIR_MASK 0xbe // 01000001 are always on and unchanged
 
-static uint16_t s_ensoniq_ptr_bits_mask[8] = {
-  0xff00, 0xfe00, 0xfc00, 0xf800, 0xf000, 0xe000, 0xc000, 0x8000
-};
+static uint16_t s_ensoniq_ptr_bits_mask[8] = {0xff00, 0xfe00, 0xfc00, 0xf800,
+                                              0xf000, 0xe000, 0xc000, 0x8000};
 
-void clem_ensoniq_reset(struct ClemensDeviceEnsoniq* doc) {
-  doc->address = 0;
-  doc->ram_read_cntr = 0;
-  doc->dt_budget = 0;
-  doc->cycle = 0;
-  doc->addr_auto_inc = false;
-  doc->is_access_ram = false;
-  doc->is_busy = false;
+void clem_ensoniq_reset(struct ClemensDeviceEnsoniq *doc) {
+    doc->address = 0;
+    doc->ram_read_cntr = 0;
+    doc->dt_budget = 0;
+    doc->cycle = 0;
+    doc->addr_auto_inc = false;
+    doc->is_access_ram = false;
+    doc->is_busy = false;
 
-  memset(doc->reg, 0, sizeof(doc->reg));
-  memset(doc->acc, 0, sizeof(doc->acc));
-  memset(doc->ptr, 0, sizeof(doc->ptr));
-  memset(doc->osc_flags, 0, sizeof(doc->osc_flags));
-  // ensures no interrupt triggered
-  doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] = 0xff;
-  // 1 oscillator x 2 at minimum enabled
-  doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] = 0;
-  // unsigned wave, so 0x80 == 0 signed
-  doc->reg[CLEM_ENSONIQ_REG_OSC_ADC] = 0x80;
+    memset(doc->reg, 0, sizeof(doc->reg));
+    memset(doc->acc, 0, sizeof(doc->acc));
+    memset(doc->ptr, 0, sizeof(doc->ptr));
+    memset(doc->osc_flags, 0, sizeof(doc->osc_flags));
+    // ensures no interrupt triggered
+    doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] = 0xff;
+    // 1 oscillator x 2 at minimum enabled
+    doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] = 0;
+    // unsigned wave, so 0x80 == 0 signed
+    doc->reg[CLEM_ENSONIQ_REG_OSC_ADC] = 0x80;
 }
 
-static void _clem_ensoniq_set_irq(struct ClemensDeviceEnsoniq* doc,
-                                   unsigned osc_index) {
-  if (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] & 0x80) {
-    doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] &= ~0xbe;    // 01000001
-    doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] |= ((uint8_t)(osc_index << 1) & 0x3e);
-  }
-  doc->osc_flags[osc_index] |= CLEM_ENSONIQ_OSC_FLAG_IRQ;
-}
-
-static void _clem_ensoniq_clear_irq(struct ClemensDeviceEnsoniq* doc) {
-  unsigned osc_index = (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] >> 1) & 0x1f;
-  doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] |= 0x80;
-  doc->osc_flags[osc_index] &= ~CLEM_ENSONIQ_OSC_FLAG_IRQ;
-}
-
-void _clem_ensoniq_reset_osc(struct ClemensDeviceEnsoniq* doc, unsigned osc_index) {
-  doc->acc[osc_index] = 0;
-  doc->ptr[osc_index] = 0;
-}
-
-
-uint8_t clem_ensoniq_oscillator_cycle(struct ClemensDeviceEnsoniq* doc,
-                                      unsigned osc_index, unsigned osc_limit,
-                                      uint8_t ctl) {
-  //  Data is read from sound RAM and sent to one of up to eight output channels
-  //  address calculation
-  //  ACC <- FREQ + ACC
-  //  OFF <- ACC
-  //  TODO: precalc these values when their registers change - may save a few
-  //        cycles if needed
-  unsigned freq_ctl =
-    (((uint16_t)doc->reg[CLEM_ENSONIQ_REG_OSC_FCHI + osc_index]) << 8) |
-    doc->reg[CLEM_ENSONIQ_REG_OSC_FCLOW + osc_index];
-  //  page aligned pointer into sound RAM
-  uint16_t ptr = ((uint16_t)doc->reg[CLEM_ENSONIQ_REG_OSC_PTR + osc_index]) << 8;
-  //  offset into the wavetable
-  unsigned acc = (doc->acc[osc_index] + freq_ctl) & 0x00ffffff; // 24-bit
-  unsigned resolution = (doc->reg[CLEM_ENSONIQ_REG_OSC_SIZE + osc_index] & 0x07) + 1;
-  unsigned size = ((doc->reg[CLEM_ENSONIQ_REG_OSC_SIZE + osc_index] >> 3) & 0x07);
-  unsigned channel = ((ctl & 0xf0) >> 4) & 0x7;
-  unsigned other_osc_index = osc_index ^ 1;
-
-  doc->acc[osc_index] = acc;
-  //  use 16-bits of the accumulator, the resolution determines *which* 16 bits
-  // size = 0, use 8 bits of accumulator at ADR0-7
-  //      = 1, use 9 bits of accumulator at ADR0-8
-  //      etc
-  acc = (acc >> resolution) & 0xffff;
-  acc = (acc >> (8 - size)) & 0x7fff;
-  ptr &= s_ensoniq_ptr_bits_mask[size];
-  ptr |= acc;
-
-  //  handle wraparound to start of wavetable, which triggers interrupts and
-  //  changes oscillator state based on control mode (one-shot, sync, swap)
-  if (ptr < doc->ptr[osc_index]) {
-    if (ctl & CLEM_ENSONIQ_OSC_CTL_IE) {
-      doc->osc_flags[osc_index] |= CLEM_ENSONIQ_OSC_FLAG_IRQ;
+static void _clem_ensoniq_set_irq(struct ClemensDeviceEnsoniq *doc, unsigned osc_index) {
+    if (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] & 0x80) {
+        doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] &= ~CLEM_ENSONIQ_REG_OSC_OIR_MASK;
+        doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] |= ((uint8_t)(osc_index << 1) & 0x3e);
     }
-    if (ctl & CLEM_ENSONIQ_OSC_CTL_M0) {
-      if (ctl & CLEM_ENSONIQ_OSC_CTL_SYNC) {
-        // swap
-        ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
-        if (other_osc_index < osc_limit) {
-          doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + other_osc_index]
-            &= ~CLEM_ENSONIQ_OSC_CTL_HALT;
+    doc->osc_flags[osc_index] |= CLEM_ENSONIQ_OSC_FLAG_IRQ;
+}
+
+static void _clem_ensoniq_clear_irq(struct ClemensDeviceEnsoniq *doc) {
+    unsigned osc_index = (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] >> 1) & 0x1f;
+    doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] |= 0x80;
+    doc->osc_flags[osc_index] &= ~CLEM_ENSONIQ_OSC_FLAG_IRQ;
+}
+
+void _clem_ensoniq_reset_osc(struct ClemensDeviceEnsoniq *doc, unsigned osc_index) {
+    doc->acc[osc_index] = 0;
+    doc->ptr[osc_index] = 0;
+}
+
+uint8_t clem_ensoniq_oscillator_cycle(struct ClemensDeviceEnsoniq *doc, unsigned osc_index,
+                                      unsigned osc_limit, uint8_t ctl) {
+    //  Data is read from sound RAM and sent to one of up to eight output channels
+    //  address calculation
+    //  ACC <- FREQ + ACC
+    //  OFF <- ACC
+    //  TODO: precalc these values when their registers change - may save a few
+    //        cycles if needed
+    unsigned freq_ctl = (((uint16_t)doc->reg[CLEM_ENSONIQ_REG_OSC_FCHI + osc_index]) << 8) |
+                        doc->reg[CLEM_ENSONIQ_REG_OSC_FCLOW + osc_index];
+    //  page aligned pointer into sound RAM
+    uint16_t ptr = ((uint16_t)doc->reg[CLEM_ENSONIQ_REG_OSC_PTR + osc_index]) << 8;
+    //  offset into the wavetable
+    unsigned acc = (doc->acc[osc_index] + freq_ctl) & 0x00ffffff; // 24-bit
+    unsigned resolution = (doc->reg[CLEM_ENSONIQ_REG_OSC_SIZE + osc_index] & 0x07) + 1;
+    unsigned size = ((doc->reg[CLEM_ENSONIQ_REG_OSC_SIZE + osc_index] >> 3) & 0x07);
+    unsigned channel = ((ctl & 0xf0) >> 4) & 0x7;
+    unsigned other_osc_index = osc_index ^ 1;
+
+    doc->acc[osc_index] = acc;
+    //  use 16-bits of the accumulator, the resolution determines *which* 16 bits
+    // size = 0, use 8 bits of accumulator at ADR0-7
+    //      = 1, use 9 bits of accumulator at ADR0-8
+    //      etc
+    acc = (acc >> resolution) & 0xffff;
+    acc = (acc >> (8 - size)) & 0x7fff;
+    ptr &= s_ensoniq_ptr_bits_mask[size];
+    ptr |= acc;
+
+    //  handle wraparound to start of wavetable, which triggers interrupts and
+    //  changes oscillator state based on control mode (one-shot, sync, swap)
+    if (ptr < doc->ptr[osc_index]) {
+        if (ctl & CLEM_ENSONIQ_OSC_CTL_IE) {
+            doc->osc_flags[osc_index] |= CLEM_ENSONIQ_OSC_FLAG_IRQ;
         }
-      } else {
-        // oneshot
-        ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
-      }
-    } else if (ctl & CLEM_ENSONIQ_OSC_CTL_SYNC) {
-      // sync mode since M0 is 0, odd osciallator will reset
-      if (other_osc_index < osc_limit && (other_osc_index & 1)) {
-        _clem_ensoniq_reset_osc(doc, other_osc_index);
-      }
-    }
-  }
-
-  doc->ptr[osc_index] = ptr;
-  doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_index] = doc->sound_ram[ptr];
-  if (!doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_index]) {
-    ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
-  }
-  return ctl;
-}
-
-uint32_t clem_ensoniq_sync(struct ClemensDeviceEnsoniq* doc,
-                       clem_clocks_duration_t dt_clocks) {
-  // 1 oscillator x 2 at minimum enabled - i.e. we always enable 2 by default
-  unsigned osc_cnt = (doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] >> 1) + 1;
-
-  doc->dt_budget += dt_clocks;
-
-  while (doc->dt_budget >= CLEM_ENSONIQ_CLOCKS_PER_CYCLE) {
-    // 2 extra cycles after running through all active oscillators
-    unsigned osc_cycle = doc->cycle % (osc_cnt + 2);
-    if (osc_cycle < osc_cnt) {
-      uint8_t ctl = doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_cycle];
-      if (ctl & CLEM_ENSONIQ_OSC_CTL_HALT) {
         if (ctl & CLEM_ENSONIQ_OSC_CTL_M0) {
-          _clem_ensoniq_reset_osc(doc, osc_cycle);
+            if (ctl & CLEM_ENSONIQ_OSC_CTL_SYNC) {
+                // swap
+                ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
+                if (other_osc_index < osc_limit) {
+                    doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + other_osc_index] &=
+                        ~CLEM_ENSONIQ_OSC_CTL_HALT;
+                }
+            } else {
+                // oneshot
+                ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
+            }
+        } else if (ctl & CLEM_ENSONIQ_OSC_CTL_SYNC) {
+            // sync mode since M0 is 0, odd osciallator will reset
+            if (other_osc_index < osc_limit && (other_osc_index & 1)) {
+                _clem_ensoniq_reset_osc(doc, other_osc_index);
+            }
         }
-      } else {
-        ctl = clem_ensoniq_oscillator_cycle(doc, osc_cycle, osc_cnt, ctl);
-        if (doc->osc_flags[osc_cycle] & CLEM_ENSONIQ_OSC_FLAG_IRQ) {
-          _clem_ensoniq_set_irq(doc, osc_cycle);
-        }
-      }
-      doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_cycle] = ctl;
     }
 
-    ++doc->cycle;
-    doc->dt_budget -= CLEM_ENSONIQ_CLOCKS_PER_CYCLE;
-  }
-
-  return (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] & 0x80) ? 0 : CLEM_IRQ_AUDIO_OSC;
+    doc->ptr[osc_index] = ptr;
+    doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_index] = doc->sound_ram[ptr];
+    if (!doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_index]) {
+        ctl |= CLEM_ENSONIQ_OSC_CTL_HALT;
+    }
+    return ctl;
 }
 
-unsigned clem_ensoniq_voices(struct ClemensDeviceEnsoniq* doc) {
-  //  run through all enabled non-halted oscillators
-  //  if the oscillator is in AM mode (sync, odd oscillator modules the lower
-  //  even?) and ignore the volume setting for the oscillator
-  unsigned osc_cnt = (doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] >> 1) + 1;
-  unsigned osc_max_channels = 0;
-  unsigned osc_idx, voice_idx;
-  for (osc_idx = 0; osc_idx < osc_cnt; ++osc_idx) {
-    uint8_t volume = doc->reg[CLEM_ENSONIQ_REG_OSC_VOLUME + osc_idx];
-    uint8_t ctl = doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_idx];
-    uint8_t channel = (ctl >> 4);
-    uint8_t data = doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_idx];
-    bool sync_mode = (ctl & CLEM_ENSONIQ_OSC_CTL_SWAP) == CLEM_ENSONIQ_OSC_CTL_SYNC;
-    float level = (2.0f * data / 255.0f) - 1.0f;
+uint32_t clem_ensoniq_sync(struct ClemensDeviceEnsoniq *doc, clem_clocks_duration_t dt_clocks) {
+    // 1 oscillator x 2 at minimum enabled - i.e. we always enable 2 by default
+    unsigned osc_cnt = (doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] >> 1) + 1;
 
-    if (ctl & CLEM_ENSONIQ_OSC_CTL_HALT) continue;
+    doc->dt_budget += dt_clocks;
 
-    if (channel >= osc_max_channels) {
-      for (voice_idx = osc_max_channels; voice_idx < channel + 1; ++voice_idx) {
-        doc->voice[voice_idx] = 0.0f;
-      }
-      osc_max_channels = channel + 1;
+    while (doc->dt_budget >= CLEM_ENSONIQ_CLOCKS_PER_CYCLE) {
+        // 2 extra cycles after running through all active oscillators
+        unsigned osc_cycle = doc->cycle % (osc_cnt + 2);
+        if (osc_cycle < osc_cnt) {
+            uint8_t ctl = doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_cycle];
+            if (ctl & CLEM_ENSONIQ_OSC_CTL_HALT) {
+                if (ctl & CLEM_ENSONIQ_OSC_CTL_M0) {
+                    _clem_ensoniq_reset_osc(doc, osc_cycle);
+                }
+            } else {
+                ctl = clem_ensoniq_oscillator_cycle(doc, osc_cycle, osc_cnt, ctl);
+                if (doc->osc_flags[osc_cycle] & CLEM_ENSONIQ_OSC_FLAG_IRQ) {
+                    _clem_ensoniq_set_irq(doc, osc_cycle);
+                }
+            }
+            doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_cycle] = ctl;
+        }
+
+        ++doc->cycle;
+        doc->dt_budget -= CLEM_ENSONIQ_CLOCKS_PER_CYCLE;
     }
 
-    // no value
-    if (!data) continue;
-    //  AM mode is handled in the even oscillator
-    if (sync_mode && (osc_idx & 1)) continue;
+    return (doc->reg[CLEM_ENSONIQ_REG_OSC_OIR] & 0x80) ? 0 : CLEM_IRQ_AUDIO_OSC;
+}
 
-    if ((osc_idx + 1) & 1) {
-      // TODO: this can be precalculated and stored into osc_flags for the
-      //       current channel during the oscillator pass
-      if ((doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_idx + 1] &
-          (CLEM_ENSONIQ_OSC_CTL_HALT + CLEM_ENSONIQ_OSC_CTL_SWAP))
-          == CLEM_ENSONIQ_OSC_CTL_SYNC) {
-        volume = doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_idx + 1];
-      }
+unsigned clem_ensoniq_voices(struct ClemensDeviceEnsoniq *doc) {
+    //  run through all enabled non-halted oscillators
+    //  if the oscillator is in AM mode (sync, odd oscillator modules the lower
+    //  even?) and ignore the volume setting for the oscillator
+    unsigned osc_cnt = (doc->reg[CLEM_ENSONIQ_REG_OSC_ENABLE] >> 1) + 1;
+    unsigned osc_max_channels = 0;
+    unsigned osc_idx, voice_idx;
+    for (osc_idx = 0; osc_idx < osc_cnt; ++osc_idx) {
+        uint8_t volume = doc->reg[CLEM_ENSONIQ_REG_OSC_VOLUME + osc_idx];
+        uint8_t ctl = doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_idx];
+        uint8_t channel = (ctl >> 4);
+        uint8_t data = doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_idx];
+        bool sync_mode = (ctl & CLEM_ENSONIQ_OSC_CTL_SWAP) == CLEM_ENSONIQ_OSC_CTL_SYNC;
+        float level = (2.0f * data / 255.0f) - 1.0f;
+
+        if (ctl & CLEM_ENSONIQ_OSC_CTL_HALT)
+            continue;
+
+        if (channel >= osc_max_channels) {
+            for (voice_idx = osc_max_channels; voice_idx < channel + 1; ++voice_idx) {
+                doc->voice[voice_idx] = 0.0f;
+            }
+            osc_max_channels = channel + 1;
+        }
+
+        // no value
+        if (!data)
+            continue;
+        //  AM mode is handled in the even oscillator
+        if (sync_mode && (osc_idx & 1))
+            continue;
+
+        if ((osc_idx + 1) & 1) {
+            // TODO: this can be precalculated and stored into osc_flags for the
+            //       current channel during the oscillator pass
+            if ((doc->reg[CLEM_ENSONIQ_REG_OSC_CTRL + osc_idx + 1] &
+                 (CLEM_ENSONIQ_OSC_CTL_HALT + CLEM_ENSONIQ_OSC_CTL_SWAP)) ==
+                CLEM_ENSONIQ_OSC_CTL_SYNC) {
+                volume = doc->reg[CLEM_ENSONIQ_REG_OSC_DATA + osc_idx + 1];
+            }
+        }
+
+        doc->voice[channel] += level * (volume / 255.0f);
     }
 
-    doc->voice[channel] += level * (volume/255.0f);
-  }
-
-  return osc_max_channels;
+    return osc_max_channels;
 }
 
 //  down convert voices output into 2 channel mono
-void clem_ensoniq_mono(struct ClemensDeviceEnsoniq* doc, unsigned osc_max_channels,
-                       float* left, float* right) {
-  *left = 0.0f;
-  *right = 0.0f;
+void clem_ensoniq_mono(struct ClemensDeviceEnsoniq *doc, unsigned osc_max_channels, float *left,
+                       float *right) {
+    *left = 0.0f;
+    *right = 0.0f;
 
-  for (unsigned channel_idx = 0; channel_idx < osc_max_channels; ++channel_idx) {
-    *left += doc->voice[channel_idx];
-  }
-  if (*left > 1.0f) *left = 1.0f;
-  else if (*left < -1.0f) *left = -1.0f;
-  *right = *left;
+    for (unsigned channel_idx = 0; channel_idx < osc_max_channels; ++channel_idx) {
+        *left += doc->voice[channel_idx];
+    }
+    if (*left > 1.0f)
+        *left = 1.0f;
+    else if (*left < -1.0f)
+        *left = -1.0f;
+    *right = *left;
 }
 
-void clem_ensoniq_write_ctl(struct ClemensDeviceEnsoniq* doc, uint8_t value) {
+void clem_ensoniq_write_ctl(struct ClemensDeviceEnsoniq *doc, uint8_t value) {
     if (doc->is_busy) {
-      CLEM_WARN("[ensoniq]: DOC busy (adr: %04X)", doc->address);
-      return;
+        CLEM_WARN("[ensoniq]: DOC busy (adr: %04X)", doc->address);
+        return;
     }
     doc->is_access_ram = (value & CLEM_AUDIO_CTL_ACCESS_RAM) != 0;
     doc->addr_auto_inc = (value & CLEM_AUDIO_CTL_AUTO_ADDRESS) != 0;
 }
 
-void clem_ensoniq_write_data(struct ClemensDeviceEnsoniq* doc, uint8_t value) {
+void clem_ensoniq_write_data(struct ClemensDeviceEnsoniq *doc, uint8_t value) {
     doc->ram_read_cntr = 0;
     if (doc->is_access_ram) {
-      doc->sound_ram[doc->address & 0xffff] = value;
+        doc->sound_ram[doc->address & 0xffff] = value;
     } else {
-      doc->reg[doc->address & 0xff] = value;
-      switch (doc->address & 0xff) {
-        default:
-          break;
-      }
-      /* TODO: write to register */
-    }
-    if (doc->addr_auto_inc) {
-      ++doc->address;
-    }
-}
-
-
-uint8_t clem_ensoniq_read_ctl(struct ClemensDeviceEnsoniq* doc, uint8_t flags) {
-  uint8_t result = 0x00;
-  if (doc->is_busy) {
-    result |= CLEM_AUDIO_CTL_BUSY;
-  }
-  if (doc->is_access_ram) {
-    result |= CLEM_AUDIO_CTL_ACCESS_RAM;
-  }
-  if (doc->addr_auto_inc) {
-    result |= CLEM_AUDIO_CTL_AUTO_ADDRESS;
-  }
-  return result;
-}
-
-uint8_t clem_ensoniq_read_data(struct ClemensDeviceEnsoniq* doc, uint8_t flags) {
-  uint8_t result = 0x00;
-  if (CLEM_IS_IO_NO_OP(flags)) return result;
-
-
-  /* refer to HW Ref Chapter 5 - p 107, Read operation,
-      first time read operations upon changing the address
-      require double reads - likely for some kind of switch
-      over/state reset on the hardware.  Will have to evalaute
-      how firmware and ROM handles this (i.e. it appears
-      when we read the interrupt register on the DOC, it's read
-      twice, following the convention here)
-  */
-  if (doc->is_access_ram) {
-    result = doc->sound_ram[doc->address & 0xffff];
-  } else {
-    result = doc->reg[doc->address & 0xff];
-  }
-  if (doc->ram_read_cntr > 0) {
-    if (!doc->is_access_ram) {
-      switch (doc->address & 0xff) {
+        /* TODO: write to specific registers that require special handling */
+        switch (doc->address & 0xff) {
         case CLEM_ENSONIQ_REG_OSC_OIR:
-          _clem_ensoniq_clear_irq(doc);
-          break;
+            // appears to be a NOP (no mention of writing to E0 in the cortland docs,
+            // and having apps write the IRQ status seems dangerous for hardware to allow)
+            CLEM_LOG("DOC: Ignoring direct write to OIR value %02x", value);
+            break;
+        case CLEM_ENSONIQ_REG_OSC_ENABLE:
+            CLEM_DEBUG("DOC: OSC Enable set to %02x", value);
+            break;
+        case CLEM_ENSONIQ_REG_OSC_ADC:
+            // should be a no-op
+            break;
         default:
-          break;
-      }
+            doc->reg[doc->address & 0xff] = value;
+            break;
+        }
     }
     if (doc->addr_auto_inc) {
-      ++doc->address;
+        ++doc->address;
     }
-  }
-
-  ++doc->ram_read_cntr;
-  return result;
 }
 
+uint8_t clem_ensoniq_read_ctl(struct ClemensDeviceEnsoniq *doc, uint8_t flags) {
+    uint8_t result = 0x00;
+    if (doc->is_busy) {
+        result |= CLEM_AUDIO_CTL_BUSY;
+    }
+    if (doc->is_access_ram) {
+        result |= CLEM_AUDIO_CTL_ACCESS_RAM;
+    }
+    if (doc->addr_auto_inc) {
+        result |= CLEM_AUDIO_CTL_AUTO_ADDRESS;
+    }
+    return result;
+}
+
+uint8_t clem_ensoniq_read_data(struct ClemensDeviceEnsoniq *doc, uint8_t flags) {
+    uint8_t result = 0x00;
+    if (CLEM_IS_IO_NO_OP(flags))
+        return result;
+
+    /* refer to HW Ref Chapter 5 - p 107, Read operation,
+        first time read operations upon changing the address
+        require double reads - likely for some kind of switch
+        over/state reset on the hardware.  Will have to evalaute
+        how firmware and ROM handles this (i.e. it appears
+        when we read the interrupt register on the DOC, it's read
+        twice, following the convention here)
+    */
+    if (doc->is_access_ram) {
+        result = doc->sound_ram[doc->address & 0xffff];
+    } else {
+        result = doc->reg[doc->address & 0xff];
+    }
+    if (doc->ram_read_cntr > 0) {
+        if (!doc->is_access_ram) {
+            switch (doc->address & 0xff) {
+            case CLEM_ENSONIQ_REG_OSC_OIR:
+                _clem_ensoniq_clear_irq(doc);
+                break;
+            default:
+                break;
+            }
+        }
+        if (doc->addr_auto_inc) {
+            ++doc->address;
+        }
+    }
+
+    ++doc->ram_read_cntr;
+    return result;
+}
 
 void clem_sound_reset(struct ClemensDeviceAudio *glu) {
-  /* some GLU reset */
+    /* some GLU reset */
 
-  clem_ensoniq_reset(&glu->doc);
+    clem_ensoniq_reset(&glu->doc);
 
-  glu->a2_speaker = false;
-  glu->a2_speaker_tense = false;
-  glu->a2_speaker_frame_count = -1;
-  glu->a2_speaker_frame_threshold = glu->mix_buffer.frames_per_second / 20;
-  glu->a2_speaker_level = 0.0f;
+    glu->a2_speaker = false;
+    glu->a2_speaker_tense = false;
+    glu->a2_speaker_frame_count = -1;
+    glu->a2_speaker_frame_threshold = glu->mix_buffer.frames_per_second / 20;
+    glu->a2_speaker_level = 0.0f;
 
-  /* other config - i.e. test tone */
-  glu->tone_frequency = 0;
-  glu->irq_line = 0;
+    /* other config - i.e. test tone */
+    glu->tone_frequency = 0;
+    glu->irq_line = 0;
 
-  /* mix buffer reset */
-  glu->dt_mix_frame = 0;
-  if (glu->mix_buffer.frames_per_second > 0) {
-    glu->dt_mix_sample =
-        (CLEM_CLOCKS_MEGA2_CYCLE * CLEM_MEGA2_CYCLES_PER_SECOND) /
-        (glu->mix_buffer.frames_per_second);
-    glu->tone_frame_delta =
-        (glu->tone_frequency * CLEM_PI_2) / glu->mix_buffer.frames_per_second;
-  } else {
-    glu->dt_mix_sample = 0;
-    glu->tone_frame_delta = 0;
-  }
-  glu->tone_theta = 0.0f;
+    /* mix buffer reset */
+    glu->dt_mix_frame = 0;
+    if (glu->mix_buffer.frames_per_second > 0) {
+        glu->dt_mix_sample = (CLEM_CLOCKS_MEGA2_CYCLE * CLEM_MEGA2_CYCLES_PER_SECOND) /
+                             (glu->mix_buffer.frames_per_second);
+        glu->tone_frame_delta =
+            (glu->tone_frequency * CLEM_PI_2) / glu->mix_buffer.frames_per_second;
+    } else {
+        glu->dt_mix_sample = 0;
+        glu->tone_frame_delta = 0;
+    }
+    glu->tone_theta = 0.0f;
 
 #if CLEM_AUDIO_DIAGNOSTICS
-  glu->diag_dt_ns = 0;
-  glu->diag_delta_frames = 0;
+    glu->diag_dt_ns = 0;
+    glu->diag_delta_frames = 0;
 #endif
 }
 
-void clem_sound_consume_frames(struct ClemensDeviceAudio *glu,
-                               unsigned consumed) {
-  if (consumed > glu->mix_frame_index) {
-    consumed = glu->mix_frame_index;
-  }
-  if (consumed < glu->mix_frame_index) {
-    memcpy(glu->mix_buffer.data,
-           glu->mix_buffer.data + consumed * glu->mix_buffer.stride,
-           (glu->mix_frame_index - consumed) * glu->mix_buffer.stride);
-  }
-  glu->mix_frame_index -= consumed;
+void clem_sound_consume_frames(struct ClemensDeviceAudio *glu, unsigned consumed) {
+    if (consumed > glu->mix_frame_index) {
+        consumed = glu->mix_frame_index;
+    }
+    if (consumed < glu->mix_frame_index) {
+        memcpy(glu->mix_buffer.data, glu->mix_buffer.data + consumed * glu->mix_buffer.stride,
+               (glu->mix_frame_index - consumed) * glu->mix_buffer.stride);
+    }
+    glu->mix_frame_index -= consumed;
 }
 
 void _clem_sound_do_tone(struct ClemensDeviceAudio *glu, float *samples) {
-  float mag = sinf(glu->tone_theta);
-  samples[0] = mag;
-  samples[1] = mag;
-  glu->tone_theta += glu->tone_frame_delta;
-  if (glu->tone_theta >= CLEM_PI_2) {
-    glu->tone_theta -= CLEM_PI_2;
-  }
-}
-
-void clem_sound_glu_sync(struct ClemensDeviceAudio *glu,
-                         struct ClemensClock *clocks) {
-  clem_clocks_duration_t dt_clocks = clocks->ts - glu->ts_last_frame;
-
-  glu->irq_line = clem_ensoniq_sync(&glu->doc, dt_clocks);
-
-  glu->dt_mix_frame += dt_clocks;
-
-  if (glu->dt_mix_sample > 0) {
-    unsigned delta_frames = (glu->dt_mix_frame / glu->dt_mix_sample);
-    if (delta_frames > 0) {
-      uint8_t *mix_out = glu->mix_buffer.data;
-      // note we only support 2 channels max output
-      float doc_out[2];
-      //  TODO: stereo
-      unsigned ensoniq_voice_cnt = clem_ensoniq_voices(&glu->doc);
-      clem_ensoniq_mono(&glu->doc, ensoniq_voice_cnt, &doc_out[0], &doc_out[1]);
-      for (unsigned i = 0; i < delta_frames; ++i) {
-        unsigned frame_index =
-            (glu->mix_frame_index + i) % glu->mix_buffer.frame_count;
-        float *samples =
-            (float *)(&mix_out[frame_index * glu->mix_buffer.stride]);
-        /* test tone support */
-        if (glu->tone_frame_delta > 0) {
-          _clem_sound_do_tone(glu, samples);
-        }
-        if (glu->a2_speaker_frame_count >= 0) {
-          glu->a2_speaker_frame_count += delta_frames;
-        }
-        if (glu->a2_speaker_frame_count > glu->a2_speaker_frame_threshold) {
-          glu->a2_speaker_frame_count = -1;
-          glu->a2_speaker_level = 0.0f;
-        }
-        if (glu->a2_speaker) {
-          /* click! - two speaker pulses = 1 complete wave */
-          glu->a2_speaker_frame_count = 0;
-          if (!glu->a2_speaker_tense) {
-            glu->a2_speaker_level = 0.75f;
-          } else {
-            glu->a2_speaker_level = -0.75f;
-          }
-          glu->a2_speaker_tense = !glu->a2_speaker_tense;
-          glu->a2_speaker = false;
-        }
-        // TODO: stereo DOC
-        samples[0] = doc_out[0] + glu->a2_speaker_level * glu->volume / 15.0f;
-        if (samples[0] > 1.0f) samples[0] = 1.0f;
-        else if (samples[0] < -1.0f) samples[0] = -1.0f;
-        samples[1] = doc_out[1] + glu->a2_speaker_level * glu->volume / 15.0f;
-        if (samples[1] > 1.0f) samples[1] = 1.0f;
-        else if (samples[1] < -1.0f) samples[1] = -1.0f;
-      }
-      glu->mix_frame_index =
-          (glu->mix_frame_index + delta_frames) % (glu->mix_buffer.frame_count);
-      glu->dt_mix_frame = glu->dt_mix_frame % glu->dt_mix_sample;
-#if CLEM_AUDIO_DIAGNOSTICS
-      glu->diag_delta_frames += delta_frames;
-#endif
+    float mag = sinf(glu->tone_theta);
+    samples[0] = mag;
+    samples[1] = mag;
+    glu->tone_theta += glu->tone_frame_delta;
+    if (glu->tone_theta >= CLEM_PI_2) {
+        glu->tone_theta -= CLEM_PI_2;
     }
-  }
+}
+
+void clem_sound_glu_sync(struct ClemensDeviceAudio *glu, struct ClemensClock *clocks) {
+    clem_clocks_duration_t dt_clocks = clocks->ts - glu->ts_last_frame;
+
+    glu->irq_line = clem_ensoniq_sync(&glu->doc, dt_clocks);
+
+    glu->dt_mix_frame += dt_clocks;
+
+    if (glu->dt_mix_sample > 0) {
+        unsigned delta_frames = (glu->dt_mix_frame / glu->dt_mix_sample);
+        if (delta_frames > 0) {
+            uint8_t *mix_out = glu->mix_buffer.data;
+            // note we only support 2 channels max output
+            float doc_out[2];
+            //  TODO: stereo
+            unsigned ensoniq_voice_cnt = clem_ensoniq_voices(&glu->doc);
+            clem_ensoniq_mono(&glu->doc, ensoniq_voice_cnt, &doc_out[0], &doc_out[1]);
+            for (unsigned i = 0; i < delta_frames; ++i) {
+                unsigned frame_index = (glu->mix_frame_index + i) % glu->mix_buffer.frame_count;
+                float *samples = (float *)(&mix_out[frame_index * glu->mix_buffer.stride]);
+                /* test tone support */
+                if (glu->tone_frame_delta > 0) {
+                    _clem_sound_do_tone(glu, samples);
+                }
+                if (glu->a2_speaker_frame_count >= 0) {
+                    glu->a2_speaker_frame_count += delta_frames;
+                }
+                if (glu->a2_speaker_frame_count > glu->a2_speaker_frame_threshold) {
+                    glu->a2_speaker_frame_count = -1;
+                    glu->a2_speaker_level = 0.0f;
+                }
+                if (glu->a2_speaker) {
+                    /* click! - two speaker pulses = 1 complete wave */
+                    glu->a2_speaker_frame_count = 0;
+                    if (!glu->a2_speaker_tense) {
+                        glu->a2_speaker_level = 0.75f;
+                    } else {
+                        glu->a2_speaker_level = -0.75f;
+                    }
+                    glu->a2_speaker_tense = !glu->a2_speaker_tense;
+                    glu->a2_speaker = false;
+                }
+                // TODO: stereo DOC
+                samples[0] = doc_out[0] + glu->a2_speaker_level * glu->volume / 15.0f;
+                if (samples[0] > 1.0f)
+                    samples[0] = 1.0f;
+                else if (samples[0] < -1.0f)
+                    samples[0] = -1.0f;
+                samples[1] = doc_out[1] + glu->a2_speaker_level * glu->volume / 15.0f;
+                if (samples[1] > 1.0f)
+                    samples[1] = 1.0f;
+                else if (samples[1] < -1.0f)
+                    samples[1] = -1.0f;
+            }
+            glu->mix_frame_index =
+                (glu->mix_frame_index + delta_frames) % (glu->mix_buffer.frame_count);
+            glu->dt_mix_frame = glu->dt_mix_frame % glu->dt_mix_sample;
+#if CLEM_AUDIO_DIAGNOSTICS
+            glu->diag_delta_frames += delta_frames;
+#endif
+        }
+    }
 
 #if CLEM_AUDIO_DIAGNOSTICS
-  glu->diag_dt_ns += clem_calc_ns_step_from_clocks(dt_clocks, clocks->ref_step);
-  glu->diag_dt += dt_clocks;
-  if (glu->diag_dt_ns >= CLEM_1SEC_NS) {
-    float scalar = ((float)CLEM_1SEC_NS) / glu->diag_dt_ns;
-    printf("clem_audio: %.01f frames/sec (dt = %u clocks)\n",
-           scalar * glu->diag_delta_frames, glu->diag_dt);
-    glu->diag_delta_frames = 0;
-    glu->diag_dt = 0;
-    glu->diag_dt_ns = 0;
-  }
+    glu->diag_dt_ns += clem_calc_ns_step_from_clocks(dt_clocks, clocks->ref_step);
+    glu->diag_dt += dt_clocks;
+    if (glu->diag_dt_ns >= CLEM_1SEC_NS) {
+        float scalar = ((float)CLEM_1SEC_NS) / glu->diag_dt_ns;
+        printf("clem_audio: %.01f frames/sec (dt = %u clocks)\n", scalar * glu->diag_delta_frames,
+               glu->diag_dt);
+        glu->diag_delta_frames = 0;
+        glu->diag_dt = 0;
+        glu->diag_dt_ns = 0;
+    }
 #endif
 
-  glu->ts_last_frame = clocks->ts;
+    glu->ts_last_frame = clocks->ts;
 }
 
-void clem_sound_write_switch(struct ClemensDeviceAudio *glu, uint8_t ioreg,
-                             uint8_t value) {
-  switch (ioreg) {
-  case CLEM_MMIO_REG_AUDIO_CTL:
-    clem_ensoniq_write_ctl(&glu->doc, value);
-    glu->volume = (value & CLEM_AUDIO_CTL_VOLUME_MASK);
-    break;
-  case CLEM_MMIO_REG_AUDIO_DATA:
-    clem_ensoniq_write_data(&glu->doc, value);
-    break;
-  case CLEM_MMIO_REG_AUDIO_ADRLO:
-    glu->doc.address &= 0xff00;
-    glu->doc.address |= value;
-    glu->doc.ram_read_cntr = 0;
-    break;
-  case CLEM_MMIO_REG_AUDIO_ADRHI:
-    glu->doc.address &= 0x00ff;
-    glu->doc.address |= ((unsigned)(value) << 8);
-    glu->doc.ram_read_cntr = 0;
-    break;
-  case CLEM_MMIO_REG_SPKR:
-    glu->a2_speaker = !glu->a2_speaker;
-    break;
-  }
-}
-
-uint8_t clem_sound_read_switch(struct ClemensDeviceAudio *glu, uint8_t ioreg,
-                               uint8_t flags) {
-  uint8_t result = 0x00;
-  switch (ioreg) {
-  case CLEM_MMIO_REG_AUDIO_CTL:
-    result = clem_ensoniq_read_ctl(&glu->doc, flags);
-    result |= glu->volume;
-    break;
-  case CLEM_MMIO_REG_AUDIO_DATA:
-    result = clem_ensoniq_read_data(&glu->doc, flags);
-    break;
-  case CLEM_MMIO_REG_AUDIO_ADRLO:
-    result = (uint8_t)(glu->doc.address & 0x00ff);
-    break;
-  case CLEM_MMIO_REG_AUDIO_ADRHI:
-    result = (uint8_t)((glu->doc.address >> 8) & 0x00ff);
-    break;
-  case CLEM_MMIO_REG_SPKR:
-    if (!CLEM_IS_IO_NO_OP(flags)) {
-      glu->a2_speaker = !glu->a2_speaker;
+void clem_sound_write_switch(struct ClemensDeviceAudio *glu, uint8_t ioreg, uint8_t value) {
+    switch (ioreg) {
+    case CLEM_MMIO_REG_AUDIO_CTL:
+        clem_ensoniq_write_ctl(&glu->doc, value);
+        glu->volume = (value & CLEM_AUDIO_CTL_VOLUME_MASK);
+        break;
+    case CLEM_MMIO_REG_AUDIO_DATA:
+        clem_ensoniq_write_data(&glu->doc, value);
+        break;
+    case CLEM_MMIO_REG_AUDIO_ADRLO:
+        glu->doc.address &= 0xff00;
+        glu->doc.address |= value;
+        glu->doc.ram_read_cntr = 0;
+        break;
+    case CLEM_MMIO_REG_AUDIO_ADRHI:
+        glu->doc.address &= 0x00ff;
+        glu->doc.address |= ((unsigned)(value) << 8);
+        glu->doc.ram_read_cntr = 0;
+        break;
+    case CLEM_MMIO_REG_SPKR:
+        glu->a2_speaker = !glu->a2_speaker;
+        break;
     }
-    result = 0x00;
-    break;
-  default:
-    result = 0x00;
-    break;
-  }
-  return result;
+}
+
+uint8_t clem_sound_read_switch(struct ClemensDeviceAudio *glu, uint8_t ioreg, uint8_t flags) {
+    uint8_t result = 0x00;
+    switch (ioreg) {
+    case CLEM_MMIO_REG_AUDIO_CTL:
+        result = clem_ensoniq_read_ctl(&glu->doc, flags);
+        result |= glu->volume;
+        break;
+    case CLEM_MMIO_REG_AUDIO_DATA:
+        result = clem_ensoniq_read_data(&glu->doc, flags);
+        break;
+    case CLEM_MMIO_REG_AUDIO_ADRLO:
+        result = (uint8_t)(glu->doc.address & 0x00ff);
+        break;
+    case CLEM_MMIO_REG_AUDIO_ADRHI:
+        result = (uint8_t)((glu->doc.address >> 8) & 0x00ff);
+        break;
+    case CLEM_MMIO_REG_SPKR:
+        if (!CLEM_IS_IO_NO_OP(flags)) {
+            glu->a2_speaker = !glu->a2_speaker;
+        }
+        result = 0x00;
+        break;
+    default:
+        result = 0x00;
+        break;
+    }
+    return result;
 }

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -405,6 +405,8 @@ ClemensBackend::main(ClemensBackendState &backendState,
                     break;
                 }
             }
+            if (!machine_.cpu.enabled)
+                break;
         }
 
         if (stepsRemaining_.has_value() && *stepsRemaining_ == 0) {
@@ -565,6 +567,11 @@ std::optional<unsigned> ClemensBackend::checkHitBreakpoint() {
             break;
         case ClemensBackendBreakpoint::IRQ:
             if (machine_.cpu.state_type == kClemensCPUStateType_IRQ) {
+                return index;
+            }
+            break;
+        case ClemensBackendBreakpoint::BRK:
+            if (machine_.cpu.regs.IR == CLEM_OPC_BRK) {
                 return index;
             }
             break;

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -496,6 +496,8 @@ ClemensBackend::main(ClemensBackendState &backendState,
     backendState.bpBufferEnd = breakpoints_.data() + breakpoints_.size();
     if (hitBreakpoint.has_value()) {
         backendState.bpHitIndex = *hitBreakpoint;
+    } else {
+        backendState.bpHitIndex = std::nullopt;
     }
 
     backendState.diskDrives = diskDrives_.data();

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -3,6 +3,7 @@
 
 #include "cinek/ckdebug.h"
 
+#include "clem_host_shared.hpp"
 #include "fmt/core.h"
 
 #include <cassert>
@@ -267,6 +268,7 @@ void ClemensCommandQueue::addBreakpoint(const ClemensBackendBreakpoint &breakpoi
                               breakpoint.type == ClemensBackendBreakpoint::DataRead ? "r"
                               : breakpoint.type == ClemensBackendBreakpoint::Write  ? "w"
                               : breakpoint.type == ClemensBackendBreakpoint::IRQ    ? "i"
+                              : breakpoint.type == ClemensBackendBreakpoint::BRK    ? "b"
                                                                                     : "",
                               breakpoint.address);
     cmd.type = Command::AddBreakpoint;
@@ -286,6 +288,8 @@ bool ClemensCommandQueue::addBreakpoint(ClemensCommandQueueListener &listener,
         bp.type = ClemensBackendBreakpoint::Write;
     } else if (type == "i") {
         bp.type = ClemensBackendBreakpoint::IRQ;
+    } else if (type == "b") {
+        bp.type = ClemensBackendBreakpoint::BRK;
     } else {
         bp.type = ClemensBackendBreakpoint::Execute;
     }

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -3643,14 +3643,15 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
     }
     if (operand == "list") {
         //  TODO: granular listing based on operand
-        static const char *bpType[] = {"unknown", "execute", "data-read", "write", "IRQ"};
+        static const char *bpType[] = {"unknown", "execute", "data-read", "write", "IRQ", "BRK"};
         if (breakpoints_.empty()) {
             CLEM_TERM_COUT.print(TerminalLine::Info, "No breakpoints defined.");
             return;
         }
         for (size_t i = 0; i < breakpoints_.size(); ++i) {
             auto &bp = breakpoints_[i];
-            if (bp.type == ClemensBackendBreakpoint::IRQ) {
+            if (bp.type == ClemensBackendBreakpoint::IRQ ||
+                bp.type == ClemensBackendBreakpoint::BRK) {
                 CLEM_TERM_COUT.format(TerminalLine::Info, "bp #{}: {}", i, bpType[bp.type]);
             } else {
                 CLEM_TERM_COUT.format(TerminalLine::Info, "bp #{}: {:02X}/{:04X} {}", i,
@@ -3690,6 +3691,7 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
         breakpoint.type = ClemensBackendBreakpoint::BRK;
         breakpoint.address = 0x0;
         backendQueue_.addBreakpoint(breakpoint);
+        return;
     } else {
         breakpoint.type = ClemensBackendBreakpoint::Execute;
     }

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -3585,6 +3585,7 @@ void ClemensFrontend::cmdHelp(std::string_view operand) {
     CLEM_TERM_COUT.print(TerminalLine::Info,
                          "b]reak erase,<index>        - remove breakpoint with index");
     CLEM_TERM_COUT.print(TerminalLine::Info, "b]reak irq                  - break on IRQ");
+    CLEM_TERM_COUT.print(TerminalLine::Info, "b]reak brk                  - break on IRQ");
     CLEM_TERM_COUT.print(TerminalLine::Info, "b]reak list                 - list all breakpoints");
     CLEM_TERM_COUT.print(TerminalLine::Info,
                          "g]et <register>             - return the current value of a register");
@@ -3685,6 +3686,10 @@ void ClemensFrontend::cmdBreak(std::string_view operand) {
         breakpoint.address = 0x0;
         backendQueue_.addBreakpoint(breakpoint);
         return;
+    } else if (operand == "brk") {
+        breakpoint.type = ClemensBackendBreakpoint::BRK;
+        breakpoint.address = 0x0;
+        backendQueue_.addBreakpoint(breakpoint);
     } else {
         breakpoint.type = ClemensBackendBreakpoint::Execute;
     }

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -34,7 +34,7 @@ struct ClemensBackendDiskDriveState {
 };
 
 struct ClemensBackendBreakpoint {
-    enum Type { Undefined, Execute, DataRead, Write, IRQ };
+    enum Type { Undefined, Execute, DataRead, Write, IRQ, BRK };
     Type type;
     uint32_t address;
 };


### PR DESCRIPTION
This is not supported per specification.   Added code to prevent writes to the OIR and the ADC registers.  

Also added support for breakpoints when a BRK is detected (which helped to find this issue.)

Found the issue while running Bards Tale IIgs, where following the title screen the BT code writes to all DOC registers (0x00 - 0xE2).   The emulator allowed writing into the OIR which can set/clear IRQs  which can cause unintended results.  

In this case the BT app had cleared its Sound IRQ handler, set the DOC registers and reenabled interrupts.  Because the OIR was cleared to 0x00 by the app, this signaled an IRQ (bit 7 low).   The system IRQ handler detects this as a DOC IRQ request and calls the default sound IRQ handler (as reset by the BT app.).  

This led to an 'Unhandled Sound Interrupt' failure screen.