### PR TITLE
Binary Load and Save of GS memory 

### DIFF
--- a/host/clem_audio.cpp
+++ b/host/clem_audio.cpp
@@ -149,10 +149,11 @@ void ClemensAudioDevice::mixClemensAudio(float *audioOut, int num_frames, int nu
     //  clemens generates an output mix == to the hardware mixer to avoid having
     //  to upsample here.
     uint32_t queuedAvailable = queuedFrameTail_ - queuedFrameHead_;
+    uint32_t remainingFrames = num_frames;
+    float *frameOut = audioOut;
     if (queuedAvailable != 0) {
         auto frameLimit = std::min(queuedAvailable, (uint32_t)num_frames);
         const uint8_t *inData = queuedFrameBuffer_ + queuedFrameHead_ * queuedFrameStride_;
-        float *frameOut = audioOut;
 
         for (uint32_t frameIndex = 0; frameIndex < frameLimit; ++frameIndex) {
             auto *frameIn = reinterpret_cast<const float *>(inData);
@@ -162,6 +163,12 @@ void ClemensAudioDevice::mixClemensAudio(float *audioOut, int num_frames, int nu
             frameOut += num_channels;
         }
         queuedFrameHead_ += frameLimit;
+        remainingFrames -= frameLimit;
+    }
+    for (; remainingFrames > 0; --remainingFrames) {
+        frameOut[0] = 0.0f;
+        frameOut[1] = 0.0f;
+        frameOut += num_channels;
     }
 }
 

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -868,40 +868,43 @@ void ClemensBackend::onCommandSendText(std::string text) {
 bool ClemensBackend::onCommandBinaryLoad(std::string pathname, unsigned address) {
     std::ifstream input(pathname, std::ios_base::binary);
     if (!input.is_open()) {
-        localLog(CLEM_DEBUG_LOG_WARN, "Unable to open {} for binary load.", pathname);
+        localLog(CLEM_DEBUG_LOG_WARN, "Unable to open '{}' for binary load.", pathname);
         return false;
     }
     auto length = input.seekg(0, std::ios_base::seekdir::end).tellg();
     input.seekg(0, std::ios_base::seekdir::beg);
     std::vector<uint8_t> data(length);
     if (input.read((char *)data.data(), data.size()).fail()) {
-        localLog(CLEM_DEBUG_LOG_WARN, "Unable to read {} bytes from {} for binary load.", length,
+        localLog(CLEM_DEBUG_LOG_WARN, "Unable to read {} bytes from '{}' for binary load.", length,
                  pathname);
         return false;
     }
     input.close();
 
-    return GS_->writeDataToMemory(data.data(), address, (unsigned)data.size());
+    bool ok = GS_->writeDataToMemory(data.data(), address, (unsigned)data.size());
+    if (ok) {
+        localLog(CLEM_DEBUG_LOG_INFO, "Loaded {} bytes from '{}'.", length, pathname);
+    }
+    return ok;
 }
 
 bool ClemensBackend::onCommandBinarySave(std::string pathname, unsigned address, unsigned length) {
     std::ofstream output(pathname, std::ios_base::binary);
     if (!output.is_open()) {
-        localLog(CLEM_DEBUG_LOG_WARN, "Unable to open {} for binary write.", pathname);
+        localLog(CLEM_DEBUG_LOG_WARN, "Unable to open '{}' for binary write.", pathname);
         return false;
     }
     std::vector<uint8_t> data(length);
     if (!GS_->readDataFromMemory(data.data(), address, (unsigned)data.size())) {
-        localLog(CLEM_DEBUG_LOG_WARN,
-                 "Unable to read {} bytes from ${:x} for binary save to {}.", length, address,
-                 pathname);
+        localLog(CLEM_DEBUG_LOG_WARN, "Unable to read {} bytes from ${:x} for binary save to '{}'.",
+                 length, address, pathname);
         return false;
     }
     if (output.write((char *)data.data(), data.size()).fail()) {
-        localLog(CLEM_DEBUG_LOG_WARN, "Unable to save {} bytes to {} for binary save.", length,
+        localLog(CLEM_DEBUG_LOG_WARN, "Unable to save {} bytes to '{}' for binary save.", length,
                  pathname);
         return false;
     }
-
+    localLog(CLEM_DEBUG_LOG_INFO, "Saved {} bytes to '{}'.", length, pathname);
     return true;
 }

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -871,8 +871,8 @@ bool ClemensBackend::onCommandBinaryLoad(std::string pathname, unsigned address)
         localLog(CLEM_DEBUG_LOG_WARN, "Unable to open '{}' for binary load.", pathname);
         return false;
     }
-    auto length = input.seekg(0, std::ios_base::seekdir::end).tellg();
-    input.seekg(0, std::ios_base::seekdir::beg);
+    auto length = input.seekg(0, std::ios::end).tellg();
+    input.seekg(0, std::ios::beg);
     std::vector<uint8_t> data(length);
     if (input.read((char *)data.data(), data.size()).fail()) {
         localLog(CLEM_DEBUG_LOG_WARN, "Unable to read {} bytes from '{}' for binary load.", length,

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -508,6 +508,16 @@ bool ClemensBackend::unserialize(const std::string &path) {
 
     auto gs = snapshot.unserialize(
         *this, [&breakpoints](mpack_reader_t *reader, ClemensAppleIIGS &) -> bool {
+            //  detect if this snapshot requires remapping storage paths to the local host
+            //  if platforms, differ then all paths will be remapped
+            //  otherwise check each path and check if the file's parent directory exists
+            //  if not, then mark as -to-remap-
+            //  if any of the paths require remapping, abort here and the frontend should offer
+            //  the option to remap paths - which will be passed to the unserializer on a second
+            //  pass
+
+
+            //  read debug settings
             mpack_expect_map(reader);
             mpack_expect_cstr_match(reader, "breakpoints");
             uint32_t breakpointCount = mpack_expect_array_max(reader, 1024);
@@ -526,6 +536,7 @@ bool ClemensBackend::unserialize(const std::string &path) {
             }
             mpack_done_array(reader);
             mpack_done_map(reader);
+
             return mpack_reader_error(reader) == mpack_ok;
         });
     if (!gs)

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -59,6 +59,7 @@ struct ClemensRunSampler {
 struct ClemensBackendConfig {
     int logLevel;
     std::string dataRootPath;
+    std::string imageRootPath;
     std::string snapshotRootPath;
     std::string traceRootPath;
     std::vector<ClemensBackendBreakpoint> breakpoints;

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -136,6 +136,8 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     void onCommandFastDiskEmulation(bool enabled) final;
     std::string onCommandDebugMessage(std::string msg) final;
     void onCommandSendText(std::string msg) final;
+    bool onCommandBinaryLoad(std::string pathname, unsigned address) final;
+    bool onCommandBinarySave(std::string pathname, unsigned address, unsigned length) final;
 
     //  internal
     bool isRunning() const;

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -136,12 +136,12 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
             break;
         }
         case Command::SaveBinary:
-            if (saveBinary(listener, cmd.operand)) {
+            if (!saveBinary(listener, cmd.operand)) {
                 commandFailed = true;
             }
             break;
         case Command::LoadBinary:
-            if (loadBinary(listener, cmd.operand)) {
+            if (!loadBinary(listener, cmd.operand)) {
                 commandFailed = true;
             }
             break;

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <charconv>
+#include <string_view>
 #include <utility>
 
 //  State affected to translate from the old main() to the new main()
@@ -134,6 +135,16 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
             listener.onCommandSendText(std::move(cmd.operand));
             break;
         }
+        case Command::SaveBinary:
+            if (saveBinary(listener, cmd.operand)) {
+                commandFailed = true;
+            }
+            break;
+        case Command::LoadBinary:
+            if (loadBinary(listener, cmd.operand)) {
+                commandFailed = true;
+            }
+            break;
         case Command::Undefined:
             break;
         }
@@ -425,6 +436,58 @@ void ClemensCommandQueue::inputMachine(ClemensCommandQueueListener &listener,
 #endif
 #endif
 
+bool ClemensCommandQueue::saveBinary(ClemensCommandQueueListener &listener,
+                                     const std::string_view &command) {
+    std::string pathname;
+    unsigned address = 0;
+    unsigned length = 0;
+    auto tokenPos = command.find(',');
+    auto tokenStart = std::string_view::size_type(0);
+    if (tokenPos == std::string_view::npos)
+        return false;
+
+    pathname = command.substr(tokenStart, tokenPos);
+    tokenStart = tokenPos + 1;
+    tokenPos = command.find(',', tokenStart);
+    if (tokenPos == std::string_view::npos)
+        return false;
+
+    std::string_view paramStr = command.substr(tokenStart, tokenPos - tokenStart);
+    if (std::from_chars(paramStr.data(), paramStr.data() + paramStr.size(), address, 16).ec !=
+        std::errc{}) {
+        return false;
+    }
+    tokenStart = tokenPos + 1;
+    paramStr = command.substr(tokenStart);
+    if (std::from_chars(paramStr.data(), paramStr.data() + paramStr.size(), length, 16).ec !=
+        std::errc{}) {
+        return false;
+    }
+
+    return listener.onCommandBinarySave(pathname, address, length);
+}
+
+bool ClemensCommandQueue::loadBinary(ClemensCommandQueueListener &listener,
+                                     const std::string_view &command) {
+    std::string pathname;
+    unsigned address = 0;
+    auto tokenPos = command.find(',');
+    auto tokenStart = std::string_view::size_type(0);
+    if (tokenPos == std::string_view::npos)
+        return false;
+
+    pathname = command.substr(tokenStart, tokenPos);
+    tokenStart = tokenPos + 1;
+   
+    std::string_view paramStr = command.substr(tokenStart);
+    if (std::from_chars(paramStr.data(), paramStr.data() + paramStr.size(), address, 16).ec !=
+        std::errc{}) {
+        return false;
+    }
+   
+    return listener.onCommandBinaryLoad(pathname, address);
+}
+
 void ClemensCommandQueue::enableFastDiskEmulation(bool enable) {
     queue(Command{Command::FastDiskEmulation, fmt::format("{}", enable ? 1 : 0)});
 }
@@ -435,6 +498,15 @@ void ClemensCommandQueue::debugMessage(std::string msg) {
 
 void ClemensCommandQueue::sendText(std::string text) {
     queue(Command{Command::SendText, std::move(text)});
+}
+
+void ClemensCommandQueue::bsave(std::string pathname, unsigned address, unsigned length) {
+    // pathname,address,length (address and length are always hex)
+    queue(Command{Command::SaveBinary, fmt::format("{},{:x},{:x}", pathname, address, length)});
+}
+
+void ClemensCommandQueue::bload(std::string pathname, unsigned address) {
+    queue(Command{Command::LoadBinary, fmt::format("{},{:x}", pathname, address)});
 }
 
 void ClemensCommandQueue::queue(const Command &cmd) { queue_.push(cmd); }

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -34,6 +34,8 @@ class ClemensCommandQueueListener {
     virtual void onCommandFastDiskEmulation(bool enabled) = 0;
     virtual std::string onCommandDebugMessage(std::string msg) = 0;
     virtual void onCommandSendText(std::string text) = 0;
+    virtual bool onCommandBinaryLoad(std::string pathname, unsigned address) = 0;
+    virtual bool onCommandBinarySave(std::string pathname, unsigned address, unsigned length) = 0;
 };
 
 class ClemensCommandQueue {
@@ -98,6 +100,10 @@ class ClemensCommandQueue {
     void debugMessage(std::string msg);
     //  Sends text to the emulator's keyboard queue
     void sendText(std::string text);
+    //  Save binary to disk
+    void bsave(std::string pathname, unsigned address, unsigned length);
+    //  Load binary from disk
+    void bload(std::string pathname, unsigned address);
 
   private:
     bool insertDisk(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
@@ -114,7 +120,9 @@ class ClemensCommandQueue {
     bool delBreakpoint(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
     bool programTrace(ClemensCommandQueueListener &listener, const std::string_view &inputParam);
     bool runScriptCommand(ClemensCommandQueueListener &listener, const std::string_view &command);
-
+    bool saveBinary(ClemensCommandQueueListener &listener, const std::string_view& command);
+    bool loadBinary(ClemensCommandQueueListener &listener, const std::string_view& command);
+    
     using Command = ClemensBackendCommand;
     cinek::CircularBuffer<Command, 16> queue_;
 

--- a/host/clem_debugger.cpp
+++ b/host/clem_debugger.cpp
@@ -12,8 +12,10 @@
 #include <charconv>
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 
 template <typename TBufferType> struct FormatView2 {
@@ -388,7 +390,7 @@ void ClemensDebugger::auxillary(ImVec2 anchor, ImVec2 dimensions) {
     ImGui::SetNextWindowPos(anchor);
     ImGui::SetNextWindowSize(dimensions);
     ImGui::Begin("DebuggerAuxillary", nullptr,
-                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove);
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
     if (frameState_) {
         // float localContentWidth = ImGui::GetWindowContentRegionWidth();
@@ -414,7 +416,7 @@ void ClemensDebugger::cpuStateTable(ImVec2 anchor, ImVec2 dimensions) {
     ImGui::SetNextWindowPos(anchor);
     ImGui::SetNextWindowSize(dimensions);
     ImGui::Begin("CPUAndMachineState", nullptr,
-                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove);
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus);
     ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(kCharSize, 2.0f));
     if (frameState_) {
         auto &regs = frameState_->cpu.regs;
@@ -588,6 +590,8 @@ void ClemensDebugger::executeCommand(std::string_view command) {
         cmdBsave(operand);
     } else if (action == "bload") {
         cmdBload(operand);
+    } else if (action == "cwd") {
+        cmdPwd(operand);
     } else {
         commandQueue_.runScript(std::string(command));
     }
@@ -949,6 +953,16 @@ void ClemensDebugger::cmdBsave(std::string_view operand) {
     commandQueue_.bsave(std::string(params[0]), address, length);
 }
 
+void ClemensDebugger::cmdPwd(std::string_view ) {
+    std::error_code ec{};
+    auto curPath = std::filesystem::current_path(ec);
+    if (ec) {
+        CLEM_TERM_COUT.format(Error, "pwd error {}", ec.message());
+    } else {
+        CLEM_TERM_COUT.print(Info, curPath.string());    
+    }
+}
+
 void ClemensDebugger::cmdHelp(std::string_view operand) {
     if (!operand.empty()) {
         CLEM_TERM_COUT.print(Warn, "Command specific help not yet supported.");
@@ -985,6 +999,8 @@ void ClemensDebugger::cmdHelp(std::string_view operand) {
         Info, "bsave <pathname>,<address>,<length>  - saves binary to file from location in memory");
     CLEM_TERM_COUT.print(
         Info, "bload <pathname>,<address>             - loads binary to address");
+    CLEM_TERM_COUT.print(
+        Info, "pwd                         - current working directory");
 
     CLEM_TERM_COUT.newline();
 }

--- a/host/clem_debugger.hpp
+++ b/host/clem_debugger.hpp
@@ -100,6 +100,8 @@ class ClemensDebugger {
     void cmdSave(std::string_view operand);
     void cmdLoad(std::string_view operand);
     void cmdDump(std::string_view operand);
+    void cmdBload(std::string_view operand);
+    void cmdBsave(std::string_view operand);
 };
 
 class ClemensDebuggerListener {

--- a/host/clem_debugger.hpp
+++ b/host/clem_debugger.hpp
@@ -102,6 +102,7 @@ class ClemensDebugger {
     void cmdDump(std::string_view operand);
     void cmdBload(std::string_view operand);
     void cmdBsave(std::string_view operand);
+    void cmdPwd(std::string_view operand);
 };
 
 class ClemensDebuggerListener {

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -676,6 +676,8 @@ void ClemensFrontend::startBackend() {
     ClemensBackendConfig backendConfig{};
 
     backendConfig.dataRootPath = config_.dataDirectory;
+    backendConfig.imageRootPath =
+        (std::filesystem::path(config_.dataDirectory) / CLEM_HOST_LIBRARY_DIR).string();
     backendConfig.snapshotRootPath = snapshotRootPath_;
     backendConfig.traceRootPath =
         (std::filesystem::path(config_.dataDirectory) / CLEM_HOST_TRACES_DIR).string();
@@ -867,6 +869,12 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, ClemensHost
     case ClemensHostInterop::About:
         setGUIMode(GUIMode::Help);
         break;
+    case ClemensHostInterop::Help:
+        setGUIMode(GUIMode::HelpShortcuts);
+        break;
+    case ClemensHostInterop::DiskHelp:
+        setGUIMode(GUIMode::HelpDisk);
+        break;
     case ClemensHostInterop::LoadSnapshot:
         if (isBackendRunning()) {
             if (!isEmulatorStarting()) {
@@ -929,6 +937,8 @@ auto ClemensFrontend::frame(int width, int height, double deltaTime, ClemensHost
         }
         break;
     case GUIMode::Help:
+    case GUIMode::HelpShortcuts:
+    case GUIMode::HelpDisk:
         doHelpScreen(width, height);
         break;
     case GUIMode::RebootEmulator:
@@ -1280,6 +1290,12 @@ void ClemensFrontend::doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop) {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Help")) {
+            if (ImGui::MenuItem("Keyboard Shortcuts")) {
+                interop.action = ClemensHostInterop::Help;
+            }
+            if (ImGui::MenuItem("Disk Selection")) {
+                interop.action = ClemensHostInterop::DiskHelp;
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("About")) {
                 interop.action = ClemensHostInterop::About;
@@ -1325,32 +1341,6 @@ void ClemensFrontend::doSidePanelLayout(ImVec2 anchor, ImVec2 dimensions) {
                  ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBringToFrontOnFocus);
     doDebuggerQuickbar(quickBarSize.x);
     ImGui::End();
-}
-
-void ClemensFrontend::doUserMenuDisplay(float /* width */) {
-    const ImGuiStyle &style = ImGui::GetStyle();
-    const ImVec2 kIconSize(24.0f, 24.0f);
-    ImGui::Spacing();
-    // ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-    //                     ImVec2(style.ItemSpacing.x * 1.25f, style.ItemSpacing.y));
-    //  Button Group 2
-    ImGui::SameLine();
-
-    ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-    ImGui::SameLine();
-    ClemensHostImGui::PushStyleButtonEnabled();
-    if (ClemensHostImGui::IconButton(
-            "Help", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kHelp), kIconSize)) {
-        setGUIMode(GUIMode::Help);
-    }
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
-        ImGui::SetTooltip("Help");
-    }
-    ClemensHostImGui::PopStyleButton();
-
-    // ImGui::PopStyleVar();
-    ImGui::Spacing();
-    ImGui::Separator();
 }
 
 void ClemensFrontend::doMachinePeripheralDisplay(float /*width */) {
@@ -1556,13 +1546,29 @@ void ClemensFrontend::doInfoStatusLayout(ImVec2 anchor, ImVec2 dimensions, float
 }
 
 void ClemensFrontend::doDebuggerQuickbar(float /*width */) {
-    const ImGuiStyle &style = ImGui::GetStyle();
-    float lineHeight = ImGui::GetWindowHeight() - (style.FramePadding.y + style.FrameBorderSize -
-                                                   style.WindowBorderSize + style.WindowPadding.y) *
-                                                      2;
+    float lineHeight = ImGui::GetTextLineHeight() * 1.25f;
     const ImVec2 kIconSize(lineHeight, lineHeight);
     if (isBackendRunning()) {
         ClemensHostImGui::PushStyleButtonEnabled();
+        ImGui::SameLine();
+
+        if (ClemensHostImGui::IconButton(
+                "Power", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kPowerButton),
+                kIconSize)) {
+            setGUIMode(GUIMode::ShutdownEmulator);
+        }
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
+            ImGui::SetTooltip("Shutdown");
+        }
+        ImGui::SameLine();
+        if (ClemensHostImGui::IconButton(
+                "Reboot", ClemensHostStyle::getImTextureOfAsset(ClemensHostAssets::kPowerCycle),
+                kIconSize)) {
+              rebootInternal();
+        }
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
+            ImGui::SetTooltip("Reboot");
+        }
         ImGui::SameLine();
         if (frameReadState_.isRunning) {
             if (ClemensHostImGui::IconButton(
@@ -1593,7 +1599,11 @@ void ClemensFrontend::doDebuggerQuickbar(float /*width */) {
             config_.setDirty();
         }
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
-            ImGui::SetTooltip("Enter debugger mode");
+            if (config_.hybridInterfaceEnabled) {
+                ImGui::SetTooltip("Enter standard mode");
+            } else {
+                ImGui::SetTooltip("Enter debugger mode");
+            }
         }
         ImGui::SameLine();
         if (ClemensHostImGui::IconButton(
@@ -2958,11 +2968,15 @@ void ClemensFrontend::doHelpScreen(int width, int height) {
                 ClemensHostImGui::Markdown(CLEM_L10N_LABEL(kEmulatorHelp));
                 ImGui::EndTabItem();
             }
-            if (ImGui::BeginTabItem("Hotkeys")) {
+            if (ImGui::BeginTabItem(
+                    "Hotkeys", NULL,
+                    guiMode_ == GUIMode::HelpShortcuts ? ImGuiTabItemFlags_SetSelected : 0)) {
                 ClemensHostImGui::Markdown(CLEM_L10N_LABEL(kGSKeyboardCommands));
                 ImGui::EndTabItem();
             }
-            if (ImGui::BeginTabItem("Disk Selection")) {
+            if (ImGui::BeginTabItem("Disk Selection", NULL,
+                                    guiMode_ == GUIMode::HelpDisk ? ImGuiTabItemFlags_SetSelected
+                                                                  : 0)) {
                 ClemensHostImGui::Markdown(CLEM_L10N_LABEL(kDiskSelectionHelp));
                 ImGui::EndTabItem();
             }
@@ -2974,6 +2988,10 @@ void ClemensFrontend::doHelpScreen(int width, int height) {
         }
 
         ImGui::EndPopup();
+    }
+    if (guiMode_ == GUIMode::HelpShortcuts || guiMode_ == GUIMode::HelpDisk) {
+        //  hacky method to automatically trigger the shortcuts tab from the main menu
+        setGUIMode(GUIMode::Help);
     }
     if (!isOpen) {
         setGUIMode(GUIMode::Emulator);

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -2756,7 +2756,7 @@ void ClemensFrontend::doDebugView(ImVec2 anchor, ImVec2 size) {
     ImGui::SetNextWindowPos(anchor, ImGuiCond_Once);
     ImGui::SetNextWindowSize(size, ImGuiCond_Once);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, IM_COL32(0, 0, 0, 128));
-    if (ImGui::Begin("Debug View", NULL)) {
+    if (ImGui::Begin("Debug View", NULL, 0)) {
         if (ImGui::CollapsingHeader("Stats", ImGuiTreeNodeFlags_DefaultOpen)) {
             ImGui::BeginTable("##Stats", 2);
             {

--- a/host/clem_front.hpp
+++ b/host/clem_front.hpp
@@ -83,7 +83,6 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
 
     void doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop);
     void doSidePanelLayout(ImVec2 anchor, ImVec2 dimensions);
-    void doUserMenuDisplay(float width);
     void doMachinePeripheralDisplay(float width);
     void doDebuggerQuickbar(float width);
     void doInfoStatusLayout(ImVec2 anchor, ImVec2 dimensions, float dividerXPos);
@@ -198,6 +197,8 @@ class ClemensFrontend : public ClemensHostView, ClemensDebuggerListener {
         LoadSnapshotAfterPowerOn,
         SaveSnapshot,
         Help,
+        HelpShortcuts,
+        HelpDisk,
         RebootEmulator,
         StartingEmulator,
         ShutdownEmulator

--- a/host/clem_host.hpp
+++ b/host/clem_host.hpp
@@ -16,6 +16,8 @@ struct ClemensHostInterop {
         Power,
         Shutdown,
         Reboot,
+        Help,
+        DiskHelp,
         About
     } action;
     

--- a/host/clem_host.mm
+++ b/host/clem_host.mm
@@ -74,6 +74,14 @@
   hostInterop->action = ClemensHostInterop::Shutdown;
 }
 
+- (void)menuShortcutsHelp:(id)sender {
+  hostInterop->action = ClemensHostInterop::Help;
+}
+
+- (void)menuDiskHelp:(id)sender {
+  hostInterop->action = ClemensHostInterop::DiskHelp;
+}
+
 //  TODO: localized strings!
 - (void)buildMenus {
   NSMenu *menubar = [NSMenu new];
@@ -153,6 +161,25 @@
                                                 action:nil
                                          keyEquivalent:@""];
   [menubar setSubmenu:machmenu forItem:machMenuItem];
+
+  // Help Menu
+  NSMenu *helpmenu = [[NSMenu alloc] initWithTitle:@"Help"];
+  menuItem = [[NSMenuItem alloc] initWithTitle:@"Keyboard Shortcuts"
+                                             action:@selector(menuShortcutsHelp:)
+                                      keyEquivalent:@""];
+  [menuItem setTarget:self];
+  [helpmenu addItem:menuItem];
+
+  menuItem = [[NSMenuItem alloc] initWithTitle:@"Disk Selection"
+                                             action:@selector(menuDiskHelp:)
+                                      keyEquivalent:@""];
+  [menuItem setTarget:self];
+  [helpmenu addItem:menuItem];
+
+  NSMenuItem *helpMenuItem = [menubar addItemWithTitle:@""
+                                                action:nil
+                                         keyEquivalent:@""];
+  [menubar setSubmenu:helpmenu forItem:helpMenuItem];
 
   // View Menu
   //    Pause or Run

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -25,7 +25,7 @@
 
 #if TARGET_OS_MAC
 #define CLEMENS_PLATFORM_MACOS
-#define CLEMENS_PLATORM_ID "MacOS"
+#define CLEMENS_PLATFORM_ID "MacOS"
 #endif
 
 //  A larger value to cover PATH_MAX but perhaps not all usecases

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -10,6 +10,7 @@
 #define CLEMENS_PLATFORM_WINDOWS
 //  A larger value to cover more edge cases but likely not all
 #define CLEMENS_PATH_MAX 1024
+#define CLEMENS_PLATFORM_ID "Win32"
 
 #elif defined(__linux__)
 
@@ -17,11 +18,14 @@
 //  A larger value to cover PATH_MAX but perhaps not all usecases
 #define CLEMENS_PATH_MAX 4096
 
+#define CLEMENS_PLATFORM_ID "Linux"
+
 #elif defined(__APPLE__)
 #include <TargetConditionals.h>
 
 #if TARGET_OS_MAC
 #define CLEMENS_PLATFORM_MACOS
+#define CLEMENS_PLATORM_ID "MacOS"
 #endif
 
 //  A larger value to cover PATH_MAX but perhaps not all usecases

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -78,7 +78,9 @@ struct ClemensBackendCommand {
         RunScript,
         FastDiskEmulation,
         DebugMessage,
-        SendText
+        SendText,
+        SaveBinary,
+        LoadBinary
     };
     Type type = Undefined;
     std::string operand;

--- a/host/core/clem_apple2gs.cpp
+++ b/host/core/clem_apple2gs.cpp
@@ -604,3 +604,11 @@ unsigned ClemensAppleIIGS::consume_utf8_input(const char* in, const char* inEnd)
     const char* cur = clemens_clipboard_push_utf8_atom(&mmio_, in, inEnd);
     return (unsigned)(cur - in);
 }
+
+bool ClemensAppleIIGS::writeDataToMemory(const uint8_t* data, unsigned address, unsigned length) {
+    return false;
+}
+
+bool ClemensAppleIIGS::readDataFromMemory(uint8_t*data , unsigned address, unsigned length) {
+    return false;
+}

--- a/host/core/clem_apple2gs.hpp
+++ b/host/core/clem_apple2gs.hpp
@@ -93,6 +93,10 @@ class ClemensAppleIIGS {
     void enableOpcodeLogging(bool enable);
     //  Sends a UTF8 character from the input stream
     unsigned consume_utf8_input(const char* in, const char* inEnd);
+    //  Performs batch memory operations on the GS using current memory/IO settings
+    //  (i.e. not binary dump directly from FPI banks)
+    bool writeDataToMemory(const uint8_t* data, unsigned address, unsigned length);
+    bool readDataFromMemory(uint8_t*data , unsigned address, unsigned length);
 
     //  Direct access to emulator state
     ClemensStorageUnit &getStorage() { return storage_; }

--- a/host/core/clem_snapshot.cpp
+++ b/host/core/clem_snapshot.cpp
@@ -2,6 +2,7 @@
 #include "clem_apple2gs.hpp"
 
 #include "clem_disk.h"
+#include "clem_host_platform.h"
 #include "clem_smartport.h"
 #include "external/cross_endian.h"
 #include "external/mpack.h"
@@ -96,6 +97,7 @@ bool ClemensSnapshot::serialize(
     //  metadata
     mpack_build_map(&writer);
     mpack_write_kv(&writer, "timestamp", (int64_t)time(NULL));
+    mpack_write_kv(&writer, "origin", CLEMENS_PLATORM_ID);
     mpack_write_cstr(&writer, "disks");
     mpack_start_array(&writer, kClemensDrive_Count);
     for (unsigned i = 0; i < kClemensDrive_Count; i++) {
@@ -252,12 +254,17 @@ std::pair<ClemensSnapshotMetadata, bool>
 ClemensSnapshot::unserializeMetadata(mpack_reader_t &reader) {
     std::pair<ClemensSnapshotMetadata, bool> result;
     char path[1024];
+    char origin[8];
     uint32_t arraySize;
 
     validation(ValidationStep::Metadata);
     mpack_expect_map(&reader);
     mpack_expect_cstr_match(&reader, "timestamp");
     result.first.timestamp = mpack_expect_i64(&reader);
+    mpack_expect_cstr_match(&reader, "origin");
+    mpack_expect_cstr(&reader, origin, sizeof(origin));
+    origin_ = origin;
+
     mpack_expect_cstr_match(&reader, "disks");
     arraySize = mpack_expect_array_max(&reader, kClemensDrive_Count);
     for (unsigned i = 0; i < arraySize; i++) {

--- a/host/core/clem_snapshot.cpp
+++ b/host/core/clem_snapshot.cpp
@@ -97,7 +97,7 @@ bool ClemensSnapshot::serialize(
     //  metadata
     mpack_build_map(&writer);
     mpack_write_kv(&writer, "timestamp", (int64_t)time(NULL));
-    mpack_write_kv(&writer, "origin", CLEMENS_PLATORM_ID);
+    mpack_write_kv(&writer, "origin", CLEMENS_PLATFORM_ID);
     mpack_write_cstr(&writer, "disks");
     mpack_start_array(&writer, kClemensDrive_Count);
     for (unsigned i = 0; i < kClemensDrive_Count; i++) {

--- a/host/core/clem_snapshot.hpp
+++ b/host/core/clem_snapshot.hpp
@@ -42,6 +42,7 @@ class ClemensSnapshot {
 
   private:
     std::string path_;
+    std::string origin_;
     enum class ValidationStep { None, Header, Metadata, Machine, Custom };
     ValidationStep validationStep_;
     std::string validationData_;


### PR DESCRIPTION
- Allow binary load of a file to GS memory via `bload <pathname>,<address>`
- Allow binary save of a file from GS memory via `bsave <pathname>, <address>, <length>`
- Get current working directory of host via `cwd` command
- Added some more menu options and shortcut buttons