### PR TITLE
Adaptive Fast Mode Emulation

### DIFF
--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -28,21 +28,28 @@ struct ClemensRunSampler {
 
     double sampledFramesPerSecond;
 
-    cinek::CircularBuffer<std::chrono::microseconds, 120> frameTimeBuffer;
+    cinek::CircularBuffer<std::chrono::microseconds, 60> frameTimeBuffer;
 
     clem_clocks_time_t sampledClocksSpent;
     uint64_t sampledCyclesSpent;
-    cinek::CircularBuffer<clem_clocks_duration_t, 120> clocksBuffer;
-    cinek::CircularBuffer<clem_clocks_duration_t, 120> cyclesBuffer;
+    cinek::CircularBuffer<clem_clocks_duration_t, 60> clocksBuffer;
+    cinek::CircularBuffer<clem_clocks_duration_t, 60> cyclesBuffer;
 
-    double sampledEmulatorSpeedMhz;
-    double actualEmulatorSpeedMhz;
+    double sampledMachineSpeedMhz;
     std::chrono::high_resolution_clock::time_point lastFrameTimePoint;
+
+    double avgVBLsPerFrame;
+    cinek::CircularBuffer<unsigned, 30> vblsBuffer;
+    unsigned sampledVblsSpent;
+    unsigned emulatorVblsPerFrame;
+    bool fastModeEnabled;
 
     ClemensRunSampler();
 
     void reset();
     void update(clem_clocks_duration_t clocksSpent, unsigned cyclesSpent);
+    void enableFastMode();
+    void disableFastMode();
 };
 
 //  TODO: Machine type logic could be subclassed into an Apple2GS backend, etc.

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -800,7 +800,8 @@ void ClemensFrontend::copyState(const ClemensBackendState &state) {
     frameWriteState_.mmioWasInitialized = state.mmioWasInitialized;
     frameWriteState_.isTracing = state.isTracing;
     frameWriteState_.isRunning = state.isRunning;
-    frameWriteState_.emulatorSpeedMhz = state.emulatorSpeedMhz;
+    frameWriteState_.machineSpeedMhz = state.machineSpeedMhz;
+    frameWriteState_.avgVBLsPerFrame = state.avgVBLsPerFrame;
     frameWriteState_.emulatorClock.ts = state.machine->tspec.clocks_spent;
     frameWriteState_.emulatorClock.ref_step = CLEM_CLOCKS_MEGA2_CYCLE;
     //  copy over component state as needed
@@ -1881,7 +1882,13 @@ void ClemensFrontend::doMachineDiagnosticsDisplay() {
     ImGui::TableNextColumn();
     ImGui::Text("RUN");
     ImGui::TableNextColumn();
-    ImGui::Text("%3.3f mhz", frameReadState_.emulatorSpeedMhz);
+    if (lastCommandState_.isFastEmulationOn) {
+        ImGui::Text("%1.3f (x%3.1f)", frameReadState_.machineSpeedMhz,
+                    frameReadState_.avgVBLsPerFrame);
+
+    } else {
+        ImGui::Text("%1.3f mhz", frameReadState_.machineSpeedMhz);
+    }
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
     ImGui::TextUnformatted("");
@@ -1892,7 +1899,7 @@ void ClemensFrontend::doMachineDiagnosticsDisplay() {
     unsigned minutes = (emulatorTime % 3600000) / 60000;
     unsigned seconds = ((emulatorTime % 3600000) % 60000) / 1000;
     unsigned milliseconds = ((emulatorTime % 3600000) % 60000) % 1000;
-    ImGui::Text("%02u:%02u:%02u.%03u", hours, minutes, seconds, milliseconds);
+    ImGui::Text("%02u:%02u:%02u.%01u", hours, minutes, seconds, milliseconds);
     ImGui::EndTable();
 }
 

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -209,7 +209,8 @@ class ClemensFrontend : public ClemensHostView {
         std::array<ClemensBackendDiskDriveState, CLEM_SMARTPORT_DRIVE_LIMIT> smartDrives;
         std::array<std::string, CLEM_CARD_SLOT_COUNT> cards;
 
-        float emulatorSpeedMhz;
+        float machineSpeedMhz;
+        float avgVBLsPerFrame;
         ClemensClock emulatorClock;
 
         Clemens65C816 cpu;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -159,7 +159,8 @@ struct ClemensBackendState {
     uint8_t ioPageValues[256]; // 0xc000 - 0xc0ff
     uint8_t debugMemoryPage;
 
-    float emulatorSpeedMhz;
+    float machineSpeedMhz;
+    float avgVBLsPerFrame;
     bool fastEmulationOn;
 
     // valid if a debugMessage() command was issued from the frontend


### PR DESCRIPTION
Use the current FPS to estimate how many vertical blanks can be executed per emulator frame.   This value will increase over time until actual worker frame-rate dips before ~30fps.  

The idea is that we want to run at least 2 VBLs per 1/30th of a second and increase the value if the worker can handle it.  

This gauge calculation may change over time if it isn't a good enough value to measure actual emulator performance (based on perception, and any reported issues.)

So far have seem about 75 - 100 mhz ( x50 when loading GS/OS while the drive is active) on an M2.

Yes, profiling is on the roadmap.  Definitely can do better.