### PR TITLE
Load snapshots when powering on the emulator

### DIFF
--- a/host/cinek/buffer.cpp
+++ b/host/cinek/buffer.cpp
@@ -10,23 +10,32 @@
 
 namespace cinek {
 
-  //  specialization to ensure alignment based on malloc style behavior
-  template<>
-  auto BufferBase<uint8_t>::forwardSize(int32_t sz) -> Range
-  {
+//  specialization to ensure alignment based on malloc style behavior
+template <> auto BufferBase<uint8_t>::forwardSize(int32_t sz) -> Range {
+    return forwardSize(sz, true);
+}
+
+template <> auto BufferBase<uint8_t>::forwardSize(int32_t sz, bool align) -> Range {
     Range range;
-    constexpr uintptr_t kAlign = CK_ARCH_MALLOC_ALIGN_BYTES;
-    size_t offset = (uint8_t*)CK_ALIGN_PTR(tail_, kAlign) - tail_;
-    // TODO: Reevaluate this equation - seems we'll always allocate another
-    // pool block if our remaining bytes == memSize, since offset in that
-    // case will return 'align'.
-    if (offset == kAlign) offset = 0;
+    size_t offset;
+
+    if (align) {
+        constexpr uintptr_t kAlign = CK_ARCH_MALLOC_ALIGN_BYTES;
+        offset = (uint8_t *)CK_ALIGN_PTR(tail_, kAlign) - tail_;
+        // TODO: Reevaluate this equation - seems we'll always allocate another
+        // pool block if our remaining bytes == memSize, since offset in that
+        // case will return 'align'.
+        if (offset == kAlign)
+            offset = 0;
+    } else {
+        offset = 0;
+    }
 
     range.first = tail_ + offset;
     range.second = range.first + sz;
     if (range.second > limit_ || range.second < head_) {
-      CK_ASSERT(false);
-      range.second = limit_;
+        CK_ASSERT(false);
+        range.second = limit_;
     }
     tail_ = range.second;
     /* - DO NOT ZERO OUT memory
@@ -35,24 +44,23 @@ namespace cinek {
     }
     */
     return range;
-  }
+}
 
-  template<>
-  auto BufferBase<char>::forwardSize(int32_t sz) -> Range
-  {
+template <> auto BufferBase<char>::forwardSize(int32_t sz) -> Range {
     Range range;
     constexpr uintptr_t kAlign = CK_ARCH_ALIGN_BYTES;
-    size_t offset = (char*)CK_ALIGN_PTR(tail_, kAlign) - tail_;
+    size_t offset = (char *)CK_ALIGN_PTR(tail_, kAlign) - tail_;
     // TODO: Reevaluate this equation - seems we'll always allocate another
     // pool block if our remaining bytes == memSize, since offset in that
     // case will return 'align'.
-    if (offset == kAlign) offset = 0;
+    if (offset == kAlign)
+        offset = 0;
 
     range.first = tail_ + offset;
     range.second = range.first + sz;
     if (range.second > limit_ || range.second < head_) {
-      CK_ASSERT(false);
-      range.second = limit_;
+        CK_ASSERT(false);
+        range.second = limit_;
     }
     tail_ = range.second;
     /* - DO NOT ZERO OUT memory
@@ -61,6 +69,6 @@ namespace cinek {
     }
     */
     return range;
-  }
-
 }
+
+} // namespace cinek

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -328,6 +328,7 @@ class ClemensFrontend : public ClemensHostView {
         Setup,
         Emulator,
         LoadSnapshot,
+        LoadSnapshotAfterPowerOn,
         SaveSnapshot,
         Help,
         RebootEmulator,

--- a/host/clem_imgui.cpp
+++ b/host/clem_imgui.cpp
@@ -276,42 +276,18 @@ std::string Markdown(std::string_view markdown) {
     return std::string(tempLinkBuffer);
 }
 
-auto ROMFileBrowser(int width, int height, const std::string &dataDirectory)
-    -> ROMFileBrowserResult {
-    ROMFileBrowserResult result;
-    result.type = ROMFileBrowserResult::Continue;
-    if (!ImGuiFileDialog::Instance()->IsOpened("Select ROM)")) {
-        ImGuiFileDialog::Instance()->OpenDialog("Select ROM", "Select a ROM", ".*", ".", 1, nullptr,
-                                                ImGuiFileDialogFlags_Modal);
-    }
-    if (ImGuiFileDialog::Instance()->Display(
-            "Select ROM", ImGuiWindowFlags_NoCollapse,
-            ImVec2(std::max(width * 0.75f, 640.0f), std::max(height * 0.75f, 480.0f)),
-            ImVec2(width, height))) {
-
-        if (ImGuiFileDialog::Instance()->IsOk()) {
-            std::error_code errc;
-            auto filePath = std::filesystem::path(ImGuiFileDialog::Instance()->GetFilePathName());
-            auto fileName = ImGuiFileDialog::Instance()->GetCurrentFileName();
-            auto destinationPath = std::filesystem::path(dataDirectory) / fileName;
-            if (filePath == destinationPath) {
-                result.filename = fileName;
-                result.type = ROMFileBrowserResult::Ok;
-            } else if (std::filesystem::copy_file(filePath, destinationPath,
-                                                  std::filesystem::copy_options::overwrite_existing,
-                                                  errc)) {
-                result.filename = fileName;
-                result.type = ROMFileBrowserResult::Ok;
-            } else {
-                result.filename = fileName;
-                result.type = ROMFileBrowserResult::Error;
-            }
-        } else {
-            result.type = ROMFileBrowserResult::Cancel;
-        }
-        ImGuiFileDialog::Instance()->Close();
-    }
-    return result;
+void PushStyleButtonEnabled() {
+    ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 255, 0, 192));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(128, 255, 128, 255));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(255, 255, 255, 255));
 }
+
+void PushStyleButtonDisabled() {
+    ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(64, 64, 64, 255));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(64, 64, 64, 255));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(64, 64, 64, 255));
+}
+
+void PopStyleButton() { ImGui::PopStyleColor(3); }
 
 } // namespace ClemensHostImGui

--- a/host/clem_imgui.hpp
+++ b/host/clem_imgui.hpp
@@ -34,13 +34,10 @@ bool IconButton(const char *strId, ImTextureID texId, const ImVec2 &size);
 //  returns the link to navigate to if selected
 std::string Markdown(std::string_view markdown);
 
-struct ROMFileBrowserResult {
-    enum Type { Ok, Cancel, Error, Continue };
-    std::string filename;
-    Type type;
-};
-
-ROMFileBrowserResult ROMFileBrowser(int width, int height, const std::string &dataDirectory);
+//  styling hooks for common widgets
+void PushStyleButtonEnabled();
+void PushStyleButtonDisabled();
+void PopStyleButton();
 
 } // namespace ClemensHostImGui
 

--- a/host/clem_ui_load_snapshot.hpp
+++ b/host/clem_ui_load_snapshot.hpp
@@ -8,8 +8,7 @@ class ClemensCommandQueue;
 class ClemensLoadSnapshotUI {
   public:
     bool isStarted() const;
-    void start(ClemensCommandQueue &backend, const std::string &snapshotDir,
-               bool isEmulatorRunning);
+    void start(ClemensCommandQueue &backend, const std::string &snapshotDir);
     bool frame(float width, float height, ClemensCommandQueue &backend);
     void stop(ClemensCommandQueue &backend);
     void succeeded();
@@ -20,8 +19,8 @@ class ClemensLoadSnapshotUI {
 
     Mode mode_ = Mode::None;
     std::string snapshotDir_;
-    bool interruptedExecution_ = false;
     char snapshotName_[128];
+    bool resumeExecutionOnExit_;
 };
 
 #endif


### PR DESCRIPTION
Allow loading of snapshots when the emulator is off.   Upon loading a snapshot:

1. the emulator is turned on
2. the user is prompted for a snapshot
3. if the snapshot is loaded, execution continues at the point of the snapshot
4. option for the user to break execution after loading a snapshot.