### PR TITLE
Send epoch time adjusted for timezone to the RTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Inside the project directory execute the following.
 ```
 cmake -B build -DCMAKE_BUILD_TYPE=<Debug|RelWithDbgInfo|Release> -DBUILD_TESTING=OFF
 cmake --build build --config <Debug|RelWithDbgInfo|Release>
-cp build-run/clemens_iigs/clemens_iigs <your_selected_install_directory>
+cp build/host/clemens_iigs <your_selected_install_directory>
 ```
 
 ### Windows

--- a/clem_shared.h
+++ b/clem_shared.h
@@ -13,12 +13,18 @@ typedef uint8_t *(*ClemensSerializerAllocateCb)(unsigned, void *);
 /** A bit confusing... used for calculating our system clock.  These values
  *  are relative to each other.
  *
- *  The clocks per mega2 cycle value will always be the largest.
- *
+ *  The clocks per mega2 cycle (PHI0) value will always be the largest.
+ *  Yet since most time calculations in the emulator are done with fixed point-like
+ *  math, the aim is to keep the clocks count per cycle high enough for fixed
+ *  math to work with unsigned 32-bit numbers.
+ *  
+ *  Based on this, care should be taken when attempting to emulate a 8mhz machine
+ *  in the future - though most I/O is performed using PHI0 cycles.
+ * 
  *  If you divide the CLEM_CLOCKS_PHI0_CYCLE by the CLEM_CLOCKS_PHI2_FAST_CYCLE
  *  the value will be the effective maximum clock speed in Mhz of the CPU.
  */
-#define CLEM_CLOCKS_14MHZ_CYCLE     100U                           // 14.318 Mhz
+#define CLEM_CLOCKS_14MHZ_CYCLE     200U                           // 14.318 Mhz
 #define CLEM_CLOCKS_PHI2_FAST_CYCLE (CLEM_CLOCKS_14MHZ_CYCLE * 5)  // 2.864  Mhz
 #define CLEM_CLOCKS_PHI0_CYCLE      (CLEM_CLOCKS_14MHZ_CYCLE * 14) // 1.023  Mhz
 

--- a/host/cinek/ckdefs.h
+++ b/host/cinek/ckdefs.h
@@ -42,7 +42,7 @@
 /**@{*/
 
 #ifdef _MSC_VER
-#define CK_COMPILER_ 1
+#define CK_COMPILER_MSVC 1
 #else
 #define CK_COMPILER_MSVC 0
 #endif

--- a/host/cinek/ckdefs.h
+++ b/host/cinek/ckdefs.h
@@ -42,7 +42,7 @@
 /**@{*/
 
 #ifdef _MSC_VER
-#define CK_COMPILER_MSVC 1
+#define CK_COMPILER_ 1
 #else
 #define CK_COMPILER_MSVC 0
 #endif

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -42,7 +42,8 @@ int get_local_epoch_time_delta_in_seconds() {
     time_t time_raw = time(NULL);
     time_t time_utc;
 #if CK_COMPILER_MSVC
-    split_time_utc_ptr = gmtime_s(&time_raw, &split_time_utc);
+    gmtime_s(&split_time_utc, &time_raw);
+    split_time_utc_ptr = &split_time_utc;
 #else
     split_time_utc_ptr = gmtime_r(&time_raw, &split_time_utc);
 #endif

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -45,9 +45,9 @@
 #elif defined(CLEMENS_PLATFORM_LINUX)
 #define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT ""
 #elif defined(CLEMENS_PLATFORM_MACOS)
-#define CLEM_HOST_JOYSTICK_PROVIDER_GAMECONTROLLER  "gamecontroller"
-#define CLEM_HOST_JOYSTICK_PROVIDER_HIDIOKIT  "hid-iokit"
-#define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT CLEM_HOST_JOYSTICK_PROVIDER_GAMECONTROLLER
+#define CLEM_HOST_JOYSTICK_PROVIDER_GAMECONTROLLER "gamecontroller"
+#define CLEM_HOST_JOYSTICK_PROVIDER_HIDIOKIT       "hid-iokit"
+#define CLEM_HOST_JOYSTICK_PROVIDER_DEFAULT        CLEM_HOST_JOYSTICK_PROVIDER_GAMECONTROLLER
 #endif
 
 #ifdef __cplusplus
@@ -80,7 +80,7 @@ void clem_host_platform_init();
 
 /**
  * @brief Reverses clem_host_platform_init()
- * 
+ *
  */
 void clem_host_platform_terminate();
 


### PR DESCRIPTION
Uses only C runtime library calls to achieve this per machine frame.  If for some reason this has performance issues, then should call this once a second instead of once per emulation VBL.