### PR TITLE
Main loop and audio fixes

### DIFF
--- a/emulator_mmio.c
+++ b/emulator_mmio.c
@@ -241,6 +241,8 @@ ClemensVideo *clemens_get_graphics_video(ClemensVideo *video, ClemensMachine *cl
     bool use_page_2 = (mmio->mmap_register & CLEM_MEM_IO_MMAP_TXTPAGE2) &&
                       !(mmio->mmap_register & CLEM_MEM_IO_MMAP_80COLSTORE);
     video->vbl_counter = vgc->vbl_counter;
+    video->rgb_buffer_size = 0;
+    video->rgb = NULL;
     video->has_640_mode_scanlines = false;
     if (vgc->mode_flags & CLEM_VGC_SUPER_HIRES) {
         video->format = kClemensVideoFormat_Super_Hires;

--- a/host/clem_audio.cpp
+++ b/host/clem_audio.cpp
@@ -61,7 +61,7 @@ void ClemensAudioDevice::stop() {
 unsigned ClemensAudioDevice::getAudioFrequency() const { return saudio_sample_rate(); }
 unsigned ClemensAudioDevice::getBufferStride() const { return queuedFrameStride_; }
 
-unsigned ClemensAudioDevice::queue(ClemensAudio &audio, float /*deltaTime */) {
+unsigned ClemensAudioDevice::queue(const ClemensAudio &audio) {
     if (!audio.frame_count || !queuedFrameBuffer_)
         return 0;
 

--- a/host/clem_audio.hpp
+++ b/host/clem_audio.hpp
@@ -16,7 +16,7 @@ class ClemensAudioDevice {
 
     void start();
     void stop();
-    unsigned queue(ClemensAudio &audio, float deltaTime);
+    unsigned queue(const ClemensAudio &audio);
 
   private:
     static void mixAudio(float *buffer, int num_frames, int num_channels, void *user_data);

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -289,6 +289,10 @@ auto ClemensBackend::step(ClemensCommandQueue& commands) -> ClemensCommandQueue:
     return result;
 }
 
+ClemensAudio ClemensBackend::renderAudioFrame() {
+    return GS_->renderAudio();
+}
+
 void ClemensBackend::post(ClemensBackendState &backendState) {
     auto &machine = GS_->getMachine();
     auto &mmio = GS_->getMMIO();

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -1,5 +1,6 @@
 #include "clem_backend.hpp"
 
+#include "clem_command_queue.hpp"
 #include "core/clem_apple2gs.hpp"
 #include "core/clem_apple2gs_config.hpp"
 #include "core/clem_disk_asset.hpp"
@@ -193,19 +194,14 @@ bool ClemensBackend::isRunning() const {
 #endif
 #endif
 
-ClemensCommandQueue::DispatchResult
-ClemensBackend::main(ClemensBackendState &backendState,
-                     const ClemensCommandQueue::ResultBuffer &commandResults,
-                     PublishStateDelegate delegate) {
+auto ClemensBackend::step(ClemensCommandQueue& commands) -> ClemensCommandQueue::DispatchResult {
     constexpr clem_clocks_time_t kClocksPerSecond =
         1e9 * CLEM_CLOCKS_14MHZ_CYCLE / CLEM_14MHZ_CYCLE_NS;
 
-    std::optional<unsigned> hitBreakpoint;
+    logOutput_.clear();
+    loggedInstructions_.clear();
 
     bool isMachineRunning = isRunning();
-
-    ClemensAppleIIGS::Frame frame{};
-
     if (isMachineRunning && GS_->isOk()) {
         //  Run the emulator in either 'step' or 'run' mode.
         //
@@ -259,7 +255,7 @@ ClemensBackend::main(ClemensBackendState &backendState,
             }
 
             if (!breakpoints_.empty()) {
-                if ((hitBreakpoint = checkHitBreakpoint()).has_value()) {
+                if ((hitBreakpoint_ = checkHitBreakpoint()).has_value()) {
                     stepsRemaining_ = 0;
                     break;
                 }
@@ -283,13 +279,24 @@ ClemensBackend::main(ClemensBackendState &backendState,
         clocksInSecondPeriod_ += machine.tspec.clocks_spent - lastClocksSpent;
     }
 
+    auto result = commands.dispatchAll(*this);
+    //  if we're starting a run, reset the sampler so framerate can be calculated correctly
+    if (isMachineRunning != isRunning()) {
+        if (!isMachineRunning) {
+            runSampler_.reset();
+        }
+    }
+    return result;
+}
+
+void ClemensBackend::post(ClemensBackendState &backendState) {
     auto &machine = GS_->getMachine();
     auto &mmio = GS_->getMMIO();
 
     backendState.machine = &machine;
     backendState.mmio = &mmio;
     backendState.fps = runSampler_.sampledFramesPerSecond;
-    backendState.isRunning = isMachineRunning;
+    backendState.isRunning = isRunning();
     if (programTrace_ != nullptr) {
         backendState.isTracing = true;
         backendState.isIWMTracing = programTrace_->isIWMLoggingEnabled();
@@ -299,7 +306,7 @@ ClemensBackend::main(ClemensBackendState &backendState,
     }
     backendState.mmioWasInitialized = clemens_is_mmio_initialized(&mmio);
 
-    backendState.frame = &GS_->getFrame(frame);
+    GS_->getFrame(backendState.frame);
     if (gsConfigUpdated_) {
         backendState.config = gsConfig_;
         gsConfigUpdated_ = false;
@@ -310,8 +317,8 @@ ClemensBackend::main(ClemensBackendState &backendState,
     backendState.logBufferEnd = logOutput_.data() + logOutput_.size();
     backendState.bpBufferStart = breakpoints_.data();
     backendState.bpBufferEnd = breakpoints_.data() + breakpoints_.size();
-    if (hitBreakpoint.has_value()) {
-        backendState.bpHitIndex = *hitBreakpoint;
+    if (hitBreakpoint_.has_value()) {
+        backendState.bpHitIndex = *hitBreakpoint_;
     } else {
         backendState.bpHitIndex = std::nullopt;
     }
@@ -331,25 +338,10 @@ ClemensBackend::main(ClemensBackendState &backendState,
     backendState.avgVBLsPerFrame = runSampler_.avgVBLsPerFrame;
     backendState.fastEmulationOn = runSampler_.emulatorVblsPerFrame > 1;
 
-    ClemensCommandQueue commands;
-    delegate(commands, commandResults, backendState);
-
-    GS_->finishFrame(frame);
-
-    logOutput_.clear();
-    loggedInstructions_.clear();
-    backendState.reset();
-
-    auto result = commands.dispatchAll(*this);
-    //  if we're starting a run, reset the sampler so framerate can be calculated correctly
-    if (isMachineRunning != isRunning()) {
-        if (!isMachineRunning) {
-            runSampler_.reset();
-        }
-    }
-
-    return result;
+    GS_->finishFrame(backendState.frame);
+    hitBreakpoint_ = std::nullopt;
 }
+
 
 #if defined(__GNUC__)
 #if !defined(__clang__)

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -87,6 +87,8 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
 
     //  Executes a single emulator timeslice
     ClemensCommandQueue::DispatchResult step(ClemensCommandQueue& commands);
+    //  Obtain current audio frame (following calls to step())
+    ClemensAudio renderAudioFrame();
     //  Populate a backend state
     void post(ClemensBackendState& backendState);
 

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -85,14 +85,10 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     ClemensBackend(std::string romPath, const Config &config);
     virtual ~ClemensBackend();
 
-    using PublishStateDelegate =
-        std::function<void(ClemensCommandQueue &, const ClemensCommandQueue::ResultBuffer &,
-                           const ClemensBackendState &)>;
-
     //  Executes a single emulator timeslice
-    ClemensCommandQueue::DispatchResult
-    main(ClemensBackendState &backendState, const ClemensCommandQueue::ResultBuffer &commandResults,
-         PublishStateDelegate delegate);
+    ClemensCommandQueue::DispatchResult step(ClemensCommandQueue& commands);
+    //  Populate a backend state
+    void post(ClemensBackendState& backendState);
 
     //  these methods do not queue instructions to execute on the runner
     //  and must be executed instead on the runner thread.  They are made public
@@ -158,6 +154,7 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     std::vector<ClemensBackendOutputText> logOutput_;
     std::vector<ClemensBackendBreakpoint> breakpoints_;
     std::vector<ClemensBackendExecutedInstruction> loggedInstructions_;
+    std::optional<unsigned> hitBreakpoint_;
 
     uint64_t nextTraceSeq_;
     std::unique_ptr<ClemensProgramTrace> programTrace_;

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -43,6 +43,7 @@ class ClemensCommandQueue {
 
     void queue(ClemensCommandQueue &other);
     bool isEmpty() const { return queue_.isEmpty(); }
+    size_t getSize() const { return queue_.size(); }
 
     //  execute all commands
     DispatchResult dispatchAll(ClemensCommandQueueListener &listener);

--- a/host/clem_frame_state.hpp
+++ b/host/clem_frame_state.hpp
@@ -19,7 +19,7 @@ struct ClemensBackendState {
     bool isIWMTracing;
     bool mmioWasInitialized;
 
-    ClemensAppleIIGSFrame *frame;
+    ClemensAppleIIGSFrame frame;
 
     unsigned hostCPUID;
     int logLevel;
@@ -117,7 +117,6 @@ struct LastCommandState {
     LogOutputNode *logNodeTail = nullptr;
     LogInstructionNode *logInstructionNode = nullptr;
     LogInstructionNode *logInstructionNodeTail = nullptr;
-    cinek::ByteBuffer audioBuffer;
     bool isFastEmulationOn;
 };
 

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -73,8 +73,6 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
 
     //  the backend state delegate is run on a separate thread and notifies
     //  when a frame has been published
-    void backendStateDelegate(const ClemensBackendState &state,
-                              const ClemensCommandQueue::ResultBuffer &results);
     void processBackendResult(const ClemensBackendResult &result);
 
     void doEmulatorInterface(ImVec2 anchor, ImVec2 dimensions,

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -68,6 +68,7 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
     void startBackend();
     void runBackend(std::unique_ptr<ClemensBackend> backend);
     void stopBackend();
+    void syncBackend(bool copyState);
     bool isBackendRunning() const;
 
     //  the backend state delegate is run on a separate thread and notifies
@@ -122,6 +123,8 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
 
     ClemensDisplay display_;
     ClemensAudioDevice audio_;
+    ClemensBackendState backendState_;
+    ClemensCommandQueue::DispatchResult backendCommandResutls_;
 
     std::unique_ptr<ClemensBackend> backend_;
     int logLevel_;
@@ -138,7 +141,7 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
     std::thread backendThread_;
     ClemensCommandQueue backendQueue_;
     ClemensCommandQueue stagedBackendQueue_;
-    double uiFrameTimeDelta_;
+    double dtEmulatorNextUpdateInterval_;
 
     // These counters are used to identify unique frames between the two threads
     // frameSeqNo is updated per executed emulator frame.  The UI thread will
@@ -153,9 +156,7 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
     std::condition_variable readyForFrame_;
     std::mutex frameMutex_;
 
-    cinek::FixedStack frameWriteMemory_;
     cinek::FixedStack frameReadMemory_;
-    ClemensFrame::FrameState frameWriteState_;
     ClemensFrame::FrameState frameReadState_;
     ClemensFrame::LastCommandState lastCommandState_;
     cinek::ByteBuffer thisFrameAudioBuffer_;

--- a/host/clem_host.mm
+++ b/host/clem_host.mm
@@ -24,9 +24,9 @@
 
 @implementation ClemensHostSystem {
   struct ClemensHostInterop *hostInterop;
-  NSMenuItem* powerMenuItem;
-  NSMenuItem* rebootMenuItem;
-  NSMenuItem* shutdownMenuItem;
+  NSMenuItem *powerMenuItem;
+  NSMenuItem *rebootMenuItem;
+  NSMenuItem *shutdownMenuItem;
 }
 
 + (id)instance {
@@ -117,7 +117,7 @@
   [menubar setSubmenu:filemenu forItem:fileMenuItem];
 
   // Edit Menu
-    NSMenu *editmenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+  NSMenu *editmenu = [[NSMenu alloc] initWithTitle:@"Edit"];
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Paste Text Input"
                                         action:@selector(menuPasteText:)
                                  keyEquivalent:@""];
@@ -130,22 +130,22 @@
   [menubar setSubmenu:editmenu forItem:editMenuItem];
 
   // Machine Menu
-    NSMenu *machmenu = [[NSMenu alloc] initWithTitle:@"Machine"];
+  NSMenu *machmenu = [[NSMenu alloc] initWithTitle:@"Machine"];
   powerMenuItem = [[NSMenuItem alloc] initWithTitle:@"Power"
-                                        action:@selector(menuPower:)
-                                 keyEquivalent:@""];
+                                             action:@selector(menuPower:)
+                                      keyEquivalent:@""];
   [powerMenuItem setTarget:self];
   [machmenu addItem:powerMenuItem];
 
   rebootMenuItem = [[NSMenuItem alloc] initWithTitle:@"Reboot"
-                                        action:@selector(menuReboot:)
-                                 keyEquivalent:@""];
+                                              action:@selector(menuReboot:)
+                                       keyEquivalent:@""];
   [rebootMenuItem setTarget:self];
   [machmenu addItem:rebootMenuItem];
 
   shutdownMenuItem = [[NSMenuItem alloc] initWithTitle:@"Shutdown"
-                                        action:@selector(menuShutdown:)
-                                 keyEquivalent:@""];
+                                                action:@selector(menuShutdown:)
+                                         keyEquivalent:@""];
   [shutdownMenuItem setTarget:self];
   [machmenu addItem:shutdownMenuItem];
 
@@ -153,7 +153,6 @@
                                                 action:nil
                                          keyEquivalent:@""];
   [menubar setSubmenu:machmenu forItem:machMenuItem];
-
 
   // View Menu
   //    Pause or Run
@@ -168,21 +167,21 @@
 }
 
 - (void)update {
-    if (hostInterop->poweredOn) {
-        [rebootMenuItem setEnabled:TRUE];
-                [rebootMenuItem setAction:@selector(menuReboot:)];
-        [shutdownMenuItem setEnabled:TRUE];
-                        [shutdownMenuItem setAction:@selector(menuShutdown:)];
-        [powerMenuItem setEnabled:FALSE];
-        [powerMenuItem setAction:nil];
-    } else {
-        [rebootMenuItem setEnabled:FALSE];
-                        [rebootMenuItem setAction:nil];
-        [shutdownMenuItem setEnabled:FALSE];
-                                [shutdownMenuItem setAction:nil];
-        [powerMenuItem setEnabled:TRUE];
-         [powerMenuItem setAction:@selector(menuPower:)];
-    }
+  if (hostInterop->poweredOn) {
+    [rebootMenuItem setEnabled:TRUE];
+    [rebootMenuItem setAction:@selector(menuReboot:)];
+    [shutdownMenuItem setEnabled:TRUE];
+    [shutdownMenuItem setAction:@selector(menuShutdown:)];
+    [powerMenuItem setEnabled:FALSE];
+    [powerMenuItem setAction:nil];
+  } else {
+    [rebootMenuItem setEnabled:FALSE];
+    [rebootMenuItem setAction:nil];
+    [shutdownMenuItem setEnabled:FALSE];
+    [shutdownMenuItem setAction:nil];
+    [powerMenuItem setEnabled:TRUE];
+    [powerMenuItem setAction:@selector(menuPower:)];
+  }
 }
 
 @end
@@ -194,8 +193,6 @@ void clemens_host_init(ClemensHostInterop *interop) {
   interop->nativeMenu = true;
 }
 
-void clemens_host_update() {
-    [[ClemensHostSystem instance] update];
-}
+void clemens_host_update() { [[ClemensHostSystem instance] update]; }
 
 void clemens_host_terminate() {}

--- a/host/clem_ui_settings.cpp
+++ b/host/clem_ui_settings.cpp
@@ -24,8 +24,8 @@ void ClemensSettingsUI::start() {
     romFileExists_ = !config_.romFilename.empty() && std::filesystem::exists(config_.romFilename);
 }
 
-void ClemensSettingsUI::frame() {
-
+bool ClemensSettingsUI::frame() {
+    bool startMachine = false;
     switch (mode_) {
     case Mode::None:
         break;
@@ -92,6 +92,12 @@ void ClemensSettingsUI::frame() {
         }
         ImGui::EndTable();
 
+        ImGui::NewLine();
+        if (ImGui::Button("Power On", ImVec2(ImGui::GetFont()->GetCharAdvance('W') * 20, ImGui::GetTextLineHeight() * 2))) {
+            startMachine = true;
+        }
+        ImGui::NewLine();
+
         ImGui::SeparatorText(CLEM_L10N_LABEL(kSettingsTabEmulation));
         ImGui::BeginTable("Emulation", 2, ImGuiTableFlags_SizingStretchSame);
         ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed,
@@ -128,4 +134,6 @@ void ClemensSettingsUI::frame() {
         break;
     }
     }
+
+    return startMachine;
 }

--- a/host/clem_ui_settings.hpp
+++ b/host/clem_ui_settings.hpp
@@ -11,7 +11,7 @@ class ClemensSettingsUI {
     void start();
     void stop();
 
-    void frame();
+    bool frame();
 
   private:
     ClemensConfiguration &config_;

--- a/host/core/clem_apple2gs.hpp
+++ b/host/core/clem_apple2gs.hpp
@@ -78,6 +78,11 @@ class ClemensAppleIIGS {
     void input(const ClemensInputEvent &input);
     //  Executes a single emulation step
     ResultFlags stepMachine();
+    //  Render current audio frame.  This will not advance the audio frame buffer
+    //  which is done by finishFrame().  This should be done after rendering a sufficient number 
+    //  of 'frames' - which may be VBL frames, or whatever the application decides
+    //  should be an audio 'frame'
+    ClemensAudio renderAudio();
     //  Retrieves frame information for display/audio/disks
     Frame &getFrame(Frame &frame);
     //  Finishes the frame


### PR DESCRIPTION
Emulator now tries to run at a 60hz framerate.    For example, systems that can run at 120hz run an emulator frame every 2 host UI frames.   A major fix that addresses a bug where with the changes to the emulator main loop completed months ago, the emulator could run at faster that 60hz potentially if the UI frame rate was higher.

Audio is also now queued in the emulator worker thread instead of on the UI thread, which should reduce the lock frequency on the UI thread.

