### PR TITLE
Fast Emulation Toggle and various debugger/misc fixes

### DIFF
--- a/clem_audio.c
+++ b/clem_audio.c
@@ -345,11 +345,12 @@ unsigned clem_ensoniq_voices(struct ClemensDeviceEnsoniq *doc) {
 //  down convert voices output into 2 channel mono
 void clem_ensoniq_mono(struct ClemensDeviceEnsoniq *doc, unsigned osc_max_channels, float *left,
                        float *right) {
+    unsigned active_osc = 0;
     *left = 0.0f;
     *right = 0.0f;
 
     for (unsigned channel_idx = 0; channel_idx < osc_max_channels; ++channel_idx) {
-        *left += (doc->voice[channel_idx] * 0.50f);
+        *left += doc->voice[channel_idx];
     }
     if (*left > 1.0f)
         *left = 1.0f;

--- a/clem_drive35.c
+++ b/clem_drive35.c
@@ -117,6 +117,9 @@ int clem_disk_control_35(struct ClemensDrive *drive, unsigned *io_flags, unsigne
                 CLEM_DEBUG("clem_drive35: step to outward tracks");
                 break;
             case CLEM_IWM_DISK35_CTL_EJECTED_RESET:
+                if (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTED) {
+                    CLEM_LOG("clem_drive35: clearing eject status");
+                }
                 drive->status_mask_35 &= ~CLEM_IWM_DISK35_STATUS_EJECTED;
                 break;
             case CLEM_IWM_DISK35_CTL_STEP_ONE:

--- a/clem_iwm.c
+++ b/clem_iwm.c
@@ -283,8 +283,8 @@ struct ClemensNibbleDisk *clem_iwm_eject_disk(struct ClemensDeviceIWM *iwm,
         return NULL;
 
     if (drive->disk.disk_type == CLEM_DISK_TYPE_3_5) {
-        drive->status_mask_35 &=
-            ~(CLEM_IWM_DISK35_STATUS_EJECTING | CLEM_IWM_DISK35_STATUS_EJECTED);
+        drive->status_mask_35 &= ~(CLEM_IWM_DISK35_STATUS_EJECTING);
+        drive->status_mask_35 |= CLEM_IWM_DISK35_STATUS_EJECTED;
     }
     drive->has_disk = false;
     return &drive->disk;
@@ -295,9 +295,10 @@ unsigned clem_iwm_eject_disk_in_progress(struct ClemensDeviceIWM *iwm, struct Cl
         if (drive->disk.disk_type == CLEM_DISK_TYPE_3_5) {
             if (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTING)
                 return CLEM_EJECT_DISK_STATUS_IN_PROGRESS;
-            if (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTED)
-                return CLEM_EJECT_DISK_STATUS_EJECTED;
         }
+    } else {
+        if (drive->status_mask_35 & CLEM_IWM_DISK35_STATUS_EJECTED)
+            return CLEM_EJECT_DISK_STATUS_EJECTED;
     }
     return CLEM_EJECT_DISK_STATUS_NONE;
 }

--- a/clem_mmio.c
+++ b/clem_mmio.c
@@ -732,6 +732,9 @@ uint8_t clem_mmio_read(ClemensMMIO *mmio, struct ClemensTimeSpec *tspec, uint16_
     case CLEM_MMIO_REG_LANGSEL:
         result = clem_vgc_get_region(&mmio->vgc);
         break;
+    case CLEM_MMIO_REG_CHARROM_TEST:
+        result = 0x00;          // TODO: unsure what to do unless we store the character ROM in memory vs font files
+        break;
     case CLEM_MMIO_REG_SLOTROMSEL:
         result = _clem_mmio_slotromsel_c02d(mmio);
         *mega2_access = false;
@@ -1072,6 +1075,9 @@ void clem_mmio_write(ClemensMMIO *mmio, struct ClemensTimeSpec *tspec, uint8_t d
         break;
     case CLEM_MMIO_REG_LANGSEL:
         clem_vgc_set_region(&mmio->vgc, data);
+        break;
+    case CLEM_MMIO_REG_CHARROM_TEST:
+        //  NO-OP - avoid the unimpl warning if done as a 16-bit write to LANGSEL
         break;
     case CLEM_MMIO_REG_SLOTROMSEL:
         _clem_mmio_slotrom_select_c02d(mmio, data);

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -744,6 +744,10 @@ bool ClemensBackend::onCommandDebugProgramTrace(std::string_view op, std::string
     return ok;
 }
 
+void ClemensBackend::onCommandDebugMemoryPrint(unsigned /*address */, unsigned /* count */) {
+    // TODO
+}
+
 bool ClemensBackend::onCommandSaveMachine(std::string path, std::unique_ptr<ClemensCommandMinizPNG> pngData) {
     auto outputPath = std::filesystem::path(config_.snapshotRootPath) / path;
 

--- a/host/clem_backend.cpp
+++ b/host/clem_backend.cpp
@@ -144,9 +144,9 @@ void ClemensRunSampler::update(clem_clocks_duration_t clocksSpent, unsigned cycl
     vblsBuffer.push(emulatorVblsPerFrame);
     sampledVblsSpent += emulatorVblsPerFrame;
     if (fastModeEnabled) {
-        if (sampledFramesPerSecond > 45.0) {
+        if (sampledFramesPerSecond > 55.0) {
             emulatorVblsPerFrame += 1;
-        } else if (sampledFramesPerSecond < 35.0) {
+        } else if (sampledFramesPerSecond < 45.0) {
             emulatorVblsPerFrame -= 1;
         }
         if (emulatorVblsPerFrame < 1)

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -39,7 +39,12 @@ struct ClemensRunSampler {
     cinek::CircularBuffer<clem_clocks_duration_t, 60> clocksBuffer;
     cinek::CircularBuffer<clem_clocks_duration_t, 60> cyclesBuffer;
 
+    // sampledMachineSpeedMhz is the speed from the machine's perspective (i.e. 2.8mhz is fast)
+    // sampledEmulationSpeedMhz is the speed from the host's perspective
+    // sampledEmulationSpeedMhz ~ sampledMachineSpeedMhz when running at NTSC frequency
+    // sampledEmulationSpeedMhz should be larger when running at full speed
     double sampledMachineSpeedMhz;
+    double sampledEmulationSpeedMhz;    
     std::chrono::high_resolution_clock::time_point lastFrameTimePoint;
 
     double avgVBLsPerFrame;
@@ -139,6 +144,7 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     void onCommandSendText(std::string msg) final;
     bool onCommandBinaryLoad(std::string pathname, unsigned address) final;
     bool onCommandBinarySave(std::string pathname, unsigned address, unsigned length) final;
+    void onCommandFastMode(bool enabled) final;
 
     //  internal
     bool isRunning() const;
@@ -172,6 +178,7 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     bool areInstructionsLogged_;
 
     ClemensRunSampler runSampler_;
+    bool fastModeEnabled_;
 
     std::optional<int> stepsRemaining_;
     int64_t clocksRemainingInTimeslice_;

--- a/host/clem_backend.hpp
+++ b/host/clem_backend.hpp
@@ -136,6 +136,7 @@ class ClemensBackend : public ClemensSystemListener, ClemensCommandQueueListener
     void onCommandDebugMemoryWrite(uint16_t addr, uint8_t value) final;
     void onCommandDebugLogLevel(int logLevel) final;
     bool onCommandDebugProgramTrace(std::string_view op, std::string_view path) final;
+    void onCommandDebugMemoryPrint(unsigned address, unsigned count) final;
     bool onCommandSaveMachine(std::string path, std::unique_ptr<ClemensCommandMinizPNG> pngData) final;
     bool onCommandLoadMachine(std::string path) final;
     bool onCommandRunScript(std::string command) final;

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -115,6 +115,10 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
             if (!programTrace(listener, cmd.operand))
                 commandFailed = true;
             break;
+        case Command::DebugPrintMemory: {
+                //  address, count (parse)
+                //  listener.onCommandDebugMemoryPrint(address, count);
+            } break;
         case Command::SaveMachine:
             commandFailed = true;
             if (!data || data->getType() == ClemensCommandData::Type::MinizPNG) {

--- a/host/clem_command_queue.cpp
+++ b/host/clem_command_queue.cpp
@@ -169,6 +169,9 @@ auto ClemensCommandQueue::dispatchAll(ClemensCommandQueueListener &listener) -> 
                 commandFailed = true;
             }
             break;
+        case Command::FastMode:
+            listener.onCommandFastMode(cmd.operand == "1");
+            break;
         case Command::Undefined:
             break;
         }
@@ -540,6 +543,10 @@ void ClemensCommandQueue::bsave(std::string pathname, unsigned address, unsigned
 
 void ClemensCommandQueue::bload(std::string pathname, unsigned address) {
     queue(Command{Command::LoadBinary, fmt::format("{},{:x}", pathname, address)});
+}
+
+void ClemensCommandQueue::fastMode(bool enable) {
+    queue(Command{Command::FastMode, enable ? "1" : "0"});
 }
 
 void ClemensCommandQueue::queue(const Command &cmd, Data data) {

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -54,6 +54,7 @@ class ClemensCommandQueueListener {
     virtual void onCommandDebugMemoryWrite(uint16_t addr, uint8_t value) = 0;
     virtual void onCommandDebugLogLevel(int logLevel) = 0;
     virtual bool onCommandDebugProgramTrace(std::string_view op, std::string_view path) = 0;
+    virtual void onCommandDebugMemoryPrint(unsigned address, unsigned count) = 0;
     virtual bool onCommandSaveMachine(std::string path,
                                       std::unique_ptr<ClemensCommandMinizPNG> pngData) = 0;
     virtual bool onCommandLoadMachine(std::string path) = 0;

--- a/host/clem_command_queue.hpp
+++ b/host/clem_command_queue.hpp
@@ -63,6 +63,7 @@ class ClemensCommandQueueListener {
     virtual void onCommandSendText(std::string text) = 0;
     virtual bool onCommandBinaryLoad(std::string pathname, unsigned address) = 0;
     virtual bool onCommandBinarySave(std::string pathname, unsigned address, unsigned length) = 0;
+    virtual void onCommandFastMode(bool enabled) = 0;
 };
 
 class ClemensCommandQueue {
@@ -131,6 +132,8 @@ class ClemensCommandQueue {
     void bsave(std::string pathname, unsigned address, unsigned length);
     //  Load binary from disk
     void bload(std::string pathname, unsigned address);
+    //  Toggle fast mode
+    void fastMode(bool enable);
 
   private:
     bool insertDisk(ClemensCommandQueueListener &listener, const std::string_view &inputParam);

--- a/host/clem_debugger.cpp
+++ b/host/clem_debugger.cpp
@@ -11,7 +11,6 @@
 #include "fmt/core.h"
 #include "imgui.h"
 
-#include <__charconv/from_chars_result.h>
 #include <algorithm>
 #include <charconv>
 #include <cmath>

--- a/host/clem_debugger.cpp
+++ b/host/clem_debugger.cpp
@@ -149,17 +149,17 @@ static bool parseAddress(std::string_view &operand, unsigned &address, uint8_t d
         auto bankStr = token.substr(0, bankSepPos);
         uint16_t offset;
         uint8_t bank;
-        if (std::from_chars(bankStr.begin(), bankStr.end(), bank, 16).ec != std::errc{}) {
+        if (std::from_chars(bankStr.data(), bankStr.data() + bankStr.size(), bank, 16).ec != std::errc{}) {
             validAddress = false;
         }
         address = (unsigned)(bank) << 16;
         auto offsetStr = token.substr(bankSepPos + 1);
-        if (std::from_chars(offsetStr.begin(), offsetStr.end(), offset, 16).ec != std::errc{}) {
+        if (std::from_chars(offsetStr.data(), offsetStr.data() + offsetStr.size(), offset, 16).ec != std::errc{}) {
             validAddress = false;
         }
         address |= offset;
     } else {
-        if (std::from_chars(token.begin(), token.end(), address, 16).ec != std::errc{}) {
+        if (std::from_chars(token.data(), token.data() + token.size(), address, 16).ec != std::errc{}) {
             validAddress = false;
         }
         if (token.size() < 5) {

--- a/host/clem_debugger.cpp
+++ b/host/clem_debugger.cpp
@@ -10,6 +10,7 @@
 #include "fmt/core.h"
 #include "imgui.h"
 
+#include <__charconv/from_chars_result.h>
 #include <algorithm>
 #include <charconv>
 #include <cmath>
@@ -129,6 +130,44 @@ static bool parseInt(const std::string_view &token, int &result) {
         return true;
     }
     return false;
+}
+
+static bool parseAddress(std::string_view &operand, unsigned &address) {
+    //  accept xx/xxxx, xxxxxx (24-bit) or xxxx (16-bit)
+    auto tailPos = operand.find(' ');
+    std::string_view token;
+    if (tailPos == std::string_view::npos) {
+        token = operand;
+        operand = std::string_view();
+    } else {
+        token = operand.substr(0, tailPos);
+        operand = operand.substr(tailPos + 1);
+    }
+    bool validAddress = true;
+    auto bankSepPos = token.find('/');
+    if (bankSepPos > 0 && bankSepPos <= 2) {
+        auto bankStr = token.substr(0, bankSepPos);
+        uint16_t offset;
+        uint8_t bank;
+        if (std::from_chars(bankStr.begin(), bankStr.end(), bank, 16).ec != std::errc{}) {
+            validAddress = false;
+        }
+        address = (unsigned)(bank) << 16;
+        auto offsetStr = token.substr(bankSepPos + 1);
+        if (std::from_chars(offsetStr.begin(), offsetStr.end(), offset, 16).ec != std::errc{}) {
+            validAddress = false;
+        }
+        address |= offset;
+    } else {
+        if (std::from_chars(token.begin(), token.end(), address, 16).ec != std::errc{}) {
+            validAddress = false;
+        }
+    }
+    if (validAddress && address >= 0x00ffffff) {
+        validAddress = false;
+    }
+
+    return validAddress;
 }
 
 static ImColor getDefaultColor(bool hi) {
@@ -1087,6 +1126,8 @@ void ClemensDebugger::executeCommand(std::string_view command) {
         cmdBload(operand);
     } else if (action == "cwd") {
         cmdPwd(operand);
+    } else if (action == "print" || action == "p") {
+        cmdPrint(operand);
     } else {
         commandQueue_.runScript(std::string(command));
     }
@@ -1167,35 +1208,18 @@ void ClemensDebugger::cmdBreak(std::string_view operand) {
         breakpoint.type = ClemensBackendBreakpoint::Execute;
     }
 
-    char address[16];
-    auto bankSepPos = operand.find('/');
-    if (bankSepPos == std::string_view::npos) {
-        if (operand.size() >= 2) {
-            snprintf(address, sizeof(address), "%02X", frameState_->cpu.regs.PBR);
-            operand.copy(address + 2, 4, 2);
-        } else if (!operand.empty()) {
-            CLEM_TERM_COUT.format(Error, "Address {} is invalid.", operand);
-            return;
-        }
-    } else if (bankSepPos == 2 && operand.size() > bankSepPos) {
-        operand.copy(address, bankSepPos, 0);
-        operand.copy(address + bankSepPos, operand.size() - (bankSepPos + 1), bankSepPos + 1);
-    } else {
+    if (operand.empty()) {
+        commandQueue_.breakExecution();
+        return;
+    }
+
+    unsigned address = 0;
+    if (!parseAddress(operand, address)) {
         CLEM_TERM_COUT.format(Error, "Address {} is invalid.", operand);
         return;
     }
-    if (operand.empty()) {
-        commandQueue_.breakExecution();
-    } else {
-        address[6] = '\0';
-        char *addressEnd = NULL;
-        breakpoint.address = std::strtoul(address, &addressEnd, 16);
-        if (addressEnd != address + 6) {
-            CLEM_TERM_COUT.format(Error, "Address format is invalid read from '{}'", operand);
-            return;
-        }
-        commandQueue_.addBreakpoint(breakpoint);
-    }
+    breakpoint.address = address;
+    commandQueue_.addBreakpoint(breakpoint);
 }
 
 void ClemensDebugger::cmdRun(std::string_view /*operand*/) { commandQueue_.run(); }
@@ -1458,6 +1482,59 @@ void ClemensDebugger::cmdPwd(std::string_view) {
     }
 }
 
+void ClemensDebugger::cmdPrint(std::string_view operand) {
+    static const char *kIrqName[32] = {"scan",
+                                       "vbl",
+                                       NULL,
+                                       NULL,
+                                       "rtc_qsec",
+                                       "rtc_1sec",
+                                       NULL,
+                                       NULL,
+                                       "adb_srq_keyb",
+                                       "adb_srq_mouse?!",
+                                       "adb_evt_mouse",
+                                       "adb_data",
+                                       "osc",
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       "s1",
+                                       "s2",
+                                       "s3",
+                                       "s4",
+                                       "s5",
+                                       "s6",
+                                       "s7",
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL};
+    if (operand.empty()) {
+        CLEM_TERM_COUT.format(Error, "usage: print <addr>:<count>|irq");
+        return;
+    }
+
+    if (operand == "irq") {
+        if (frameState_->cpu.pins.irqbIn) {
+            CLEM_TERM_COUT.format(Info, "There are no IRQs pending.");
+        } else {
+            for (unsigned irqIdx = 0, irqs = frameState_->irqs; irqs && irqIdx < 32;
+                 ++irqIdx, irqs >>= 1) {
+                if (irqs & 1) {
+                    CLEM_TERM_COUT.format(Info, "{:08x}:{}", 1 << irqIdx, kIrqName[irqIdx]);
+                }
+            }
+        }
+        return;
+    }
+}
+
 void ClemensDebugger::cmdHelp(std::string_view operand) {
     if (!operand.empty()) {
         CLEM_TERM_COUT.print(Warn, "Command specific help not yet supported.");
@@ -1480,6 +1557,8 @@ void ClemensDebugger::cmdHelp(std::string_view operand) {
     CLEM_TERM_COUT.print(Info, "b]reak irq                  - break on IRQ");
     CLEM_TERM_COUT.print(Info, "b]reak brk                  - break on IRQ");
     CLEM_TERM_COUT.print(Info, "b]reak list                 - list all breakpoints");
+    CLEM_TERM_COUT.print(Info, "p]rint <address>:<count>    - print bytes at address");
+    CLEM_TERM_COUT.print(Info, "p]rint irq                  - print irqs raised");
     CLEM_TERM_COUT.print(Info, "log {DEBUG|INFO|WARN|UNIMPL}- set the emulator log level");
     CLEM_TERM_COUT.print(Info, "dump <bank_begin>,          - dump memory from selected banks\n"
                                "     <bank_end>,              to a file with the specified\n"

--- a/host/clem_debugger.hpp
+++ b/host/clem_debugger.hpp
@@ -109,6 +109,7 @@ class ClemensDebugger {
     void cmdBload(std::string_view operand);
     void cmdBsave(std::string_view operand);
     void cmdPwd(std::string_view operand);
+    void cmdPrint(std::string_view operand);
 };
 
 class ClemensDebuggerListener {

--- a/host/clem_file_browser.cpp
+++ b/host/clem_file_browser.cpp
@@ -1,5 +1,6 @@
 #include "clem_file_browser.hpp"
 
+#include "clem_host_platform.h"
 #include "imgui.h"
 
 #include <cassert>
@@ -48,7 +49,9 @@ ClemensFileBrowser::ClemensFileBrowser() {
 
 void ClemensFileBrowser::setCurrentDirectory(const std::string &directory) {
     if (directory.empty()) {
-        currentDirectoryPath_ = std::filesystem::current_path();
+        char userPath[CLEMENS_PATH_MAX];
+        get_local_user_directory(userPath, sizeof(userPath));
+        currentDirectoryPath_ = userPath;
     } else {
         currentDirectoryPath_ = directory;
     }
@@ -60,7 +63,7 @@ void ClemensFileBrowser::forceRefresh() { nextRefreshTime_ = std::chrono::steady
 void ClemensFileBrowser::frame(ImVec2 size) {
     //  standardize our current working directory
     if (currentDirectoryPath_.empty()) {
-        currentDirectoryPath_ = std::filesystem::current_path();
+        setCurrentDirectory("");
     }
     auto cwd = currentDirectoryPath_.make_preferred();
     if (!cwd.is_absolute()) {

--- a/host/clem_frame_state.cpp
+++ b/host/clem_frame_state.cpp
@@ -272,8 +272,10 @@ void FrameState::copyState(const ClemensBackendState &state, LastCommandState &c
     }
 
     commandState.isFastEmulationOn = state.fastEmulationOn;
+    commandState.isFastModeOn = state.fastModeEnabled;
 
     machineSpeedMhz = state.machineSpeedMhz;
+    emulationSpeedMhz = state.emulationSpeedMhz;
     avgVBLsPerFrame = state.avgVBLsPerFrame;
     vgcModeFlags = state.mmio->vgc.mode_flags;
     irqs = state.mmio->irq_line;

--- a/host/clem_frame_state.hpp
+++ b/host/clem_frame_state.hpp
@@ -44,8 +44,10 @@ struct ClemensBackendState {
     uint8_t debugMemoryPage = 0;
 
     float machineSpeedMhz = 0.0f;
+    float emulationSpeedMhz = 0.0f;
     float avgVBLsPerFrame = 0.0f;
     bool fastEmulationOn = false;
+    bool fastModeEnabled = false;
 
     // valid if a debugMessage() command was issued from the frontend
     std::optional<std::string> message;
@@ -131,7 +133,8 @@ struct LastCommandState {
     LogOutputNode *logNodeTail = nullptr;
     LogInstructionNode *logInstructionNode = nullptr;
     LogInstructionNode *logInstructionNodeTail = nullptr;
-    bool isFastEmulationOn;
+    bool isFastEmulationOn = false;
+    bool isFastModeOn = false;
 };
 
 // This state comes in for any update to the emulator per frame.  As such
@@ -158,14 +161,15 @@ struct FrameState {
     unsigned breakpointCount = 0;
     int logLevel;
 
-    float machineSpeedMhz;
-    float avgVBLsPerFrame;
-    uint32_t vgcModeFlags;
-    uint32_t irqs, nmis;
+    float machineSpeedMhz = 0.0f;
+    float emulationSpeedMhz = 0.0f;
+    float avgVBLsPerFrame = 0;
+    uint32_t vgcModeFlags = 0;
+    uint32_t irqs = 0, nmis = 0;
     uint8_t memoryViewBank = 0;
 
-    unsigned backendCPUID;
-    float fps;
+    unsigned backendCPUID = 0;
+    float fps = 0.0f;
     bool mmioWasInitialized = false;
     bool isTracing = false;
     bool isIWMTracing = false;

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -626,10 +626,16 @@ ClemensFrontend::ClemensFrontend(ClemensConfiguration &config,
 }
 
 ClemensFrontend::~ClemensFrontend() {
+    bool poweredOn = config_.poweredOn;
+
     stopBackend();
     audio_.stop();
     clem_joystick_close_devices();
 
+    //  we want to use the same power status as it was right before termination,
+    //  since stopping the backend will always clear poweredOn (requiring manual
+    //  powering on every time the user launches the app)
+    config_.poweredOn = poweredOn;
     config_.save();
 
     free(frameReadMemory_.getHead());

--- a/host/clem_front.cpp
+++ b/host/clem_front.cpp
@@ -1374,20 +1374,20 @@ void ClemensFrontend::doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop) {
         }
         if (ImGui::BeginMenu("View")) {
             if (config_.hybridInterfaceEnabled) {
-                if (ImGui::MenuItem("User Mode", CLEM_L10N_LABEL(kHybridModeShortCutText))) {
+                if (ImGui::MenuItem("User Mode", CLEM_L10N_LABEL(kHybridModeShortcutText))) {
                     config_.hybridInterfaceEnabled = false;
                 }
             } else {
-                if (ImGui::MenuItem("Debugger Mode", CLEM_L10N_LABEL(kHybridModeShortCutText))) {
+                if (ImGui::MenuItem("Debugger Mode", CLEM_L10N_LABEL(kHybridModeShortcutText))) {
                     config_.hybridInterfaceEnabled = true;
                 }
             }
             if (interop.mouseLock) {
-                if (ImGui::MenuItem("Unlock Mouse", CLEM_L10N_LABEL(kLockMouseShortCutText))) {
+                if (ImGui::MenuItem("Unlock Mouse", CLEM_L10N_LABEL(kLockMouseShortcutText))) {
                     interop.action = ClemensHostInterop::MouseUnlock;
                 }
             } else {
-                if (ImGui::MenuItem("Lock Mouse", CLEM_L10N_LABEL(kLockMouseShortCutText))) {
+                if (ImGui::MenuItem("Lock Mouse", CLEM_L10N_LABEL(kLockMouseShortcutText))) {
                     interop.action = ClemensHostInterop::MouseLock;
                 }
             }
@@ -1400,12 +1400,12 @@ void ClemensFrontend::doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop) {
                 }
             } else {
                 if (frameReadState_.isRunning) {
-                    if (ImGui::MenuItem("Pause", CLEM_L10N_LABEL(kTogglePauseText), false,
+                    if (ImGui::MenuItem("Pause", CLEM_L10N_LABEL(kTogglePauseShortcutText), false,
                                         !isEmulatorStarting())) {
                         interop.action = ClemensHostInterop::PauseExecution;
                     }
                 } else {
-                    if (ImGui::MenuItem("Run", CLEM_L10N_LABEL(kTogglePauseText), false,
+                    if (ImGui::MenuItem("Run", CLEM_L10N_LABEL(kTogglePauseShortcutText), false,
                                         !isEmulatorStarting())) {
                         interop.action = ClemensHostInterop::ContinueExecution;
                     }
@@ -1419,6 +1419,13 @@ void ClemensFrontend::doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop) {
                 }
             }
             ImGui::Separator();
+            if (ImGui::MenuItem("Fast Mode", CLEM_L10N_LABEL(kFastModeShortCutText), interop.fastMode, isBackendRunning())) {
+                if (interop.fastMode) {
+                    interop.action = ClemensHostInterop::DisableFastMode;
+                } else {
+                    interop.action = ClemensHostInterop::EnableFastMode;    
+                }
+            }
             if (ImGui::MenuItem("Configure Joystick", NULL, false,
                                 interop.allowConfigureJoystick)) {
                 interop.action = ClemensHostInterop::JoystickConfig;
@@ -1463,6 +1470,12 @@ void ClemensFrontend::doMainMenu(ImVec2 &anchor, ClemensHostInterop &interop) {
                         interop.action = ClemensHostInterop::PauseExecution;
                     } else {
                         interop.action = ClemensHostInterop::ContinueExecution;
+                    }
+                } else if (ImGui::IsKeyPressed(ImGuiKey_F8)) {
+                    if (lastCommandState_.isFastModeOn) {
+                        interop.action = ClemensHostInterop::DisableFastMode;
+                    } else {
+                        interop.action = ClemensHostInterop::EnableFastMode;
                     }
                 }
             }
@@ -2069,8 +2082,6 @@ void ClemensFrontend::doMachineDiskStatus(ClemensDriveType driveType, float /*wi
                         std::filesystem::path(driveStatus.assetPath).parent_path().string());
                 } else if (!savedDiskBrowsePaths_[driveType].empty()) {
                     assetBrowser_.setCurrentDirectory(savedDiskBrowsePaths_[driveType]);
-                } else {
-                    assetBrowser_.setCurrentDirectory(std::filesystem::current_path().string());
                 }
                 assetBrowser_.setDiskType(ClemensDiskAsset::diskTypeFromDriveType(driveType));
             }
@@ -2236,8 +2247,6 @@ void ClemensFrontend::doMachineSmartDriveStatus(unsigned driveIndex, const char 
                         std::filesystem::path(driveStatus.assetPath).parent_path().string());
                 } else if (!savedSmartDiskBrowsePaths_[driveIndex].empty()) {
                     assetBrowser_.setCurrentDirectory(savedSmartDiskBrowsePaths_[driveIndex]);
-                } else {
-                    assetBrowser_.setCurrentDirectory(std::filesystem::current_path().string());
                 }
                 assetBrowser_.setDiskType(ClemensDiskAsset::DiskHDD);
             }

--- a/host/clem_host.hpp
+++ b/host/clem_host.hpp
@@ -25,6 +25,8 @@ struct ClemensHostInterop {
         MouseUnlock,
         PauseExecution,
         ContinueExecution,
+        EnableFastMode,
+        DisableFastMode,
         About
     } action;
 
@@ -34,6 +36,7 @@ struct ClemensHostInterop {
     bool allowConfigureJoystick;
     bool mouseLock;
     bool running;
+    bool fastMode;
     unsigned viewWidth;         //   0 = no change
     unsigned viewHeight;        //   0 = no change
     unsigned minWindowWidth;

--- a/host/clem_host.hpp
+++ b/host/clem_host.hpp
@@ -6,7 +6,6 @@ struct ClemensHostInterop {
     bool mouseShow;
 
     //  system/menu notifications to the main app
-    bool mouseLock;
     bool nativeMenu;
     enum {
         None,
@@ -22,6 +21,10 @@ struct ClemensHostInterop {
         Standard,
         AspectView,
         JoystickConfig,
+        MouseLock,
+        MouseUnlock,
+        PauseExecution,
+        ContinueExecution,
         About
     } action;
 
@@ -29,6 +32,8 @@ struct ClemensHostInterop {
     bool poweredOn;
     bool debuggerOn;
     bool allowConfigureJoystick;
+    bool mouseLock;
+    bool running;
     unsigned viewWidth;         //   0 = no change
     unsigned viewHeight;        //   0 = no change
     unsigned minWindowWidth;

--- a/host/clem_host.mm
+++ b/host/clem_host.mm
@@ -33,6 +33,7 @@
   NSMenuItem *joysickMenuItem;
   NSMenuItem *lockMouseItem;
   NSMenuItem *pauseItem;
+  NSMenuItem *fastMode;
 }
 
 + (id)instance {
@@ -115,6 +116,14 @@
     hostInterop->action = ClemensHostInterop::PauseExecution;
   } else {
     hostInterop->action = ClemensHostInterop::ContinueExecution;
+  }
+}
+
+- (void)menuFastMode:(id)sender {
+  if (hostInterop->fastMode) {
+    hostInterop->action = ClemensHostInterop::DisableFastMode;
+  } else {
+    hostInterop->action = ClemensHostInterop::EnableFastMode;
   }
 }
 
@@ -222,11 +231,10 @@
   [pauseItem setTarget:self];
   keyEquivalentChar = NSF5FunctionKey;
   [pauseItem setKeyEquivalentModifierMask:NSEventModifierFlagControl |
-                                              NSEventModifierFlagOption |
-                                              NSEventModifierFlagFunction];
-  [pauseItem
-      setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
-                                               length:1]];
+                                          NSEventModifierFlagOption |
+                                          NSEventModifierFlagFunction];
+  [pauseItem setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
+                                                      length:1]];
   [machmenu addItem:pauseItem];
 
   rebootMenuItem = [[NSMenuItem alloc] initWithTitle:@"Reboot"
@@ -242,6 +250,19 @@
   [machmenu addItem:shutdownMenuItem];
 
   [machmenu addItem:[NSMenuItem separatorItem]];
+
+  fastMode = [[NSMenuItem alloc] initWithTitle:@"Fast Mode"
+                                        action:@selector(menuFastMode:)
+                                 keyEquivalent:@""];
+  [fastMode setTarget:self];
+  keyEquivalentChar = NSF8FunctionKey;
+  [fastMode setKeyEquivalentModifierMask:NSEventModifierFlagControl |
+                                                 NSEventModifierFlagOption |
+                                                 NSEventModifierFlagFunction];
+  [fastMode
+      setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
+                                               length:1]];
+  [machmenu addItem:fastMode];
 
   joysickMenuItem =
       [[NSMenuItem alloc] initWithTitle:@"Configure Joystick"
@@ -298,6 +319,9 @@
     [lockMouseItem setAction:@selector(menuLockMouse:)];
     [pauseItem setEnabled:TRUE];
     [pauseItem setAction:@selector(menuPauseEmulator:)];
+    [fastMode setEnabled:TRUE];
+    [fastMode setAction:@selector(menuFastMode:)];
+    [fastMode setState: hostInterop->fastMode ? NSControlStateValueOn : NSControlStateValueOff];
   } else {
     [rebootMenuItem setEnabled:FALSE];
     [rebootMenuItem setAction:nil];
@@ -309,6 +333,8 @@
     [lockMouseItem setAction:nil];
     [pauseItem setEnabled:FALSE];
     [pauseItem setAction:nil];
+    [fastMode setEnabled:FALSE];
+    [fastMode setAction:nil];
   }
   if (hostInterop->debuggerOn) {
     [debuggerMenuItem setTitle:@"User Mode"];

--- a/host/clem_host.mm
+++ b/host/clem_host.mm
@@ -31,6 +31,8 @@
   NSMenuItem *shutdownMenuItem;
   NSMenuItem *debuggerMenuItem;
   NSMenuItem *joysickMenuItem;
+  NSMenuItem *lockMouseItem;
+  NSMenuItem *pauseItem;
 }
 
 + (id)instance {
@@ -98,8 +100,27 @@
   }
 }
 
+- (void)menuLockMouse:(id)sender {
+  if (hostInterop->mouseLock) {
+    hostInterop->action = ClemensHostInterop::MouseUnlock;
+  } else {
+    hostInterop->action = ClemensHostInterop::MouseLock;
+  }
+}
+
+- (void)menuPauseEmulator:(id)sender {
+  if (!hostInterop->poweredOn)
+    return;
+  if (hostInterop->running) {
+    hostInterop->action = ClemensHostInterop::PauseExecution;
+  } else {
+    hostInterop->action = ClemensHostInterop::ContinueExecution;
+  }
+}
+
 //  TODO: localized strings!
 - (void)buildMenus {
+  unichar keyEquivalentChar = 0;
   NSMenu *menubar = [NSMenu new];
 
   // Application Menu
@@ -160,7 +181,27 @@
                                                 action:@selector(menuDebugger:)
                                          keyEquivalent:@""];
   [debuggerMenuItem setTarget:self];
+  keyEquivalentChar = NSF11FunctionKey;
+  [debuggerMenuItem setKeyEquivalentModifierMask:NSEventModifierFlagControl |
+                                                 NSEventModifierFlagOption |
+                                                 NSEventModifierFlagFunction];
+  [debuggerMenuItem
+      setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
+                                               length:1]];
   [viewmenu addItem:debuggerMenuItem];
+
+  lockMouseItem = [[NSMenuItem alloc] initWithTitle:@"Lock Mouse"
+                                             action:@selector(menuLockMouse:)
+                                      keyEquivalent:@""];
+  [lockMouseItem setTarget:self];
+  keyEquivalentChar = NSF10FunctionKey;
+  [lockMouseItem setKeyEquivalentModifierMask:NSEventModifierFlagControl |
+                                              NSEventModifierFlagOption |
+                                              NSEventModifierFlagFunction];
+  [lockMouseItem
+      setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
+                                               length:1]];
+  [viewmenu addItem:lockMouseItem];
 
   NSMenuItem *viewMenuItem = [menubar addItemWithTitle:@""
                                                 action:nil
@@ -174,6 +215,19 @@
                                       keyEquivalent:@""];
   [powerMenuItem setTarget:self];
   [machmenu addItem:powerMenuItem];
+
+  pauseItem = [[NSMenuItem alloc] initWithTitle:@"Pause"
+                                         action:@selector(menuPauseEmulator::)
+                                  keyEquivalent:@""];
+  [pauseItem setTarget:self];
+  keyEquivalentChar = NSF5FunctionKey;
+  [pauseItem setKeyEquivalentModifierMask:NSEventModifierFlagControl |
+                                              NSEventModifierFlagOption |
+                                              NSEventModifierFlagFunction];
+  [pauseItem
+      setKeyEquivalent:[NSString stringWithCharacters:&keyEquivalentChar
+                                               length:1]];
+  [machmenu addItem:pauseItem];
 
   rebootMenuItem = [[NSMenuItem alloc] initWithTitle:@"Reboot"
                                               action:@selector(menuReboot:)
@@ -189,11 +243,12 @@
 
   [machmenu addItem:[NSMenuItem separatorItem]];
 
-  joysickMenuItem = [[NSMenuItem alloc] initWithTitle:@"Configure Joystick"
-                                                action:@selector(menuConfigureJoystick:)
-                                         keyEquivalent:@""];
-  [joysickMenuItem setTarget: self];
-  [machmenu addItem: joysickMenuItem];
+  joysickMenuItem =
+      [[NSMenuItem alloc] initWithTitle:@"Configure Joystick"
+                                 action:@selector(menuConfigureJoystick:)
+                          keyEquivalent:@""];
+  [joysickMenuItem setTarget:self];
+  [machmenu addItem:joysickMenuItem];
 
   NSMenuItem *machMenuItem = [menubar addItemWithTitle:@""
                                                 action:nil
@@ -239,6 +294,10 @@
     [shutdownMenuItem setAction:@selector(menuShutdown:)];
     [powerMenuItem setEnabled:FALSE];
     [powerMenuItem setAction:nil];
+    [lockMouseItem setEnabled:TRUE];
+    [lockMouseItem setAction:@selector(menuLockMouse:)];
+    [pauseItem setEnabled:TRUE];
+    [pauseItem setAction:@selector(menuPauseEmulator:)];
   } else {
     [rebootMenuItem setEnabled:FALSE];
     [rebootMenuItem setAction:nil];
@@ -246,11 +305,25 @@
     [shutdownMenuItem setAction:nil];
     [powerMenuItem setEnabled:TRUE];
     [powerMenuItem setAction:@selector(menuPower:)];
+    [lockMouseItem setEnabled:FALSE];
+    [lockMouseItem setAction:nil];
+    [pauseItem setEnabled:FALSE];
+    [pauseItem setAction:nil];
   }
   if (hostInterop->debuggerOn) {
     [debuggerMenuItem setTitle:@"User Mode"];
   } else {
     [debuggerMenuItem setTitle:@"Debugger Mode"];
+  }
+  if (hostInterop->mouseLock) {
+    [lockMouseItem setTitle:@"Unlock Mouse"];
+  } else {
+    [lockMouseItem setTitle:@"Lock Mouse"];
+  }
+  if (hostInterop->running) {
+    [pauseItem setTitle:@"Pause"];
+  } else {
+    [pauseItem setTitle:@"Continue"];
   }
   if (hostInterop->allowConfigureJoystick) {
     [joysickMenuItem setEnabled:TRUE];
@@ -262,7 +335,7 @@
   NSSize minSize;
   minSize.width = hostInterop->minWindowWidth;
   minSize.height = hostInterop->minWindowHeight;
-  NSWindow* mainWindow = [NSApp mainWindow];
+  NSWindow *mainWindow = [NSApp mainWindow];
   mainWindow.contentMinSize = minSize;
 }
 

--- a/host/clem_host_platform.h
+++ b/host/clem_host_platform.h
@@ -106,6 +106,15 @@ void clem_host_uuid_gen(ClemensHostUUID *uuid);
 char *get_process_executable_path(char *outpath, size_t *outpath_size);
 
 /**
+ * @brief Get the local user directory object
+ * 
+ * @param outpath 
+ * @param outpath_size 
+ * @return char* 
+ */
+char* get_local_user_directory(char *outpath, size_t outpath_size);
+
+/**
  * @brief Get the local user data directory qualified with identifiers
  *
  * @param outpath

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -81,7 +81,8 @@ struct ClemensBackendCommand {
         SendText,
         SaveBinary,
         LoadBinary,
-        FastMode
+        FastMode,
+        DebugPrintMemory
     };
     Type type = Undefined;
     std::string operand;

--- a/host/clem_host_shared.hpp
+++ b/host/clem_host_shared.hpp
@@ -80,7 +80,8 @@ struct ClemensBackendCommand {
         DebugMessage,
         SendText,
         SaveBinary,
-        LoadBinary
+        LoadBinary,
+        FastMode
     };
     Type type = Undefined;
     std::string operand;

--- a/host/clem_l10n.hpp
+++ b/host/clem_l10n.hpp
@@ -52,9 +52,10 @@ extern const char* kButtonJoystickButton1[];
 extern const char* kButtonJoystickButton2[];
 
 //  shortcuts
-extern const char *kHybridModeShortCutText[];
-extern const char *kLockMouseShortCutText[];
-extern const char *kTogglePauseText[];
+extern const char *kHybridModeShortcutText[];
+extern const char *kLockMouseShortcutText[];
+extern const char *kTogglePauseShortcutText[];
+extern const char *kFastModeShortCutText[];
 
 constexpr unsigned kLanguageDefault = 0;
 

--- a/host/clem_l10n.hpp
+++ b/host/clem_l10n.hpp
@@ -51,6 +51,11 @@ extern const char* kLabelJoystick2Help[];
 extern const char* kButtonJoystickButton1[];
 extern const char* kButtonJoystickButton2[];
 
+//  shortcuts
+extern const char *kHybridModeShortCutText[];
+extern const char *kLockMouseShortCutText[];
+extern const char *kTogglePauseText[];
+
 constexpr unsigned kLanguageDefault = 0;
 
 } // namespace ClemensL10N

--- a/host/platform/host_linux.c
+++ b/host/platform/host_linux.c
@@ -69,6 +69,13 @@ char *get_process_executable_path(char *outpath, size_t *outpath_size) {
     return outpath;
 }
 
+char* get_local_user_directory(char *outpath, size_t outpath_size) {
+    const char *user_home_dir = getpwuid(getuid())->pw_dir;
+    strncpy(outpath, user_home_dir, outpath_size - 1);
+    outpath[outpath_size - 1] = '\0';
+    return outpath;
+}
+
 char *get_local_user_config_directory(char *outpath, size_t outpath_size, const char *company_name,
                                     const char *app_name) {
     //  retrieve $XDG_CONFIG_HOME or if not found ~/.config/<company_name>

--- a/host/platform/host_macos.m
+++ b/host/platform/host_macos.m
@@ -37,6 +37,14 @@ char *get_process_executable_path(char *outpath, size_t *outpath_size) {
   return outpath;
 }
 
+char* get_local_user_directory(char *outpath, size_t outpath_size) {
+  NSString *user_directory = NSHomeDirectory();
+  const char *dir_cstr = [user_directory UTF8String];
+  strncpy(outpath, dir_cstr, outpath_size - 1);
+  outpath[outpath_size - 1] = '\0';
+  return outpath; 
+}
+
 char *get_local_user_data_directory(char *outpath, size_t outpath_size,
                                     const char *company_name,
                                     const char *app_name) {

--- a/host/platform/host_windows.c
+++ b/host/platform/host_windows.c
@@ -62,6 +62,25 @@ char *get_process_executable_path(char *outpath, size_t *outpath_size) {
     return outpath;
 }
 
+char* get_local_user_directory(char *outpath, size_t outpath_size) {
+    char *current_path = outpath;
+    char *tail_path = outpath + outpath_size - 1;
+    int state = 0;
+    PWSTR directoryString;
+    HRESULT hr = SHGetKnownFolderPath(&FOLDERID_Profile, 0, NULL, &directoryString);
+    if (SUCCEEDED(hr)) {
+        int cnt = WideCharToMultiByte(CP_UTF8, 0, directoryString, wcslen(directoryString), outpath,
+                                      outpath_size, NULL, NULL);
+        if (cnt <= 0) {
+            return NULL;
+        }
+        current_path += cnt;
+    }
+    CoTaskMemFree(directoryString);
+    *current_path = '\0';
+    return outpath;
+}
+
 char *get_local_user_data_directory(char *outpath, size_t outpath_size, const char *company_name,
                                     const char *app_name) {
     char *current_path = outpath;

--- a/host/strings/clem_hotkeys.inl
+++ b/host/strings/clem_hotkeys.inl
@@ -23,9 +23,10 @@ The Tux/Super key when combined with number keys will treat them as function key
 )md"};
 const char *kMouseUnlock[] = {"Press Tux, Ctrl, Alt and F10 to unlock mouse"};
 
-const char *kHybridModeShortCutText[]= {"Tux+Ctrl+LAlt+minus"};
-const char *kLockMouseShortCutText[]={"Tux+Ctrl+LAlt+F10"};
-const char *kTogglePauseText[]={"Tux+Ctrl+LAlt+5"};
+const char *kHybridModeShortcutText[]= {"Tux+Ctrl+LAlt+minus"};
+const char *kLockMouseShortcutText[]={"Tux+Ctrl+LAlt+F10"};
+const char *kTogglePauseShortcutText[]={"Tux+Ctrl+LAlt+5"};
+const char *kFastModeShortCutText[] = {"Tux+Ctrl+Lalt+8"};
 
 #elif defined(__APPLE__)
 const char *kGSKeyboardCommands[] = {R"md(
@@ -47,9 +48,10 @@ There may be titles where this mouse emulation does not work.  In those cases, t
 const char *kMouseUnlock[] = {"Press CTRL + Option + F10 to unlock mouse"};
 
 //  UNUSED since these are handled outside of ImGUI
-const char *kHybridModeShortCutText[]= {"Ctrl + Option + F11"};
-const char *kLockMouseShortCutText[]={"Ctrl + Option+ F10"};
-const char *kTogglePauseText[]={"Ctrl + Option + F5"};
+const char *kHybridModeShortcutText[]= {"Ctrl + Option + F11"};
+const char *kLockMouseShortcutText[]={"Ctrl + Option+ F10"};
+const char *kTogglePauseShortcutText[]={"Ctrl + Option + F5"};
+const char *kFastModeShortCutText[] = {"Ctrl + Option + F8"};
 #else
 const char *kGSKeyboardCommands[] = {R"md(
 ## Mouse Control
@@ -65,7 +67,8 @@ To transfer control of the mouse to the IIGS session, click within the view.  To
 - Ctrl-Left ALT-F10 to lock mouse)md"};
 const char *kMouseUnlock[] = {"Press  CTRL + ALT + F10 to unlock mouse"};
 
-const char *kHybridModeShortCutText[]= {"Ctrl + Left Alt + F11"};
-const char *kLockMouseShortCutText[]={"Ctrl + Left Alt + F10"};
-const char *kTogglePauseText[]={"Ctrl + Left Alt + F5"};
+const char *kHybridModeShortcutText[]= {"Ctrl + Left Alt + F11"};
+const char *kLockMouseShortcutText[]={"Ctrl + Left Alt + F10"};
+const char *kTogglePauseShortcutText[]={"Ctrl + Left Alt + F5"};
+const char *kFastModeShortCutText[]={"Ctrl + Left Alt + F8"};
 #endif

--- a/host/strings/clem_hotkeys.inl
+++ b/host/strings/clem_hotkeys.inl
@@ -22,6 +22,11 @@ The Tux/Super key when combined with number keys will treat them as function key
 
 )md"};
 const char *kMouseUnlock[] = {"Press Tux, Ctrl, Alt and F10 to unlock mouse"};
+
+const char *kHybridModeShortCutText[]= {"Tux+Ctrl+LAlt+minus"};
+const char *kLockMouseShortCutText[]={"Tux+Ctrl+LAlt+F10"};
+const char *kTogglePauseText[]={"Tux+Ctrl+LAlt+5"};
+
 #elif defined(__APPLE__)
 const char *kGSKeyboardCommands[] = {R"md(
 ## Mouse Control
@@ -40,6 +45,11 @@ There may be titles where this mouse emulation does not work.  In those cases, t
 
 )md"};
 const char *kMouseUnlock[] = {"Press CTRL + Option + F10 to unlock mouse"};
+
+//  UNUSED since these are handled outside of ImGUI
+const char *kHybridModeShortCutText[]= {"Ctrl + Option + F11"};
+const char *kLockMouseShortCutText[]={"Ctrl + Option+ F10"};
+const char *kTogglePauseText[]={"Ctrl + Option + F5"};
 #else
 const char *kGSKeyboardCommands[] = {R"md(
 ## Mouse Control
@@ -54,4 +64,8 @@ To transfer control of the mouse to the IIGS session, click within the view.  To
 - Ctrl-Left ALT-F11 to switch to Debugger Mode
 - Ctrl-Left ALT-F10 to lock mouse)md"};
 const char *kMouseUnlock[] = {"Press  CTRL + ALT + F10 to unlock mouse"};
+
+const char *kHybridModeShortCutText[]= {"Ctrl + Left Alt + F11"};
+const char *kLockMouseShortCutText[]={"Ctrl + Left Alt + F10"};
+const char *kTogglePauseText[]={"Ctrl + Left Alt + F5"};
 #endif

--- a/host/strings/clem_welcome.inl
+++ b/host/strings/clem_welcome.inl
@@ -3,19 +3,24 @@ const char *kWelcomeText[] = {R"md(
 
 This release contains the following changes:
 
-- User-minimal interface mode (by default)
+- "User" mode GUI for regular use with larger view
 - macOS Intel and Apple Silicon support
+- Better emulation of system time based on the IIgs 28khz master clock frequency
+- IWM fixes for 3.5 disk timings and overall emulation speed
+- Dual Slot 7 smartport hard drive
 - Better emulation of all graphics modes
-- Snapshot save/load fixes in some cases
-- Improved Keyboard shortcut support
-- Ensoniq emulation fixes
-- System timing fixes
+- Ensoniq emulation improved
+- Mouse tracking for GSOS/System Software
+- Added fast disk and general fast mode emulation
+- Passes all System Diagnostic tests
 
 The following IIGS features are not yet supported:
                             
-- Serial Controller emulation
-- Host desktop mouse integration
+- Serial and Print Controllers
 - ROM 1 support
 - ROM 0 (//e-like) support
 - Emulator Localization (PAL, Monochrome)
+- Ethernet via Bridge Network
+- ROM 3 mouse emulation
+
 )md"};


### PR DESCRIPTION
- toggle fast emulation on/off to run emulator at fastest speed on its thread
- removed 50% damping of ensoniq mixer
- default to user's home directory when first browsing disk files
- debugger print IRQs in detail
- allow both bbwxyz and bb/wxyz format addresses for breakpoints
- changed welcome screen text to update latest features