### PR TITLE
Implemented floating bus for switch/read Apple II I/O registers

### DIFF
--- a/app.c
+++ b/app.c
@@ -45,7 +45,8 @@ int main(int argc, char *argv[]) {
     memset(&mmio, 0, sizeof(mmio));
     clemens_init(&machine, 1000, 1000, rom, 256 * 1024, malloc(CLEM_IIGS_BANK_SIZE),
                  malloc(CLEM_IIGS_BANK_SIZE), malloc(CLEM_IIGS_BANK_SIZE * 16), 16);
-    clem_mmio_init(&mmio, &machine.dev_debug, machine.mem.bank_page_map, malloc(2048 * 7), 16);
+    clem_mmio_init(&mmio, &machine.dev_debug, machine.mem.bank_page_map, malloc(2048 * 7), 16,
+                   machine.mem.mega2_bank_map[0],  machine.mem.mega2_bank_map[1);
 
     machine.cpu.pins.resbIn = false;
     machine.resb_counter = 3;

--- a/clem_mmio.h
+++ b/clem_mmio.h
@@ -11,7 +11,7 @@ void clem_mmio_reset(ClemensMMIO *mmio);
 
 void clem_mmio_init(ClemensMMIO *mmio, struct ClemensDeviceDebugger *dev_debug,
                     struct ClemensMemoryPageMap **bank_page_map, void *slot_expansion_rom,
-                    unsigned int fpi_ram_bank_count);
+                    unsigned int fpi_ram_bank_count, uint8_t *e0_bank, uint8_t *e1_bank);
 
 uint8_t clem_mmio_read(ClemensMMIO *mmio, struct ClemensTimeSpec *tspec, uint16_t addr,
                        uint8_t flags, bool *mega2_access);

--- a/clem_mmio_defs.h
+++ b/clem_mmio_defs.h
@@ -175,6 +175,8 @@
 #define CLEM_MMIO_REG_ALTCHARSET_TEST 0x1E
 /** Bit 7: 80 column mode on */
 #define CLEM_MMIO_REG_80COLUMN_TEST 0x1F
+/** Cassette Port (floating bus use only) */
+#define CLEM_MMIO_REG_CASSETTE_PORT_NOP 0x20
 /** Write Bit 7: 1 = monochrome, 0 = color */
 #define CLEM_MMIO_REG_VGC_MONO 0x21
 /** Text: Bits 7-4, background: bits 3-0 color */
@@ -598,8 +600,6 @@
 #define CLEM_ADB_KEY_MOD_STATE_ESCAPE  0x00010000
 
 /** Emulated duration of every 'step' iwm_glu_sync runs. 1.023 / 2 ~ 0.511 */
-#define CLEM_IWM_SYNC_FRAME_NS           (CLEM_MEGA2_CYCLE_NS / 2)
-#define CLEM_IWM_SYNC_FRAME_NS_FAST      (CLEM_MEGA2_CYCLE_NS / 4)
 #define CLEM_IWM_SYNC_CLOCKS_FAST        CLEM_CLOCKS_4MHZ_CYCLE
 #define CLEM_IWM_SYNC_CLOCKS_NORMAL      CLEM_CLOCKS_2MHZ_CYCLE
 #define CLEM_IWM_SYNC_DISK_FRAME_NS      500

--- a/clem_mmio_types.h
+++ b/clem_mmio_types.h
@@ -398,6 +398,12 @@ typedef struct ClemensMMIO {
     struct ClemensMemoryShadowMap fpi_mega2_main_shadow_map;
     struct ClemensMemoryShadowMap fpi_mega2_aux_shadow_map;
 
+    /* Reflected mega2 memory used for MMIO operations that require such access:
+       i.e. floating bus data retrieval
+    */
+    uint8_t *e0_bank;
+    uint8_t *e1_bank;
+
     /* All devices */
     struct ClemensDeviceDebugger *dev_debug;
     struct ClemensVGC vgc;

--- a/clem_shared.h
+++ b/clem_shared.h
@@ -39,7 +39,6 @@ typedef uint8_t *(*ClemensSerializerAllocateCb)(unsigned, void *);
 #define CLEM_14MHZ_CYCLE_NS 70U
 #define CLEM_PHI0_CYCLE_NS  980U
 
-#define CLEM_MEGA2_CYCLE_NS          978
 #define CLEM_MEGA2_CYCLES_PER_SECOND 1023000U
 
 //#define CLEM_CLOCKS_MEGA2_CYCLE 2864U

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -100,6 +100,7 @@ class ClemensBackend : public ClemensCommandQueueListener {
     bool onCommandLoadMachine(std::string path) final;
     bool onCommandRunScript(std::string command) final;
     void onCommandFastDiskEmulation(bool enabled) final;
+    std::string onCommandDebugMessage(std::string msg) final;
 
     std::optional<unsigned> checkHitBreakpoint();
     bool isRunning() const;

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <charconv>
+#include <utility>
 
 //  State affected to translate from the old main() to the new main()
 //  bool isRunning = !stepsRemaining.has_value() || *stepsRemaining > 0;
@@ -116,6 +117,14 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
             } else {
                 listener.onCommandFastDiskEmulation(value == 1);
             }
+            break;
+        }
+        case Command::DebugMessage: {
+            auto msgResponse = listener.onCommandDebugMessage(cmd.operand);
+            if (msgResponse.substr(0, 2) != "OK") {
+                commandFailed = true;
+            }
+            cmd.operand = msgResponse;
             break;
         }
         case Command::Undefined:
@@ -383,6 +392,10 @@ void ClemensCommandQueue::inputMachine(ClemensCommandQueueListener &listener,
 
 void ClemensCommandQueue::enableFastDiskEmulation(bool enable) {
     queue(Command{Command::FastDiskEmulation, fmt::format("{}", enable ? 1 : 0)});
+}
+
+void ClemensCommandQueue::debugMessage(std::string msg) {
+    queue(Command{Command::DebugMessage, std::move(msg)});
 }
 
 void ClemensCommandQueue::queue(const Command &cmd) { queue_.push(cmd); }

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -31,6 +31,7 @@ class ClemensCommandQueueListener {
     virtual bool onCommandLoadMachine(std::string path) = 0;
     virtual bool onCommandRunScript(std::string command) = 0;
     virtual void onCommandFastDiskEmulation(bool enabled) = 0;
+    virtual std::string onCommandDebugMessage(std::string msg) = 0;
 };
 
 class ClemensCommandQueue {
@@ -88,6 +89,8 @@ class ClemensCommandQueue {
     void runScript(std::string command);
     //  Enables fast disk emulation
     void enableFastDiskEmulation(bool enable);
+    //  TODO: remove in place of interpreter commands
+    void debugMessage(std::string msg);
 
   private:
     bool insertDisk(ClemensCommandQueueListener &listener, const std::string_view &inputParam,

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -953,10 +953,6 @@ void ClemensFrontend::copyState(const ClemensBackendState &state) {
         }
     }
 
-    if (!lastCommandState_.message.has_value() && state.message.has_value()) {
-        lastCommandState_.message = cmdMessageFromBackend(*state.message, state.machine);
-    }
-
     if (state.audio.data) {
         auto audioBufferSize = int32_t(state.audio.frame_count * state.audio.frame_stride);
         auto audioBufferRange = lastCommandState_.audioBuffer.forwardSize(audioBufferSize);
@@ -1167,10 +1163,6 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, FrameAppInt
                                       breakpoints_[bpIndex].address & 0xffff);
                 emulatorHasMouseFocus_ = false;
                 lastCommandState_.hitBreakpoint = std::nullopt;
-            }
-            if (lastCommandState_.message.has_value()) {
-                cmdMessageLocal(*lastCommandState_.message);
-                lastCommandState_.message = std::nullopt;
             }
 
             for (size_t driveIndex = 0; driveIndex < frameReadState_.diskDrives.size();
@@ -3519,7 +3511,7 @@ void ClemensFrontend::cmdDump(std::string_view operand) {
     }
     message.pop_back();
     // CK_TODO(DebugMessage : Send Message to thread so it can fill in the data)
-    //  backendQueue_.debugMessage(std::move(message));
+    backendQueue_.debugMessage(std::move(message));
 }
 
 void ClemensFrontend::cmdTrace(std::string_view operand) {
@@ -3579,104 +3571,6 @@ void ClemensFrontend::cmdTrace(std::string_view operand) {
                              "Operation only allowed while tracing is active.");
     }
     backendQueue_.debugProgramTrace(std::string(params[0]), path);
-}
-
-std::string ClemensFrontend::cmdMessageFromBackend(std::string_view message,
-                                                   const ClemensMachine *machine) {
-    auto [params, cmd, paramCount] = gatherMessageParams(message, true);
-    if (cmd == "dump") {
-        unsigned startBank, endBank;
-        if (std::from_chars(params[0].data(), params[0].data() + params[0].size(), startBank, 16)
-                .ec != std::errc{}) {
-            return fmt::format("FAIL:{} {},{}", cmd, params[2], params[3]);
-        }
-        if (std::from_chars(params[1].data(), params[1].data() + params[1].size(), endBank, 16)
-                .ec != std::errc{}) {
-            return fmt::format("FAIL:{} {},{}", cmd, params[2], params[3]);
-        }
-        startBank &= 0xff;
-        endBank &= 0xff;
-        lastCommandState_.memoryCaptureAddress = startBank << 16;
-        lastCommandState_.memoryCaptureSize = (endBank - startBank) + 1;
-        lastCommandState_.memoryCaptureSize <<= 16;
-        lastCommandState_.memory = new uint8_t[lastCommandState_.memoryCaptureSize];
-        uint8_t *memoryOut = lastCommandState_.memory;
-        for (; startBank <= endBank; ++startBank, memoryOut += 0x10000) {
-            clemens_out_bin_data(machine, memoryOut, 0x10000, startBank, 0);
-        }
-        return fmt::format("OK:{} {},{}", cmd, params[2], params[3]);
-    }
-
-    return fmt::format("UNK:{}", cmd);
-}
-
-bool ClemensFrontend::cmdMessageLocal(std::string_view message) {
-    auto [params, cmd, paramCount] = gatherMessageParams(message, true);
-    auto setPos = cmd.find(':');
-    std::string_view status;
-    if (setPos != std::string_view::npos) {
-        status = cmd.substr(0, setPos);
-        cmd = cmd.substr(setPos + 1);
-    }
-    if (status == "UNK") {
-        CLEM_TERM_COUT.format(TerminalLine::Error, "Message command '{}' failure.", cmd);
-        return false;
-    } else if (status == "FAIL") {
-        std::string paramLine;
-        for (auto &param : params) {
-            paramLine += param;
-            paramLine.push_back(',');
-        }
-        paramLine.pop_back();
-        CLEM_TERM_COUT.format(TerminalLine::Error, "Message '{}' error with params {}.", cmd,
-                              paramLine);
-        return false;
-    } else if (cmd == "dump") {
-        bool isOk = true;
-        auto outPath = std::filesystem::path(diskTracesRootPath_) / params[0];
-        std::ios_base::openmode flags = std::ios_base::out | std::ios_base::binary;
-        std::ofstream outstream(outPath, flags);
-        if (outstream.is_open()) {
-            if (params[1] == "bin") {
-                outstream.write((char *)lastCommandState_.memory,
-                                lastCommandState_.memoryCaptureSize);
-                outstream.close();
-            } else {
-                constexpr unsigned kHexByteCountPerLine = 64;
-                char hexDump[kHexByteCountPerLine * 2 + 8 + 1];
-                unsigned adrBegin = lastCommandState_.memoryCaptureAddress;
-                unsigned adrEnd =
-                    lastCommandState_.memoryCaptureAddress + lastCommandState_.memoryCaptureSize;
-                uint8_t *memoryOut = lastCommandState_.memory;
-                while (adrBegin < adrEnd) {
-                    snprintf(hexDump, sizeof(hexDump), "%06X: ", adrBegin);
-                    clemens_out_hex_data_from_memory(hexDump + 8, memoryOut,
-                                                     kHexByteCountPerLine * 2, adrBegin);
-                    hexDump[sizeof(hexDump) - 1] = '\n';
-                    outstream.write(hexDump, sizeof(hexDump));
-                    adrBegin += 0x40;
-                    memoryOut += 0x40;
-                }
-                outstream.close();
-            }
-        }
-        if (outstream.fail()) {
-            CLEM_TERM_COUT.format(TerminalLine::Error, "Dump memory failed to open output file {}",
-                                  outPath.string());
-            isOk = false;
-        } else {
-            CLEM_TERM_COUT.format(TerminalLine::Info, "Dump memory to file {}", outPath.string());
-        }
-        delete[] lastCommandState_.memory;
-        lastCommandState_.memory = nullptr;
-        lastCommandState_.memoryCaptureAddress = 0;
-        lastCommandState_.memoryCaptureSize = 0;
-        return isOk;
-    } else {
-        CLEM_TERM_COUT.format(TerminalLine::Error, "Message command '{}' unrecogized.", cmd);
-        return false;
-    }
-    return false;
 }
 
 void ClemensFrontend::cmdSave(std::string_view operand) {

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -98,8 +98,6 @@ class ClemensFrontend : public ClemensHostView {
     void cmdLog(std::string_view operand);
     void cmdDump(std::string_view operand);
     void cmdTrace(std::string_view operand);
-    std::string cmdMessageFromBackend(std::string_view operand, const ClemensMachine *machine);
-    bool cmdMessageLocal(std::string_view operand);
     void cmdSave(std::string_view operand);
     void cmdLoad(std::string_view operand);
     void cmdGet(std::string_view operand);
@@ -248,9 +246,6 @@ class ClemensFrontend : public ClemensHostView {
         LogOutputNode *logNodeTail = nullptr;
         LogInstructionNode *logInstructionNode = nullptr;
         LogInstructionNode *logInstructionNodeTail = nullptr;
-        uint32_t memoryCaptureAddress = 0;
-        uint32_t memoryCaptureSize = 0;
-        uint8_t *memory = nullptr;
         cinek::ByteBuffer audioBuffer;
         bool isFastEmulationOn;
     };

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -118,7 +118,8 @@ struct ClemensBackendCommand {
         SaveMachine,
         LoadMachine,
         RunScript,
-        FastDiskEmulation
+        FastDiskEmulation,
+        DebugMessage
     };
     Type type = Undefined;
     std::string operand;

--- a/host/clem_interpreter.hpp
+++ b/host/clem_interpreter.hpp
@@ -34,6 +34,8 @@ class ClemensInterpreter {
         Chain,
         // assignment(identifier, value)
         Assignment,
+        // command
+        Command,
         // identifies a variable or attribute
         Identifier,
         //  always regard as a decimal value
@@ -93,6 +95,7 @@ class ClemensInterpreter {
     ParseResult parseStatement(std::string_view script);
     ParseResult parseAssignment(std::string_view script);
     ParseResult parseExpression(std::string_view script);
+    ParseResult parseCommand(std::string_view script);
     ParseResult parseNumberOperand(std::string_view script);
     ParseResult parseIdentifier(std::string_view script);
     ParseResult parseNumber(std::string_view script);


### PR DESCRIPTION
Discovered this block of code in Bards Table IIGS that generates random stats.   Discovered that random stat generation was broken.  Often the game returned the same stat rolls over and over differed only by class selection. 

```
 117 | 00 | 3836 | ( 4)  LDA $384F      | PC=3839, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=BC, X=00, Y=00, 10110001
 118 | 00 | 3839 | ( 2)  TAX            | PC=383A, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=BC, X=BC, Y=00, 10110001
 119 | 00 | 383A | ( 4)  ADC $00, X     | PC=383C, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=28, X=BC, Y=00, 00110001
 120 | 00 | 383C | ( 4)  ADC $C000      | PC=383F, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=5A, X=BC, Y=00, 00110000
 121 | 00 | 383F | ( 4)  ADC $C057      | PC=3842, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=5A, X=BC, Y=00, 00110000
 122 | 00 | 3842 | ( 4)  ADC $C050      | PC=3845, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=5A, X=BC, Y=00, 00110000
 123 | 00 | 3845 | ( 4)  ADC $C054      | PC=3848, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=5A, X=BC, Y=00, 00110000
 124 | 00 | 3848 | ( 4)  STA $384F      | PC=384B, PBR=00, DBR=00, S=01FC, D=0000, e=0, A=5A, X=BC, Y=00, 00110000
```
Some of the I/O switches used above were expected to have values.   The emulator naively always returns 0 for them.  After some exhaustive documentation / apple 2 group list searches, found that A2 emulators implemented "floating bus" emulation.    Floating bus is one of those many interesting quirks of Apple II circuit logic described in detail in an article linked to inside `clem_mmio.c`. 

Basically some I/O switch-only registers when read return the value of the current video byte being scanned for display.   This is due to how the 65xxx architectures read memory on the first half of a cycle.   If there's nothing loaded onto the bus from RAM/ROM/FPI/Mega II, this video byte is what's left.

Apparently the Mega II also emulates this as pointed out in a comparison found on the Apple //e card [Gemini IC vs Mega II](http://apple2.guidero.us/doku.php/%E2%80%8Bmg_notes/iie_card/gemini_vs_megaii).   It appears to only affect Apple II modes and not the GS specific ones.

This implementation isn't the most efficient as there's a lot of logic inside each of these reads.  Hopefully being limited to just a set of I/O switches shouldn't affect performance that much.