### PR TITLE
Fix CLRVBLINT and INTTYPE register read/reset to pass IRQ diagnostic

### DIFF
--- a/clem_mmio_defs.h
+++ b/clem_mmio_defs.h
@@ -383,6 +383,7 @@
 /** Timer (internal, C023 partial) device flags */
 #define CLEM_MMIO_TIMER_1SEC_ENABLED 0x00000040
 #define CLEM_MMIO_TIMER_QSEC_ENABLED 0x00000100
+#define CLEM_MMIO_TIMER_QSEC_IRQ     0x00010000
 
 /** Used for emulator detection at c04f
  * Apple II Technical Notes #201 (IIgs)

--- a/clem_mmio_types.h
+++ b/clem_mmio_types.h
@@ -307,6 +307,7 @@ struct ClemensVGC {
 
     bool scanline_irq_enable;
     bool vbl_started; /**< Limits VBL IRQ */
+    bool irq_vbl;     /**< Used for C046 INTFLAG and cleared via C047 CLRVBLINT */
 
     uint32_t irq_line; /**< IRQ flags passed to machine */
 };

--- a/clem_timer.c
+++ b/clem_timer.c
@@ -1,15 +1,9 @@
 #include "clem_device.h"
 #include "clem_mmio_defs.h"
 
+void clem_timer_reset(struct ClemensDeviceTimer *timer) { timer->flags = 0; }
 
-void clem_timer_reset(struct ClemensDeviceTimer* timer) {
-    timer->flags = 0;
-}
-
-void clem_timer_sync(
-    struct ClemensDeviceTimer* timer,
-    uint32_t delta_us
-) {
+void clem_timer_sync(struct ClemensDeviceTimer *timer, uint32_t delta_us) {
     timer->irq_1sec_us += delta_us;
     timer->irq_qtrsec_us += delta_us;
 
@@ -23,6 +17,7 @@ void clem_timer_sync(
         timer->irq_qtrsec_us -= CLEM_MEGA2_TIMER_QSEC_US;
         if (timer->flags & CLEM_MMIO_TIMER_QSEC_ENABLED) {
             timer->irq_line |= CLEM_IRQ_TIMER_QSEC;
+            timer->flags |= CLEM_MMIO_TIMER_QSEC_IRQ;
         }
     }
 }

--- a/clem_vgc.c
+++ b/clem_vgc.c
@@ -149,6 +149,7 @@ void clem_vgc_reset(struct ClemensVGC *vgc) {
     vgc->text_bg_color = CLEM_VGC_COLOR_MEDIUM_BLUE;
     vgc->scanline_irq_enable = false;
     vgc->vbl_started = false;
+    vgc->irq_vbl = false;
     vgc->vbl_counter = 0;
 
     for (row = 0; row < CLEM_VGC_SHGR_SCANLINE_COUNT * 16; ++row) {
@@ -254,6 +255,7 @@ void clem_vgc_sync(struct ClemensVGC *vgc, struct ClemensClock *clock, const uin
         if (vgc->v_counter >= CLEM_VGC_VBL_NTSC_LOWER_BOUND && !vgc->vbl_started) {
             if (vgc->mode_flags & CLEM_VGC_ENABLE_VBL_IRQ) {
                 vgc->irq_line |= CLEM_IRQ_VGC_BLANK;
+                vgc->irq_vbl = true;
             }
             vgc->vbl_started = true;
         }

--- a/serializer.c
+++ b/serializer.c
@@ -39,6 +39,7 @@ struct ClemensSerializerRecord kVGC[] = {
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensVGC, text_language),
     CLEM_SERIALIZER_RECORD_BOOL(struct ClemensVGC, scanline_irq_enable),
     CLEM_SERIALIZER_RECORD_BOOL(struct ClemensVGC, vbl_started),
+    CLEM_SERIALIZER_RECORD_BOOL(struct ClemensVGC, irq_vbl),
     CLEM_SERIALIZER_RECORD_UINT32(struct ClemensVGC, irq_line),
     CLEM_SERIALIZER_RECORD_EMPTY()};
 


### PR DESCRIPTION
- Passes Self Test 0x0b for Interrupts (VBL, Scanline, RTC timers)