### PR TITLE
Changed power-off to shutdown the application

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(clemens_iigs PRIVATE -Wall -Wextra -Wno-missing-field-initializers -pedantic)
-    target_compile_options(clemens_iigs PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fno-exceptions -fno-rtti>)
+    target_compile_options(clemens_iigs PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-fno-exceptions -fno-rtti>)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         # GCC 8 doesn't link the fs library even with C++17 enabled
         target_link_libraries(clemens_iigs PRIVATE $<$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>:stdc++fs>)

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -91,7 +91,7 @@ class ClemensFrontend : public ClemensHostView {
     void cmdBreak(std::string_view operand);
     void cmdRun(std::string_view operand);
     void cmdReboot(std::string_view operand);
-    void cmdPower(std::string_view operand);
+    void cmdShutdown(std::string_view operand);
     void cmdReset(std::string_view operand);
     void cmdDisk(std::string_view operand);
     void cmdStep(std::string_view operand);
@@ -336,7 +336,7 @@ class ClemensFrontend : public ClemensHostView {
         Help,
         RebootEmulator,
         StartingEmulator,
-        NoEmulator
+        ShutdownEmulator
     };
     void setGUIMode(GUIMode guiMode);
 

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -76,13 +76,13 @@ typedef struct {
  * a change to perform any platform specific initialization not handled by
  * the cross-platform application framework used.
  */
-void clem_host_platform_init();
+void clem_host_platform_init(void);
 
 /**
  * @brief Reverses clem_host_platform_init()
  *
  */
-void clem_host_platform_terminate();
+void clem_host_platform_terminate(void);
 
 /**
  * @brief Returns the current processor the local thread is running on
@@ -91,7 +91,7 @@ void clem_host_platform_terminate();
  *
  * @return unsigned
  */
-unsigned clem_host_get_processor_number();
+unsigned clem_host_get_processor_number(void);
 
 /**
  * @brief Generates a UUID using the preferred OS method
@@ -144,7 +144,7 @@ unsigned clem_joystick_poll(ClemensHostJoystick *joysticks);
  * @brief Terminates the active joystick system.
  *
  */
-void clem_joystick_close_devices();
+void clem_joystick_close_devices(void);
 
 #ifdef __cplusplus
 }

--- a/host/clem_l10n.cpp
+++ b/host/clem_l10n.cpp
@@ -5,6 +5,7 @@ namespace ClemensL10N {
 #include "strings/clem_hotkeys.inl"
 #include "strings/clem_welcome.inl"
 
+const char *kExitMessage[] = {"Any unsaved progress will be lost.\nDo you want to exit?"};
 const char *kMouseLock[] = {"Click in View to lock mouse input"};
 const char *kViewInput[] = {"Move mouse into view for key input"};
 

--- a/host/clem_l10n.hpp
+++ b/host/clem_l10n.hpp
@@ -5,6 +5,8 @@
 
 namespace ClemensL10N {
 
+extern const char *kExitMessage[];
+
 extern const char *kWelcomeText[];
 extern const char *kGSKeyboardCommands[];
 extern const char *kMouseLock[];

--- a/host/platform/host_linux.c
+++ b/host/platform/host_linux.c
@@ -231,7 +231,7 @@ static int _clem_joystick_evdev_normalize_value(int value, struct ClemensEvdevAx
     return (int)(scalar * CLEM_HOST_JOYSTICK_AXIS_DELTA);
 }
 
-static void _clem_joystick_evdev_clear_devices() {
+static void _clem_joystick_evdev_clear_devices(void) {
     unsigned i;
     for (i = 0; i < CLEM_HOST_JOYSTICK_LIMIT; ++i) {
         _clem_joystick_evdev_close(&s_joysticks[i]);
@@ -243,7 +243,7 @@ static void _clem_joystick_evdev_clear_devices() {
 //  specific device and the device enumeration couldn't find that device.
 //  If so, then this function is called again to enumerate all valid devices
 //
-void _clem_joystick_evdev_enum_devices() {
+void _clem_joystick_evdev_enum_devices(void) {
     DIR *dir;
     struct dirent *entry;
     size_t prefix_len = strlen(CLEM_HOST_EVDEV_PREFIX);

--- a/host/platform/host_linux.c
+++ b/host/platform/host_linux.c
@@ -23,7 +23,7 @@
 #include <uuid/uuid.h>
 
 //  seems to be a reliable way to call getcpu() regardless of glibc/distribution
-static inline unsigned local_getcpu() {
+static inline unsigned local_getcpu(void) {
 #ifdef SYS_getcpu
     int cpu, status;
     status = syscall(SYS_getcpu, &cpu, NULL, NULL);
@@ -33,18 +33,18 @@ static inline unsigned local_getcpu() {
 #endif
 }
 
-void clem_host_platform_init() {}
+void clem_host_platform_init(void) {}
 
-void clem_host_platform_terminate() {}
+void clem_host_platform_terminate(void) {}
 
-unsigned clem_host_get_processor_number() { return local_getcpu(); }
+unsigned clem_host_get_processor_number(void) { return local_getcpu(); }
 
 void clem_host_uuid_gen(ClemensHostUUID *uuid) {
     assert(sizeof(uuid_t) <= sizeof(uuid->data));
     uuid_generate(uuid->data);
 }
 
-char *get_process_executable_path(char *outpath, size_t* outpath_size) {
+char *get_process_executable_path(char *outpath, size_t *outpath_size) {
     //   TODO: /proc/self/exe
     struct stat file_stat;
     ssize_t bufsz;
@@ -369,4 +369,4 @@ unsigned clem_joystick_poll(ClemensHostJoystick *joysticks) {
     return CLEM_HOST_JOYSTICK_LIMIT;
 }
 
-void clem_joystick_close_devices() { _clem_joystick_evdev_clear_devices(); }
+void clem_joystick_close_devices(void) { _clem_joystick_evdev_clear_devices(); }


### PR DESCRIPTION
Write Protect feature already works with different disk drives.  The change here is to remove the "power off" emulator mode - instead it will exit the application.  This change helps kill two stones:

- In application windows that do not have close widgets (i.e. tiling window managers), this power off can act as a shutdown.
- We don't have to deal with the power off / disk tray issue that originated this PR.