### PR TITLE
ADB features added to address SRQ/TALK keyboard functionality

### DIFF
--- a/clem_adb.c
+++ b/clem_adb.c
@@ -104,6 +104,8 @@
 #define CLEM_ADB_DEVICE_KEYBOARD 0x02
 #define CLEM_ADB_DEVICE_MOUSE    0x03
 
+#define CLEM_ADB_DEVICE_ID_APPLE_EXTENDED_KEYB 0x02
+
 /* ADB Mode Flags */
 #define CLEM_ADB_MODE_AUTOPOLL_KEYB  0x00000001
 #define CLEM_ADB_MODE_AUTOPOLL_MOUSE 0x00000002
@@ -119,16 +121,22 @@ void clem_adb_reset(struct ClemensDeviceADB *adb) {
 
     adb->version = CLEM_ADB_ROM_3; /* TODO - input to reset? */
     adb->mode_flags = CLEM_ADB_MODE_AUTOPOLL_KEYB | CLEM_ADB_MODE_AUTOPOLL_MOUSE;
-    adb->keyb.reset_key = false;
-    adb->keyb.size = 0;
-    adb->mouse.size = 0;
-    adb->mouse.tracking_enabled = false;
-    adb->mouse.valid_clamp_box = false;
-    adb->gameport.ann_mask = 0;
-    adb->gameport.btn_mask[0] = adb->gameport.btn_mask[1] = 0;
     adb->irq_dispatch = 0;
     adb->clipboard.tail = 0;
 
+    //  See ADB_Manager.pdf, 5-12 for the source of these values
+    adb->keyb_reg[3] = (CLEM_ADB_DEVICE_KEYBOARD << 8) | CLEM_ADB_DEVICE_ID_APPLE_EXTENDED_KEYB;
+    adb->keyb.reset_key = false;
+    adb->keyb.size = 0;
+    //  TODO: total guess for mouse device ID - maybe not needed?????
+    adb->mouse_reg[3] = (CLEM_ADB_DEVICE_MOUSE << 8) | 0x01;
+    adb->mouse.size = 0;
+    adb->mouse.tracking_enabled = false;
+    adb->mouse.valid_clamp_box = false;
+    
+    adb->gameport.ann_mask = 0;
+    adb->gameport.btn_mask[0] = adb->gameport.btn_mask[1] = 0;
+    
     for (i = 0; i < 4; ++i) {
         adb->gameport.paddle[i] = CLEM_GAMEPORT_PADDLE_AXIS_VALUE_INVALID;
         adb->gameport.paddle_timer_ns[i] = 0;

--- a/clem_adb.c
+++ b/clem_adb.c
@@ -65,6 +65,7 @@
 #define CLEM_ADB_CMD_READ_MEM           0x09
 #define CLEM_ADB_CMD_READ_MODES         0x0A
 #define CLEM_ADB_CMD_VERSION            0x0d
+#define CLEM_ADB_CMD_SYSTEM_RESET       0x10
 #define CLEM_ADB_CMD_SEND_ADB_KEYCODE   0x11
 #define CLEM_ADB_CMD_UNDOCUMENTED_12    0x12
 #define CLEM_ADB_CMD_UNDOCUMENTED_13    0x13
@@ -1407,7 +1408,7 @@ static void _clem_adb_glu_keyb_send_to_host(struct ClemensDeviceADB *adb, uint8_
 
     //  TODO: paste text will override this (and set KEY_FULL itself)
     if (ascii_key != 0xff) {
-        CLEM_LOG("SKS: ascii: %02X [%s]", ascii_key, is_key_down ? "down" : "up");
+        //CLEM_LOG("SKS: ascii: %02X [%s]", ascii_key, is_key_down ? "down" : "up");
         if (is_key_down) {
             adb->io_key_last_ascii = 0x80 | ascii_key;
             /* via HWRef, but FWRef contradicts? */
@@ -1992,6 +1993,12 @@ void _clem_adb_glu_command(struct ClemensDeviceADB *adb) {
         _clem_adb_glu_result_init(adb, 1);
         _clem_adb_glu_result_data(adb, (uint8_t)adb->version);
         return;
+    case CLEM_ADB_CMD_SYSTEM_RESET:
+        CLEM_DEBUG("ADB: SYSTEM RESET");
+        adb->keyb.reset_key = true;
+        //  not that this command result will be handled...
+        _clem_adb_glu_command_done(adb);
+        return;
     case CLEM_ADB_CMD_SEND_ADB_KEYCODE:
         CLEM_DEBUG("ADB: SEND KEY (%02X)", adb->cmd_data[0]);
         _clem_adb_glu_keyb_send_to_host(adb, adb->cmd_data[0]);
@@ -2340,6 +2347,9 @@ static void _clem_adb_start_cmd(struct ClemensDeviceADB *adb, uint8_t value) {
         _clem_adb_expect_data(adb, 0);
         break;
     case CLEM_ADB_CMD_VERSION:
+        _clem_adb_expect_data(adb, 0);
+        break;
+    case CLEM_ADB_CMD_SYSTEM_RESET:
         _clem_adb_expect_data(adb, 0);
         break;
     case CLEM_ADB_CMD_SEND_ADB_KEYCODE:

--- a/clem_mmio.c
+++ b/clem_mmio.c
@@ -1754,6 +1754,11 @@ void _clem_mmio_init_page_maps(ClemensMMIO *mmio, struct ClemensMemoryPageMap **
 }
 
 void clem_mmio_reset(ClemensMMIO *mmio, struct ClemensTimeSpec *tspec) {
+    mmio->card_expansion_rom_index = -1;
+    mmio->new_video_c029 &= ~CLEM_MMIO_NEWVIDEO_SUPERHIRES_ENABLE;
+    mmio->mmap_register = CLEM_MEM_IO_MMAP_NSHADOW_SHGR | CLEM_MEM_IO_MMAP_WRLCRAM |
+                                  CLEM_MEM_IO_MMAP_LCBANK2;
+    _clem_mmio_restore_mappings(mmio);
     clem_timer_reset(&mmio->dev_timer);
     clem_rtc_reset(&mmio->dev_rtc, CLEM_CLOCKS_PHI0_CYCLE);
     clem_adb_reset(&mmio->dev_adb);
@@ -1780,7 +1785,6 @@ void clem_mmio_init(ClemensMMIO *mmio, struct ClemensDeviceDebugger *dev_debug,
     mmio->mega2_cycles = 0;
     mmio->last_data_address = 0xffffffff;
     mmio->emulator_detect = CLEM_MMIO_EMULATOR_DETECT_IDLE;
-    mmio->card_expansion_rom_index = -1;
     mmio->fpi_ram_bank_count = fpi_ram_bank_count;
     mmio->fpi_rom_bank_count = fpi_rom_bank_count;
 

--- a/clem_vgc.c
+++ b/clem_vgc.c
@@ -148,8 +148,8 @@ void clem_vgc_reset(struct ClemensVGC *vgc) {
     vgc->text_fg_color = CLEM_VGC_COLOR_WHITE;
     vgc->text_bg_color = CLEM_VGC_COLOR_MEDIUM_BLUE;
     vgc->scanline_irq_enable = false;
-    vgc->vbl_started = false;
     vgc->irq_vbl = false;
+    vgc->irq_line = 0;
     vgc->vbl_counter = 0;
 
     for (row = 0; row < CLEM_VGC_SHGR_SCANLINE_COUNT * 16; ++row) {

--- a/devices/hddcard.c
+++ b/devices/hddcard.c
@@ -142,6 +142,7 @@ static void io_reset(struct ClemensClock *clock, void *ctxptr) {
     //  HDD mount NOT reset (hdd, write_prot, drive_index)
     context->state = CLEM_CARD_HDD_STATE_IDLE;
     context->cmd_num = 0;
+    context->unit_num = 0;
     context->dma_addr = 0;
     context->dma_offset = 0;
     context->block_num = 0;


### PR DESCRIPTION
- Keyboard SRQs + TALK 0/3 if autopolling disabled (GSOS install uses SRQ+Talk instead of autopolling)
- ADB system reset
- A fix when unserializing snapshots without a slot 7 drive
