### PR TITLE
ADB Self-Test Pass (Diagnostic 9)

### DIFF
--- a/clem_rtc.c
+++ b/clem_rtc.c
@@ -272,9 +272,7 @@ void clem_rtc_command(struct ClemensDeviceRTC *rtc, clem_clocks_time_t ts, unsig
         case CLEM_RTC_EXECUTE_WRITE_CLOCK:
             if (has_recv_started) {
                 if (is_write_cmd) {
-                    CLEM_LOG("RTC: write clock data: %02X", rtc->data_c033);
                     _clem_rtc_clock_write(rtc, rtc->data_c033);
-                    //  _clem_rtc_bram_write(rtc, rtc->data_c033);
                 } else {
                     CLEM_WARN("RTC: unexpected ctrl $02X, state: %02X", rtc->ctl_c034, rtc->state);
                 }

--- a/clem_scc.c
+++ b/clem_scc.c
@@ -77,7 +77,7 @@
     - Most interrupt features that aren't needed on the IIGS
 */
 
-#define CLEM_SCC_DEBUG
+// #define CLEM_SCC_DEBUG
 
 #ifdef CLEM_SCC_DEBUG
 #define CLEM_SCC_LOG(...) CLEM_LOG(__VA_ARGS__)

--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -487,10 +487,13 @@ void clemens_emulate_mmio(ClemensMachine *clem, ClemensMMIO *mmio) {
     clem_gameport_sync(&mmio->dev_adb.gameport, &clock);
 
     /* background execution of some async devices on the 60 hz timer */
-    /* TODO: ADB should occur on the VBL */
+    /* TODO: ADB autopoll should occur on the VBL, also mega2 cycles aren't 1us (close!)
+       ADB should use clocks like all other subsystems (ADB was the second subsystem written
+       for this emulator!) */
+    clem_adb_glu_sync(&mmio->dev_adb, &m2mem, delta_mega2_cycles);
+
     while (mmio->timer_60hz_us >= CLEM_MEGA2_CYCLES_PER_60TH) {
         clem_timer_sync(&mmio->dev_timer, CLEM_MEGA2_CYCLES_PER_60TH);
-        clem_adb_glu_sync(&mmio->dev_adb, &m2mem, CLEM_MEGA2_CYCLES_PER_60TH);
         if (clem->resb_counter <= 0 && mmio->dev_adb.keyb.reset_key) {
             /* TODO: move into its own utility */
             clem->resb_counter = 2;


### PR DESCRIPTION
- Update ADB every MMIO frame to pump the command processor rapidly (otherwise extremely slow ADB memory commands.)
- Return proper checksum based on ROM version
- Self tests pass up to 0x0b02 (VBL IRQ)